### PR TITLE
Include `rzk.cabal`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-rzk/rzk.cabal
 docs/out/
 dist
 dist-*

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -1,0 +1,183 @@
+cabal-version: 1.24
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           rzk
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/fizruk/rzk#readme>
+homepage:       https://github.com/fizruk/rzk#readme
+bug-reports:    https://github.com/fizruk/rzk/issues
+author:         Nikolai Kudasov
+maintainer:     nickolay.kudasov@gmail.com
+copyright:      2020-2021 Nikolai Kudasov
+license:        BSD3
+build-type:     Custom
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/fizruk/rzk
+
+custom-setup
+  setup-depends:
+      Cabal
+    , base
+    , cabal-doctest >=1.0.2 && <1.1
+
+library
+  exposed-modules:
+      Rzk
+      Rzk.Debug.Trace
+      Rzk.Evaluator
+      Rzk.Free.Bound.Name
+      Rzk.Free.Eval
+      Rzk.Free.Example
+      Rzk.Free.Parser
+      Rzk.Free.Pretty
+      Rzk.Free.Syntax.Decl
+      Rzk.Free.Syntax.Example.MLTT
+      Rzk.Free.Syntax.Example.PCF
+      Rzk.Free.Syntax.Example.STLC
+      Rzk.Free.Syntax.Example.TTSC
+      Rzk.Free.Syntax.Example.ULC
+      Rzk.Free.Syntax.Free2
+      Rzk.Free.Syntax.FreeScoped
+      Rzk.Free.Syntax.FreeScoped.Pretty
+      Rzk.Free.Syntax.FreeScoped.ScopedUnification
+      Rzk.Free.Syntax.FreeScoped.TypeCheck
+      Rzk.Free.Syntax.FreeScoped.Unification
+      Rzk.Free.Syntax.FreeScoped.Unification2
+      Rzk.Free.Syntax.Module
+      Rzk.Free.Syntax.Term
+      Rzk.Free.Syntax.Term2
+      Rzk.Free.TypeCheck
+      Rzk.Free.TypeCheck.Context
+      Rzk.Free.TypeCheck.Trans
+      Rzk.Free.TypeCheck.TypeError
+      Rzk.Parser.Text
+      Rzk.Polylingual
+      Rzk.Pretty.Text
+      Rzk.Syntax.Decl
+      Rzk.Syntax.Module
+      Rzk.Syntax.Term
+      Rzk.Syntax.Var
+      Rzk.TypeChecker
+  other-modules:
+      Paths_rzk
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -fno-warn-type-defaults -O2
+  build-depends:
+      ansi-terminal
+    , base >=4.7 && <5
+    , bifunctors
+    , bound
+    , deepseq
+    , free
+    , hashable
+    , kan-extensions
+    , logict
+    , mtl
+    , parsers
+    , prettyprinter
+    , prettyprinter-ansi-terminal >=1.1.2
+    , profunctors
+    , text
+    , transformers
+    , trifecta >=2.1
+    , unordered-containers
+  default-language: Haskell2010
+
+executable rzk
+  main-is: Main.hs
+  other-modules:
+      Paths_rzk
+  hs-source-dirs:
+      app
+  ghc-options: -Wall -fno-warn-type-defaults -O2 -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      ansi-terminal
+    , base >=4.7 && <5
+    , bifunctors
+    , bound
+    , deepseq
+    , free
+    , hashable
+    , kan-extensions
+    , logict
+    , mtl
+    , parsers
+    , prettyprinter
+    , prettyprinter-ansi-terminal >=1.1.2
+    , profunctors
+    , rzk
+    , text
+    , transformers
+    , trifecta >=2.1
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite doctests
+  type: exitcode-stdio-1.0
+  main-is: doctests.hs
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -fno-warn-type-defaults -O2
+  build-depends:
+      Glob
+    , QuickCheck
+    , ansi-terminal
+    , base
+    , bifunctors
+    , bound
+    , deepseq
+    , doctest
+    , free
+    , hashable
+    , kan-extensions
+    , logict
+    , mtl
+    , parsers
+    , prettyprinter
+    , prettyprinter-ansi-terminal >=1.1.2
+    , profunctors
+    , template-haskell
+    , text
+    , transformers
+    , trifecta >=2.1
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite rzk-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_rzk
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -fno-warn-type-defaults -O2 -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      ansi-terminal
+    , base >=4.7 && <5
+    , bifunctors
+    , bound
+    , deepseq
+    , free
+    , hashable
+    , kan-extensions
+    , logict
+    , mtl
+    , parsers
+    , prettyprinter
+    , prettyprinter-ansi-terminal >=1.1.2
+    , profunctors
+    , rzk
+    , text
+    , transformers
+    , trifecta >=2.1
+    , unordered-containers
+  default-language: Haskell2010


### PR DESCRIPTION
In order to build this package via `cabal` or use it as a dependency in `cabal.project` for another project following file required to be included in the repo:

`rzk/rzk.cabal`

This PR intended to unignore the mentioned file and to restore it. 
File was generated by `hpack` version `0.34.4`.