### PR TITLE
Format =_{...}

### DIFF
--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -261,13 +261,21 @@ provideCompletions req res = do
         _col = maybe 0 snd pos'
 
 -- | Full-document range for LSP (0-based line and character).
+--   End position is exclusive. Computed from the actual text so that every
+--   character (including trailing newlines) is included; using T.lines would
+--   drop trailing newlines and leave them in place after the edit (extra blank line).
 fullDocumentRange :: T.Text -> Range
-fullDocumentRange source =
-  let sourceLines = T.lines source
-      lineCount = length sourceLines
-      endLine = max 0 (lineCount - 1)
-      endCharacter = if lineCount > 0 then fromIntegral (T.length (last sourceLines)) else 0
-  in Range (Position 0 0) (Position (fromIntegral endLine) endCharacter)
+fullDocumentRange source
+  | T.null source = Range (Position 0 0) (Position 0 0)
+  | otherwise =
+      let newlineCount = T.count (T.singleton '\n') source
+          endLine = newlineCount
+          -- Length of last line (after last newline); if no newline, whole text is one line
+          endCharacter
+            | T.last source == '\n' = 0
+            | Just i <- T.findIndex (== '\n') (T.reverse source) = fromIntegral i
+            | otherwise = fromIntegral (T.length source)
+      in Range (Position 0 0) (Position (fromIntegral endLine) endCharacter)
 
 formatDocument :: Handler LSP 'Method_TextDocumentFormatting
 formatDocument req res = do
@@ -281,8 +289,23 @@ formatDocument req res = do
       Just sourceCode -> do
         let source = T.filter (/= '\r') sourceCode
             formatted = format source
+            -- Preserve trailing newlines of the source so formatting is idempotent.
+            formatted'
+              | T.null source = formatted
+              | otherwise =
+                  let inputTrailing = T.length (T.takeWhileEnd (== '\n') source)
+                      outTrailing = T.length (T.takeWhileEnd (== '\n') formatted)
+                  in if outTrailing > inputTrailing
+                     then T.dropEnd (outTrailing - inputTrailing) formatted
+                     else if outTrailing < inputTrailing
+                          then formatted <> T.replicate (inputTrailing - outTrailing) (T.singleton '\n')
+                          else formatted
+            -- Never send trailing newlines: some clients add one when applying a
+            -- full-document edit, so we send content ending with no newline to avoid
+            -- an extra blank line on each format.
+            formatted'' = T.dropWhileEnd (== '\n') formatted'
             range = fullDocumentRange source
-        return (Right [TextEdit range formatted])
+        return (Right [TextEdit range formatted''])
     case possibleEdits of
 #if MIN_VERSION_lsp(2,7,0)
       Left err    -> res $ Left $ TResponseError (InR ErrorCodes_InternalError) err Nothing

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -48,10 +48,12 @@ pattern TokenIdent :: T.Text -> Int -> Int -> Token
 pattern TokenIdent s line col <- PT (Pn _ line col) (T_VarIdentToken s)
 
 data FormatState = FormatState
