### PR TITLE
Update GHCJS CI

### DIFF
--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ❄️ Install Nix
-        uses: nixbuild/nix-quick-install-action@v27
+        uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: |
             substituters = https://cache.nixos.org/ https://cache.iog.io https://nix-community.cachix.org https://miso-haskell.cachix.org
@@ -43,7 +43,7 @@ jobs:
             keep-outputs = true
 
       - name: 👝 Restore and Cache Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
           restore-prefixes-first-match: |
@@ -56,7 +56,7 @@ jobs:
           purge-primary-key: never
 
       - name: 👝 Restore and cache NodeJS deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -79,7 +79,7 @@ jobs:
         run: nix run .#release-rzk-playground
 
       - name: 🔨 Save flake from garbage collection
-        run: nix run .#save-flake
+        run: nix profile add .#save-flake
 
       - name: '🚀 Publish JS "binaries" (${{ github.ref_name }})'
         if: ${{ github.ref_name != 'main' && github.event_name == 'push' }}

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -49,7 +49,7 @@ jobs:
           restore-prefixes-first-match: |
             ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
             ${{ runner.os }}-nix-
-          gc-max-store-size: 7000000000
+          gc-max-store-size: 7G
           purge: true
           purge-prefixes: ${{ runner.os }}-nix-
           purge-created: 0

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -42,18 +42,13 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= miso-haskell.cachix.org-1:6N2DooyFlZOHUfJtAx1Q09H0P5XXYzoxxQYiwn6W1e8=
             keep-outputs = true
 
-      - name: 👝 Restore and Cache Nix store
-        uses: nix-community/cache-nix-action@v7
+      - name: 👝 Restore Nix store
+        uses: nix-community/cache-nix-action/restore@v7
         with:
           primary-key: ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
           restore-prefixes-first-match: |
             ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
             ${{ runner.os }}-nix-
-          gc-max-store-size: 7G
-          purge: true
-          purge-prefixes: ${{ runner.os }}-nix-
-          purge-created: 0
-          purge-primary-key: never
 
       - name: 👝 Restore and cache NodeJS deps
         uses: actions/cache@v5
@@ -110,3 +105,14 @@ jobs:
           target-folder: playground
           clean: false
           single-commit: true
+
+      - if: always()
+        name: 👝 Save Nix store
+        uses: nix-community/cache-nix-action/save@v7
+        with:
+          primary-key: ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
+          gc-max-store-size: 7G
+          purge: true
+          purge-prefixes: ${{ runner.os }}-nix-
+          purge-created: 0
+          purge-primary-key: never

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -45,17 +45,17 @@ jobs:
       - name: 👝 Restore Nix store
         uses: nix-community/cache-nix-action/restore@v7
         with:
-          primary-key: ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
+          primary-key: ghcjs-nix-${{ runner.os }}-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
           restore-prefixes-first-match: |
-            ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
-            ${{ runner.os }}-nix-
+            ghcjs-nix-${{ runner.os }}-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
+            ghcjs-nix-${{ runner.os }}-
 
       - name: 👝 Restore and cache NodeJS deps
         uses: actions/cache@v5
         with:
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ghcjs-node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ghcjs-node-${{ runner.os }}-
           path: |
             ~/.npm
 
@@ -110,9 +110,9 @@ jobs:
         name: 👝 Save Nix store
         uses: nix-community/cache-nix-action/save@v7
         with:
-          primary-key: ${{ runner.os }}-nix-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
+          primary-key: ghcjs-nix-${{ runner.os }}-${{ hashfiles('./flake.nix', './flake.lock', '.github/workflows/ghcjs.yml', './rzk/rzk.cabal') }}
           gc-max-store-size: 7G
           purge: true
-          purge-prefixes: ${{ runner.os }}-nix-
+          purge-prefixes: ghcjs-nix-${{ runner.os }}-
           purge-created: 0
           purge-primary-key: never

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -41,6 +41,7 @@ jobs:
             substituters = https://cache.nixos.org/ https://cache.iog.io https://nix-community.cachix.org https://miso-haskell.cachix.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= miso-haskell.cachix.org-1:6N2DooyFlZOHUfJtAx1Q09H0P5XXYzoxxQYiwn6W1e8=
             keep-outputs = true
