### PR TITLE
Remove malicious polyfill.io dependency in the docs

### DIFF
--- a/docs/config/base.yml
+++ b/docs/config/base.yml
@@ -24,7 +24,6 @@ theme:
 
 extra_javascript:
   - javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
Fix #229.

The polyfill.io domain apparently was sold to a malicious operator in 2024 and has been serving attacker-controlled scripts that, in some regions, trigger the WWW-Authenticate / login prompt (as reported in #229). MathJax v3's es5/tex-mml-chtml.js bundle (already loaded) does not require this polyfill in any browser Chrome would ship — that's why MathJax's own docs removed the polyfill.io recommendation.