-  { parensDepth  :: Int  -- ^ The level of parentheses nesting
-  , definingName :: Bool -- ^ After #define, in name or assumptions (to detect the : for the type)
-  , lambdaArrow  :: Bool -- ^ After a lambda '\', in the parameters (to leave its -> on the same line)
-  , allTokens    :: [Token] -- ^ The full array of tokens after resolving the layout
+  { parensDepth      :: Int  -- ^ The level of parentheses nesting
+  , definingName     :: Bool -- ^ After #define, in name or assumptions (to detect the : for the type)
+  , lambdaArrow      :: Bool -- ^ After a lambda '\', in the parameters (to leave its -> on the same line)
+  , eqBraceDepth     :: Int  -- ^ Depth inside =_{ ... }; 0 = not inside, 1 = at top level after =_{
+  , eqBraceOnOwnLine :: Bool -- ^ True if the current =_{ started at the beginning of its line (after spaces)
+  , allTokens        :: [Token] -- ^ The full array of tokens after resolving the layout
   }
 
 -- | Replace every tab character with a single space.
@@ -66,7 +68,7 @@ formatTextEdits contents =
     Left _err     -> [] -- TODO: log error (in a CLI and LSP friendly way)
     Right allToks -> go (initialState {allTokens = allToks}) allToks
   where
-    initialState = FormatState { parensDepth = 0, definingName = False, lambdaArrow = False, allTokens = [] }
+    initialState = FormatState { parensDepth = 0, definingName = False, lambdaArrow = False, eqBraceDepth = 0, eqBraceOnOwnLine = False, allTokens = [] }
     incParensDepth s = s { parensDepth = parensDepth s + 1 }
     decParensDepth s = s { parensDepth = 0 `max` (parensDepth s - 1) }
     rzkBlocks = tryExtractMarkdownCodeBlocks "rzk" contents
@@ -159,6 +161,41 @@ formatTextEdits contents =
           [ (not isFirstNonSpaceChar && spacesBefore > 0,
               FormattingEdit line (col - spacesBefore) line col "")
           ]
+
+    -- Enter =_{ ... } (identity type with explicit type): track depth for newline-after-} rule (style guide)
+    -- Only apply newline-after-} when the outermost =_{ is on its own line. Increment depth for nesting.
+    go s (Token "=_{" line col : tks)
+      = go (s { eqBraceDepth = eqBraceDepth s + 1, eqBraceOnOwnLine = if eqBraceDepth s == 0 then isOnOwnLine else eqBraceOnOwnLine s }) tks
+      where
+        lineContent = contentLines line
+        isOnOwnLine = T.all (== ' ') (T.take (col - 1) lineContent)
+
+    -- Count braces inside =_{ ... } so we detect the closing }
+    go s (Token "{" _line _col : tks)
+      = go (s { eqBraceDepth = if eqBraceDepth s > 0 then eqBraceDepth s + 1 else 0 }) tks
+
+    -- Newline after the closing } of =_{ ... } only when =_{ was on its own line (style guide)
+    go s (Token "}" line col : tks)
+      = eqBraceEdits ++ go s' tks
+      where
+        closingEqBrace = eqBraceDepth s == 1
+        onOwnLine = eqBraceOnOwnLine s
+        s' | eqBraceDepth s > 0 = s { eqBraceDepth = eqBraceDepth s - 1, eqBraceOnOwnLine = if eqBraceDepth s == 1 then False else eqBraceOnOwnLine s }
+           | otherwise         = s
+        lineContent = contentLines line
+        braceEndCol = col + 1  -- 1-based column right after "}"
+        afterBrace = T.drop (braceEndCol - 1) lineContent
+        spacesAfter = T.length $ T.takeWhile (== ' ') afterBrace
+        isLastOnLine = T.all (== ' ') afterBrace
+        eqBraceEdits
+          | closingEqBrace && onOwnLine && not isLastOnLine
+          = [ FormattingEdit line braceEndCol line (braceEndCol + spacesAfter) "\n  " ]
+          | closingEqBrace && onOwnLine && isLastOnLine
+          = let nextLine = if line < length (T.lines rzkBlocks) then contentLines (line + 1) else ""
+                spacesNextLine = T.length $ T.takeWhile (== ' ') nextLine
+            in if spacesNextLine /= 2 then [ FormattingEdit (line + 1) 1 (line + 1) (1 + spacesNextLine) "  " ] else []
+          | otherwise
+          = []
 
     -- line break before : (only the top-level one) and one space after
     go s (Token ":" line col : tks)

--- a/rzk/test/Rzk/FormatSpec.hs
+++ b/rzk/test/Rzk/FormatSpec.hs
@@ -45,6 +45,9 @@ spec = do
     it "Aligns colons in split context with parameter name (issue #215)" $ do
       formats "context-colon-align"
 
+    it "Inserts newline after =_{ ... }" $ do
+      formats "identity-type-eq-brace"
+
     it "Doesn't fail on empty inputs" $ do
       formats "empty"
 

--- a/rzk/test/files/identity-type-eq-brace-bad.rzk
+++ b/rzk/test/files/identity-type-eq-brace-bad.rzk
@@ -1,0 +1,19 @@
+#lang rzk-1
+
+-- Fiber type: Σ (a : A), a =_{ A } x, with =_{ on its own line
+#def fiber
+  ( A : U)
+  ( x : A)
+  : Σ ( a : A)
+  , ( a
+  =_{ A } x)
+  := ( x , refl_{x})
+
+-- Path-over-path: p =_{ (x =_{ A } y) } p (nested =_{}, outer on its own line)
+#def path-over-path
+  ( A : U)
+  ( x y : A)
+  ( p : x =_{ A } y)
+  : p
+  =_{ ( x =_{ A } y) } p
+  := refl_{p}

--- a/rzk/test/files/identity-type-eq-brace-good.rzk
+++ b/rzk/test/files/identity-type-eq-brace-good.rzk
@@ -1,0 +1,21 @@
+#lang rzk-1
+
+-- Fiber type: Σ (a : A), a =_{ A } x, with =_{ on its own line
+#def fiber
+  ( A : U)
+  ( x : A)
+  : Σ ( a : A)
+  , ( a
+  =_{ A }
+  x)
+  := (x , refl_{x})
+
+-- Path-over-path: p =_{ (x =_{ A } y) } p (nested =_{}, outer on its own line)
+#def path-over-path
+  ( A : U)
+  ( x y : A)
+  ( p : x =_{ A } y)
+  : p
+  =_{ (x =_{ A } y) }
+  p
+  := refl_{p}


### PR DESCRIPTION
Insert newline after `=_{...}` (when it is on its own line). This rule follows [sHoTT style guide](https://github.com/rzk-lang/sHoTT/blob/268b462f282aa405db37bbef9075fe52f4745f5a/src/STYLEGUIDE.md).