### PR TITLE
Release 0.7.5.1

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.7.5.1 — 2025-08-14
+
+Minor fix:
+
+- Support BNFC 2.9.6 ([#201](https://github.com/rzk-lang/rzk/pull/201))
+
 ## v0.7.5 — 2024-08-18
 
 Minor changes:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.7.5
+version: 0.7.5.1
 github: "rzk-lang/rzk"
 license: BSD3
 author: "Nikolai Kudasov"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.7.5
+version:        0.7.5.1
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
This release includes a minor fix/workaround:

- Support BNFC 2.9.6 ([#201](https://github.com/rzk-lang/rzk/pull/201))