### PR TITLE
Add version bounds for successful Hackage upload

### DIFF
--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -4,11 +4,13 @@ github: "rzk-lang/rzk"
 license: BSD3
 author: "Nikolai Kudasov"
 maintainer: "nickolay.kudasov@gmail.com"
-copyright: "2023-2024 Nikolai Kudasov"
+copyright: "2023-2025 Nikolai Kudasov"
 
-extra-source-files:
+extra-doc-files:
   - README.md
   - ChangeLog.md
+  
+extra-source-files:
   - grammar/Syntax.cf
 
 synopsis: An experimental proof assistant for synthetic ∞-categories
@@ -64,7 +66,9 @@ ghc-options:
   - -Wpartial-fields
   - -Wredundant-constraints
   - -optP-Wno-nonportable-include-path
-  - -XDeriveDataTypeable
+
+default-extensions:
+  - DeriveDataTypeable
 
 library:
   source-dirs: src
@@ -126,8 +130,8 @@ tests:
     main: doctests.hs
     other-modules: []
     dependencies:
-      - base
-      - doctest
-      - Glob
-      - QuickCheck
-      - template-haskell
+      base: ">= 4.11.0.0 && < 5.0"
+      doctest: ">= 0.21.0"
+      Glob: ">= 0.9.3"
+      QuickCheck: ">= 2.14"
+      template-haskell: ">= 2.14.0.0"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -13,14 +13,15 @@ homepage:       https://github.com/rzk-lang/rzk#readme
 bug-reports:    https://github.com/rzk-lang/rzk/issues
 author:         Nikolai Kudasov
 maintainer:     nickolay.kudasov@gmail.com
-copyright:      2023-2024 Nikolai Kudasov
+copyright:      2023-2025 Nikolai Kudasov
 license:        BSD3
 license-file:   LICENSE
 build-type:     Custom
 extra-source-files:
+    grammar/Syntax.cf
+extra-doc-files:
     README.md
     ChangeLog.md
-    grammar/Syntax.cf
 
 source-repository head
   type: git
@@ -57,7 +58,9 @@ library
       Paths_rzk
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -XDeriveDataTypeable
+  default-extensions:
+      DeriveDataTypeable
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -101,7 +104,9 @@ executable rzk
       Paths_rzk
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -XDeriveDataTypeable -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+      DeriveDataTypeable
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -132,23 +137,25 @@ test-suite doctests
   main-is: doctests.hs
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -XDeriveDataTypeable
+  default-extensions:
+      DeriveDataTypeable
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
   build-tool-depends:
       BNFC:bnfc >=2.9.4.1
   build-depends:
-      Glob
-    , QuickCheck
+      Glob >=0.9.3
+    , QuickCheck >=2.14
     , array >=0.5.3.0
-    , base
+    , base >=4.11.0.0 && <5.0
     , bifunctors >=5.5.3
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
-    , doctest
+    , doctest >=0.21.0
     , mtl >=2.2.2
-    , template-haskell
+    , template-haskell >=2.14.0.0
     , text >=1.2.3.1
     , yaml >=0.11.0.0
   default-language: Haskell2010
@@ -163,7 +170,9 @@ test-suite rzk-test
       Paths_rzk
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -XDeriveDataTypeable -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+      DeriveDataTypeable
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9


### PR DESCRIPTION
When using `curl` to upload a Hackage package, it did not report an error message, instead giving the following (e.g. in [this Hackage upload job](https://github.com/rzk-lang/rzk/actions/runs/16964128411/job/48103206842))

```
curl: (22) The requested URL returned error: 400
```

When trying locally, it apparently was unhappy specifically with a missing bound for `base` in `doctests` test suite:

```
cabal upload packages/rzk-0.7.6.tar.gz
```
```
Uploading packages/rzk-0.7.6.tar.gz...
Error uploading packages/rzk-0.7.6.tar.gz: http code 400
Error: Invalid package

[missing-bounds-important] The dependency 'build-depends: base' does not
specify an upper bound on the version number. Each major release of the 'base'
package changes the API in various ways and most packages will need some
changes to compile with it. The recommended practice is to specify an upper
bound on the version of the 'base' package. This ensures your package will
continue to build when a new major version of the 'base' package is released.
If you are not sure what upper bound to use then use the next major version.
For example if you have tested your package with 'base' version 4.5 and 4.6
then use 'build-depends: base >= 4.5 && < 4.7'.
```

After specifying explicit version bounds (and fixing other warnings along the way), the package candidate was successfully uploaded on Hackage (from a local machine).