+            accept-flake-config = true
 
       - name: 👝 Restore Nix store
         uses: nix-community/cache-nix-action/restore@v7

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ❄️ Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: cachix/install-nix-action@v31.9.0
         with:
-          nix_conf: |
+          extra_nix_config: |
             substituters = https://cache.nixos.org/ https://cache.iog.io https://nix-community.cachix.org https://miso-haskell.cachix.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= miso-haskell.cachix.org-1:6N2DooyFlZOHUfJtAx1Q09H0P5XXYzoxxQYiwn6W1e8=
             keep-outputs = true

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
 
       default = import ./nix/default.nix { inherit inputs pkgs rzk rzk-src ghcVersion tools; };
       ghcjs = import ./nix/ghcjs.nix { inherit inputs pkgs scripts rzk rzk-src rzk-js rzk-js-src ghcVersion tools; };
-      scripts = import ./nix/scripts.nix { inherit pkgs packages; };
+      scripts = import ./nix/scripts.nix { inherit pkgs packages inputs; };
 
 
       packages = {

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -1,4 +1,4 @@
-{ pkgs, packages }:
+{ pkgs, packages, inputs }:
 let scripts =
   {
     build-rzk-js = pkgs.writeShellApplication {
@@ -20,32 +20,31 @@ let scripts =
         '';
     };
 
-    save-flake = pkgs.writeShellApplication {
-      name = "save-flake";
-      runtimeInputs = [ pkgs.jq ];
-      text = ''
-        # save flake inputs - # https://github.com/NixOS/nix/issues/4250#issuecomment-1146878407
-
-        mkdir -p "/nix/var/nix/gcroots/per-user/$USER"
-        
-        gc_root_prefix="/nix/var/nix/gcroots/per-user/$USER/$(systemd-escape -p "$PWD")-flake-"
-        echo "Adding per-user gcroots..."
-        rm -f "$gc_root_prefix"*
-        nix flake archive --json 2>/dev/null \
-          | jq -r '.inputs | to_entries[] | "ln -fsT "+.value.path+" \"'"$gc_root_prefix"'"+.key+"\""' \
-          | while read -r line; \
-            do
-              eval "$line"
-            done
-      
-        # save scripts
-
-        nix profile install --profile "$gc_root_prefix""${scripts.save-flake.name}" .#${scripts.save-flake.name}
-        nix profile install --profile "$gc_root_prefix""${scripts.release-rzk-playground.name}" .#${scripts.release-rzk-playground.name}
-
-        printf "Entries saved with prefix %s\n" "$gc_root_prefix"
-      '';
-    };
+    save-flake = 
+      let 
+        cache-nix-action = pkgs.fetchgit {
+          url = "https://github.com/nix-community/cache-nix-action";
+          nonConeMode = true;
+          fetchSubmodules = false;
+          sparseCheckout = [
+            "saveFromGC.nix"
+          ];
+          hash = "sha256-jl5OdBJTG6DXohERmZQmziSs439HF07xJAdPRdFpATw=";
+        };
+        saveFromGC = import "${cache-nix-action}/saveFromGC.nix";
+      in
+        (saveFromGC {
+          inherit pkgs inputs;
+          inputsInclude = [
+            "flake-utils"
+            "nixpkgs"
+            "miso"
+            "nix-filter"
+          ];
+          derivationsAttrs = {
+            inherit (scripts) release-rzk-playground;
+          };
+        }).package;
 
     release-rzk-playground = pkgs.writeShellApplication {
       name = "release-rzk-playground";


### PR DESCRIPTION
## Changes

- Bump actions versions.
- Use a newer syntax for a `cache-nix-action` input.
- Rename cache keys (prefix with `ghcjs`) for better discoverability of caches on the [Caches](https://github.com/rzk-lang/rzk/actions/caches) page.
- Use a newer way to save dependencies from GC.
- Automatically use specified binary caches.
- Try to save cache even if a previous step fails.
  Note: if you want to force a new cache to be created, you can run the workflow, wait until it restores from a cache and remove that cache on the Caches page.