### PR TITLE
Restore pattern binder names

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -47,6 +47,7 @@ extra-source-files:
     test/typecheck/cases/ill-bare-refl-compute.rzk
     test/typecheck/cases/ill-duplicate.rzk
     test/typecheck/cases/ill-hole-infer.rzk
+    test/typecheck/cases/ill-hole-pattern-binder-names.rzk
     test/typecheck/cases/ill-hole-unsolved.rzk
     test/typecheck/cases/ill-implicit.rzk
     test/typecheck/cases/ill-interval-no-totality.rzk
@@ -142,6 +143,7 @@ extra-source-files:
     test/typecheck/cases/ill-bare-refl-compute.expect.yaml
     test/typecheck/cases/ill-duplicate.expect.yaml
     test/typecheck/cases/ill-hole-infer.expect.yaml
+    test/typecheck/cases/ill-hole-pattern-binder-names.expect.yaml
     test/typecheck/cases/ill-hole-unsolved.expect.yaml
     test/typecheck/cases/ill-implicit.expect.yaml
     test/typecheck/cases/ill-interval-no-totality.expect.yaml

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 module Language.Rzk.Free.Syntax where
 
+import           Data.Bifunctor      (bimap)
 import           Data.Bifunctor.TH
 import           Data.Char           (chr, ord)
 import           Data.Coerce
@@ -76,6 +77,32 @@ holeIdentToken :: Maybe VarIdent -> T.Text
 holeIdentToken Nothing  = "?"
 holeIdentToken (Just x) = "?" <> T.pack (show x)
 
+-- | The name(s) a binder introduces. A binder may name a single (possibly
+-- anonymous) variable, or destructure a pair\/tuple via a pattern. The pattern
+-- structure is kept around purely so that goals, holes and error messages can
+-- show the user's original names (e.g. @t@ and @s@ for @\\ (t , s) -> …@)
+-- instead of projections of a fresh variable (e.g. @π₁ x₄@ and @π₂ x₄@).
+--
+-- Operationally a pair pattern still binds a /single/ variable; the components
+-- are projections of it (see 'toScopePattern'). 'Binder' only records the names
+-- so they can be restored when rendering.
+data Binder
+  = BinderVar (Maybe VarIdent)   -- ^ a single variable (@Nothing@ for @_@)
+  | BinderPair Binder Binder     -- ^ a pair pattern @(l , r)@
+  | BinderUnit                   -- ^ the unit pattern @unit@
+  deriving (Eq)
+
+-- | The single name of a binder, if it binds exactly one named variable.
+-- A pair\/unit pattern has no single name, so this is 'Nothing' for them.
+-- Used wherever the old @Maybe VarIdent@ binder name is still sufficient.
+binderName :: Binder -> Maybe VarIdent
+binderName (BinderVar mname) = mname
+binderName _                 = Nothing
+
+-- | A binder that names a single variable.
+binderVar :: Maybe VarIdent -> Binder
+binderVar = BinderVar
+
 data TModality = Sharp | Flat | Op | Id deriving (Eq, Show)
 
 toModality :: Rzk.Modality -> TModality
@@ -126,12 +153,12 @@ data TermF scope term
     | TopeUninvF term
     | RecBottomF
     | RecOrF [(term, term)]
-    | TypeFunF (Maybe VarIdent) term (Maybe scope) scope
-    | TypeSigmaF (Maybe VarIdent) term scope
+    | TypeFunF Binder term (Maybe scope) scope
+    | TypeSigmaF Binder term scope
     | TypeIdF term (Maybe term) term
     | AppF term term
-    | LetF (Maybe VarIdent) (Maybe term) term scope
-    | LambdaF (Maybe VarIdent) (Maybe (term, Maybe scope)) scope
+    | LetF Binder (Maybe term) term scope
+    | LambdaF Binder (Maybe (term, Maybe scope)) scope
     | PairF term term
     | FirstF term
     | SecondF term
@@ -144,7 +171,7 @@ data TermF scope term
     | TypeModalF TModality term
     | ModAppF TModality term
     | ModExtractF TModality TModality term
-    | LetModF (Maybe VarIdent) TModality TModality (Maybe term) term scope
+    | LetModF Binder TModality TModality (Maybe term) term scope
     | HoleF (Maybe VarIdent)
     deriving (Eq, Functor, Foldable, Traversable)
 deriveBifunctor ''TermF
@@ -347,19 +374,19 @@ toTerm bvars = go
         in go (Rzk.TypeFun _loc (Rzk.ParamTermShape loc' patTerm (Rzk.ModType loc' md cube) (letMod tope)) (letMod ret))
       Rzk.TypeFun _loc (Rzk.ParamTermType _ patTerm arg) ret ->
         let pat = unsafeTermToPattern patTerm
-        in TypeFun (patternVar pat) (go arg) Nothing (toScopePattern pat bvars ret)
+        in TypeFun (toBinder pat) (go arg) Nothing (toScopePattern pat bvars ret)
       t@(Rzk.TypeFun loc (Rzk.ParamTermShape loc' patTerm cube tope) ret) ->
         let lint' = case tope of
               Rzk.App _loc fun arg | void arg == void patTerm ->
                 lint t (Rzk.TypeFun loc (Rzk.ParamTermType loc' patTerm fun) ret)
               _ -> id
             pat = unsafeTermToPattern patTerm
-        in lint' $ TypeFun (patternVar pat) (go cube) (Just (toScopePattern pat bvars tope)) (toScopePattern pat bvars ret)
+        in lint' $ TypeFun (toBinder pat) (go cube) (Just (toScopePattern pat bvars tope)) (toScopePattern pat bvars ret)
       Rzk.TypeFun _loc (Rzk.ParamType _ arg) ret ->
-        TypeFun Nothing (go arg) Nothing (toTerm (fmap S <$> bvars) ret)
+        TypeFun (BinderVar Nothing) (go arg) Nothing (toTerm (fmap S <$> bvars) ret)
 
       Rzk.TypeSigma _loc pat tA tB ->
-        TypeSigma (patternVar pat) (go tA) (toScopePattern pat bvars tB)
+        TypeSigma (toBinder pat) (go tA) (toScopePattern pat bvars tB)
 
       Rzk.TypeSigmaModal _loc pat mc ty body ->
         let md = modalColonModality mc
@@ -411,11 +438,11 @@ toTerm bvars = go
         in go (Rzk.Lambda _loc [Rzk.ParamPatternShape loc' [pat] (Rzk.ModType loc' md cube) (letMod tope)] (letMod inner))
       Rzk.Lambda _loc [] body -> go body
       Rzk.Lambda _loc (Rzk.ParamPattern _ pat : params) body ->
-        Lambda (patternVar pat) Nothing (toScopePattern pat bvars (Rzk.Lambda _loc params body))
+        Lambda (toBinder pat) Nothing (toScopePattern pat bvars (Rzk.Lambda _loc params body))
       Rzk.Lambda _loc (Rzk.ParamPatternType _ [] _ty : params) body ->
         go (Rzk.Lambda _loc params body)
       Rzk.Lambda _loc (Rzk.ParamPatternType _ (pat:pats) ty : params) body ->
-        Lambda (patternVar pat) (Just (go ty, Nothing))
+        Lambda (toBinder pat) (Just (go ty, Nothing))
           (toScopePattern pat bvars (Rzk.Lambda _loc (Rzk.ParamPatternType _loc pats ty : params) body))
       Rzk.Lambda _loc (Rzk.ParamPatternShape _ [] _cube _tope : params) body ->
         go (Rzk.Lambda _loc params body)
@@ -425,12 +452,12 @@ toTerm bvars = go
                 | null pats && void arg == void (patternToTerm pat) ->
                     lint t (Rzk.Lambda _loc (Rzk.ParamPatternType _loc' [pat] fun : params) body)
               _ -> id
-         in lint' $ Lambda (patternVar pat) (Just (go cube, Just (toScopePattern pat bvars tope)))
+         in lint' $ Lambda (toBinder pat) (Just (go cube, Just (toScopePattern pat bvars tope)))
               (toScopePattern pat bvars (Rzk.Lambda _loc (Rzk.ParamPatternShape _loc' pats cube tope : params) body))
       Rzk.Let _loc (Rzk.BindPattern _ pat) val expr ->
-        Let (patternVar pat) Nothing (go val) (toScopePattern pat bvars expr)
+        Let (toBinder pat) Nothing (go val) (toScopePattern pat bvars expr)
       Rzk.Let _loc (Rzk.BindPatternType _ pat ty) val expr -> 
-        Let (patternVar pat) (Just (go ty)) (go val) (toScopePattern pat bvars expr)
+        Let (toBinder pat) (Just (go ty)) (go val) (toScopePattern pat bvars expr)
       Rzk.TypeRestricted _loc ty rs ->
         TypeRestricted (go ty) $ flip map rs $ \case
           Rzk.Restriction _loc tope term       -> (go tope, go term)
@@ -443,14 +470,18 @@ toTerm bvars = go
       Rzk.ModExtract{} -> error "$extract$ is an internal term and cannot appear in source"
       Rzk.LetMod _loc comp (Rzk.BindPattern _ pat) val body ->
         let (ext, inn) = modCompToMods comp
-        in LetMod (patternVar pat) ext inn Nothing (go val) (toScopePattern pat bvars body)
+        in LetMod (toBinder pat) ext inn Nothing (go val) (toScopePattern pat bvars body)
       Rzk.LetMod _loc comp (Rzk.BindPatternType _ pat ty) val body ->
         let (ext, inn) = modCompToMods comp
-        in LetMod (patternVar pat) ext inn (Just (go ty)) (go val) (toScopePattern pat bvars body)
+        in LetMod (toBinder pat) ext inn (Just (go ty)) (go val) (toScopePattern pat bvars body)
 
-    patternVar (Rzk.PatternVar _loc (Rzk.VarIdent _ "_")) = Nothing
-    patternVar (Rzk.PatternVar _loc x)                    = Just (varIdent x)
-    patternVar _                                          = Nothing
+    -- Translate a surface pattern into a 'Binder', keeping the pair\/tuple
+    -- structure so the component names can be restored when rendering.
+    toBinder (Rzk.PatternVar _loc (Rzk.VarIdent _ "_")) = BinderVar Nothing
+    toBinder (Rzk.PatternVar _loc x)                    = BinderVar (Just (varIdent x))
+    toBinder (Rzk.PatternUnit _loc)                     = BinderUnit
+    toBinder (Rzk.PatternPair _loc l r)                 = BinderPair (toBinder l) (toBinder r)
+    toBinder (Rzk.PatternTuple loc p1 p2 ps)            = toBinder (desugarTuple loc (reverse ps) p2 p1)
 
 patternToTerm :: Rzk.Pattern -> Rzk.Term
 patternToTerm = ptt
@@ -487,6 +518,79 @@ sigmaParamToTypeSigma loc sp body = case sp of
   Rzk.SigmaParam      _ pat ty      -> Rzk.TypeSigma      loc pat ty body
   Rzk.SigmaParamModal _ pat mc ty  -> Rzk.TypeSigmaModal loc pat mc ty body
 
+-- | A projection step: first (@π₁@) or second (@π₂@) component.
+data Proj = PFst | PSnd
+  deriving (Eq)
+
+-- | Render a 'Binder' as a surface pattern (used to display the binder itself,
+-- e.g. @(t , s)@). Anonymous variables become @_@.
+binderToPattern :: Binder -> Rzk.Pattern
+binderToPattern (BinderVar Nothing)  = Rzk.PatternVar Nothing (fromVarIdent "_")
+binderToPattern (BinderVar (Just x)) = Rzk.PatternVar Nothing (fromVarIdent x)
+binderToPattern (BinderPair l r)     = Rzk.PatternPair Nothing (binderToPattern l) (binderToPattern r)
+binderToPattern BinderUnit           = Rzk.PatternUnit Nothing
+
+-- | The named leaves of a binder, each paired with the projection path that
+-- reaches it from the bound variable. For example @(t , (a , b))@ yields
+-- @[([PFst], t), ([PSnd, PFst], a), ([PSnd, PSnd], b)]@.
+binderPaths :: Binder -> [([Proj], VarIdent)]
+binderPaths (BinderVar (Just x)) = [([], x)]
+binderPaths (BinderVar Nothing)  = []
+binderPaths BinderUnit           = []
+binderPaths (BinderPair l r)     =
+  [ (PFst : p, n) | (p, n) <- binderPaths l ] ++
+  [ (PSnd : p, n) | (p, n) <- binderPaths r ]
+
+-- | The names appearing in a binder.
+binderLeaves :: Binder -> [VarIdent]
+binderLeaves = map snd . binderPaths
+
+-- | Does this binder destructure a pair\/tuple (as opposed to naming a single
+-- variable or @_@)?
+binderIsCompound :: Binder -> Bool
+binderIsCompound BinderVar{} = False
+binderIsCompound _           = True
+
+-- | Refresh the named leaves of a binder so they avoid the given names (and one
+-- another). Anonymous leaves and the unit pattern are left unchanged.
+freshenBinderLeaves :: [VarIdent] -> Binder -> Binder
+freshenBinderLeaves used = snd . go used
+  where
+    go u (BinderVar (Just x)) = let x' = refreshVar u x in (x' : u, BinderVar (Just x'))
+    go u b@(BinderVar Nothing) = (u, b)
+    go u BinderUnit            = (u, BinderUnit)
+    go u (BinderPair l r)      =
+      let (u1, l') = go u l
+          (u2, r') = go u1 r
+      in (u2, BinderPair l' r')
+
+-- | Decompose a chain of projections applied to a variable, e.g.
+-- @π₁ (π₂ x)@ becomes @Just ([PFst, PSnd], x)@.
+projChain :: Term a -> Maybe ([Proj], a)
+projChain (First t)  = (\(ps, r) -> (PFst : ps, r)) <$> projChain t
+projChain (Second t) = (\(ps, r) -> (PSnd : ps, r)) <$> projChain t
+projChain (Pure x)   = Just ([], x)
+projChain _          = Nothing
+
+-- | Replace projection chains rooted at a pattern binder with the binder's
+-- component name. Given a map from a (bound) variable to the named leaves of
+-- its binder, every @π₁/π₂@ chain that reaches a named leaf is rewritten to
+-- that name. Ordinary projections (of variables not bound by a pattern, or
+-- chains that do not reach a named leaf) are left untouched.
+foldBinderProjections :: Eq a => [(a, [([Proj], a)])] -> Term a -> Term a
+foldBinderProjections m = go
+  where
+    go t
+      | Just (ps, root) <- projChain t
+      , not (null ps)
+      , Just leaves <- lookup root m
+      , Just nm <- lookup ps leaves
+      = Pure nm
+    go (Free f) = Free (bimap goScope go f)
+    go (Pure x) = Pure x
+    goScope = foldBinderProjections (map liftEntry m)
+    liftEntry (k, leaves) = (S k, map (fmap S) leaves)
+
 fromTerm' :: Term' -> Rzk.Term
 fromTerm' t = fromTermWith' vars (defaultVarIdents \\ vars) t
   where vars = freeVars t
@@ -497,16 +601,47 @@ fromScope' x used xs = fromTermWith' (x : used) xs . (>>= f)
     f Z     = Pure x
     f (S z) = Pure z
 
+-- | Like 'fromScope'', but additionally restores pattern-binder component names
+-- inside the scope: projections of the bound variable @x@ are folded back to
+-- the names recorded in @binder@ (e.g. @π₁ x@ becomes @t@). For a binder that
+-- names a single variable this is exactly 'fromScope''.
+fromScopeBinder' :: Binder -> VarIdent -> [VarIdent] -> [VarIdent] -> Scope Term VarIdent -> Rzk.Term
+fromScopeBinder' binder x used xs scope =
+  fromTermWith' (x : used) xs
+    (foldBinderProjections [(x, binderPaths binder)] (scope >>= f))
+  where
+    f Z     = Pure x
+    f (S z) = Pure z
+
 fromTermWith' :: [VarIdent] -> [VarIdent] -> Term' -> Rzk.Term
 fromTermWith' used vars = go
   where
-    withFresh Nothing f =
-      case vars of
-        x:xs -> f (x, xs)
+    -- Refresh a binder's named leaves against the names already in use and draw
+    -- fresh names for anonymous leaves from the remaining supply.
+    freshenBinder _    stream (BinderVar Nothing) =
+      case stream of
+        x:xs -> (BinderVar (Just x), xs)
         _    -> error "not enough fresh variables!"
-    withFresh (Just z) f = f (z', filter (/= z') vars)    -- FIXME: very inefficient filter
+    freshenBinder used' stream (BinderVar (Just z)) =
+      (BinderVar (Just z'), filter (/= z') stream)
+      where z' = refreshVar used' z
+    freshenBinder _    stream BinderUnit = (BinderUnit, stream)
+    freshenBinder used' stream (BinderPair l r) =
+      let (l', s1) = freshenBinder used' stream l
+          (r', s2) = freshenBinder (used' ++ binderLeaves l') s1 r
+      in (BinderPair l' r', s2)
+
+    -- Pick fresh names for a binder. Yields the bound variable's display name
+    -- (used as the De Bruijn placeholder), the freshened binder (for the
+    -- displayed pattern and for projection folding), and the remaining supply.
+    withFreshBinder z f =
+      case binder' of
+        BinderVar (Just x) -> f (x, binder', stream)
+        _ -> case stream of
+               x:xs -> f (x, binder', xs)
+               _    -> error "not enough fresh variables!"
       where
-        z' = refreshVar used z
+        (binder', stream) = freshenBinder used vars z
 
     loc = Nothing
 
@@ -548,28 +683,28 @@ fromTermWith' used vars = go
 
       Hole mname -> Rzk.Hole loc (Rzk.HoleIdent loc (Rzk.HoleIdentToken (holeIdentToken mname)))
 
-      TypeFun z arg Nothing ret -> withFresh z $ \(x, xs) ->
-        Rzk.TypeFun loc (Rzk.ParamTermType loc (Rzk.Var loc (fromVarIdent x)) (go arg)) (fromScope' x used xs ret)
-      TypeFun z arg (Just tope) ret -> withFresh z $ \(x, xs) ->
-        Rzk.TypeFun loc (Rzk.ParamTermShape loc (Rzk.Var loc (fromVarIdent x)) (go arg) (fromScope' x used xs tope)) (fromScope' x used xs ret)
+      TypeFun z arg Nothing ret -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.TypeFun loc (Rzk.ParamTermType loc (patternToTerm (binderToPattern z')) (go arg)) (fromScopeBinder' z' x used xs ret)
+      TypeFun z arg (Just tope) ret -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.TypeFun loc (Rzk.ParamTermShape loc (patternToTerm (binderToPattern z')) (go arg) (fromScopeBinder' z' x used xs tope)) (fromScopeBinder' z' x used xs ret)
 
-      TypeSigma z a b -> withFresh z $ \(x, xs) ->
-        Rzk.TypeSigma loc (Rzk.PatternVar loc (fromVarIdent x)) (go a) (fromScope' x used xs b)
+      TypeSigma z a b -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.TypeSigma loc (binderToPattern z') (go a) (fromScopeBinder' z' x used xs b)
       TypeId l (Just tA) r -> Rzk.TypeId loc (go l) (go tA) (go r)
       TypeId l Nothing r -> Rzk.TypeIdSimple loc (go l) (go r)
       App l r -> Rzk.App loc (go l) (go r)
 
-      Lambda z Nothing scope -> withFresh z $ \(x, xs) ->
-        Rzk.Lambda loc [Rzk.ParamPattern loc (Rzk.PatternVar loc (fromVarIdent x))] (fromScope' x used xs scope)
-      Lambda z (Just (ty, Nothing)) scope -> withFresh z $ \(x, xs) ->
-        Rzk.Lambda loc [Rzk.ParamPatternType loc [Rzk.PatternVar loc (fromVarIdent x)] (go ty)] (fromScope' x used xs scope)
-      Lambda z (Just (cube, Just tope)) scope -> withFresh z $ \(x, xs) ->
-        Rzk.Lambda loc [Rzk.ParamPatternShape loc [Rzk.PatternVar loc (fromVarIdent x)] (go cube) (fromScope' x used xs tope)] (fromScope' x used xs scope)
+      Lambda z Nothing scope -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.Lambda loc [Rzk.ParamPattern loc (binderToPattern z')] (fromScopeBinder' z' x used xs scope)
+      Lambda z (Just (ty, Nothing)) scope -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.Lambda loc [Rzk.ParamPatternType loc [binderToPattern z'] (go ty)] (fromScopeBinder' z' x used xs scope)
+      Lambda z (Just (cube, Just tope)) scope -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.Lambda loc [Rzk.ParamPatternShape loc [binderToPattern z'] (go cube) (fromScopeBinder' z' x used xs tope)] (fromScopeBinder' z' x used xs scope)
       -- Lambda (Maybe (term, Maybe scope)) scope -> Rzk.Lambda loc (Maybe (term, Maybe scope)) scope
-      Let z Nothing val scope -> withFresh z $ \(x, xs) -> 
-        Rzk.Let loc (Rzk.BindPattern loc (Rzk.PatternVar loc (fromVarIdent  x))) (go val) (fromScope' x used xs scope)
-      Let z (Just ty) val scope -> withFresh z $ \(x, xs) -> 
-        Rzk.Let loc (Rzk.BindPatternType loc (Rzk.PatternVar loc (fromVarIdent  x)) (go ty)) (go val) (fromScope' x used xs scope)
+      Let z Nothing val scope -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.Let loc (Rzk.BindPattern loc (binderToPattern z')) (go val) (fromScopeBinder' z' x used xs scope)
+      Let z (Just ty) val scope -> withFreshBinder z $ \(x, z', xs) ->
+        Rzk.Let loc (Rzk.BindPatternType loc (binderToPattern z') (go ty)) (go val) (fromScopeBinder' z' x used xs scope)
       Pair l r -> Rzk.Pair loc (go l) (go r)
       First term -> Rzk.First loc (go term)
       Second term -> Rzk.Second loc (go term)
@@ -585,14 +720,14 @@ fromTermWith' used vars = go
       TypeModal m ty -> Rzk.ModType loc (goMod m) (go ty)
       ModApp m ty -> Rzk.ModApp loc (goMod m) (go ty)
       ModExtract ma mb t -> Rzk.ModExtract loc (Rzk.Comp loc (goMod ma) (goMod mb)) (go t)
-      LetMod z ext inn Nothing val scope -> withFresh z $ \(x, xs) ->
+      LetMod z ext inn Nothing val scope -> withFreshBinder z $ \(x, z', xs) ->
         Rzk.LetMod loc (modsToModComp ext inn)
-          (Rzk.BindPattern loc (Rzk.PatternVar loc (fromVarIdent x)))
-          (go val) (fromScope' x used xs scope)
-      LetMod z ext inn (Just ty) val scope -> withFresh z $ \(x, xs) ->
+          (Rzk.BindPattern loc (binderToPattern z'))
+          (go val) (fromScopeBinder' z' x used xs scope)
+      LetMod z ext inn (Just ty) val scope -> withFreshBinder z $ \(x, z', xs) ->
         Rzk.LetMod loc (modsToModComp ext inn)
-          (Rzk.BindPatternType loc (Rzk.PatternVar loc (fromVarIdent x)) (go ty))
-          (go val) (fromScope' x used xs scope)
+          (Rzk.BindPatternType loc (binderToPattern z') (go ty))
+          (go val) (fromScopeBinder' z' x used xs scope)
 
 
 defaultVarIdents :: [VarIdent]

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -526,6 +526,12 @@ binderToPattern (BinderVar (Just x)) = Rzk.PatternVar Nothing (fromVarIdent x)
 binderToPattern (BinderPair l r)     = Rzk.PatternPair Nothing (binderToPattern l) (binderToPattern r)
 binderToPattern BinderUnit           = Rzk.PatternUnit Nothing
 
+-- | A 'VarIdent' that prints as the binder's surface pattern, e.g. @(t , s)@.
+-- Used to display a pattern binder in a hole's local context as the pattern
+-- itself rather than as the underlying single variable.
+binderDisplayName :: Binder -> VarIdent
+binderDisplayName = fromString . Rzk.printTree . binderToPattern
+
 -- | The named leaves of a binder, each paired with the projection path that
 -- reaches it from the bound variable. For example @(t , (a , b))@ yields
 -- @[([PFst], t), ([PSnd, PFst], a), ([PSnd, PSnd], b)]@.

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -99,10 +99,6 @@ binderName :: Binder -> Maybe VarIdent
 binderName (BinderVar mname) = mname
 binderName _                 = Nothing
 
--- | A binder that names a single variable.
-binderVar :: Maybe VarIdent -> Binder
-binderVar = BinderVar
-
 data TModality = Sharp | Flat | Op | Id deriving (Eq, Show)
 
 toModality :: Rzk.Modality -> TModality

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -564,11 +564,13 @@ freshenBinderLeaves used = snd . go used
           (u2, r') = go u1 r
       in (u2, BinderPair l' r')
 
--- | Decompose a chain of projections applied to a variable, e.g.
--- @π₁ (π₂ x)@ becomes @Just ([PFst, PSnd], x)@.
+-- | Decompose a chain of projections applied to a variable into the projection
+-- path /from the variable outwards/, matching 'binderPaths'. The outermost
+-- projection is applied last, so it goes at the /end/ of the path: e.g.
+-- @π₂ (π₁ x)@ (select @π₁@ first, then @π₂@) becomes @Just ([PFst, PSnd], x)@.
 projChain :: Term a -> Maybe ([Proj], a)
-projChain (First t)  = (\(ps, r) -> (PFst : ps, r)) <$> projChain t
-projChain (Second t) = (\(ps, r) -> (PSnd : ps, r)) <$> projChain t
+projChain (First t)  = (\(ps, r) -> (ps ++ [PFst], r)) <$> projChain t
+projChain (Second t) = (\(ps, r) -> (ps ++ [PSnd], r)) <$> projChain t
 projChain (Pure x)   = Just ([], x)
 projChain _          = Nothing
 

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -595,6 +595,30 @@ foldBinderProjections m = go
     goScope = foldBinderProjections (map liftEntry m)
     liftEntry (k, leaves) = (S k, map (fmap S) leaves)
 
+-- | Like 'projChain', but for type-annotated terms.
+projChainT :: TermT a -> Maybe ([Proj], a)
+projChainT (FirstT _ t)  = (\(ps, r) -> (ps ++ [PFst], r)) <$> projChainT t
+projChainT (SecondT _ t) = (\(ps, r) -> (ps ++ [PSnd], r)) <$> projChainT t
+projChainT (Pure x)      = Just ([], x)
+projChainT _             = Nothing
+
+-- | Like 'foldBinderProjections', but for type-annotated terms (e.g. those
+-- embedded in type errors). The annotation of a folded leaf is dropped, which
+-- is harmless: the result is only rendered, and a bare variable needs none.
+foldBinderProjectionsT :: Eq a => [(a, [([Proj], a)])] -> TermT a -> TermT a
+foldBinderProjectionsT m = go
+  where
+    go t
+      | Just (ps, root) <- projChainT t
+      , not (null ps)
+      , Just leaves <- lookup root m
+      , Just nm <- lookup ps leaves
+      = Pure nm
+    go (Free (AnnF info f)) = Free (AnnF (fmap go info) (bimap goScope go f))
+    go (Pure x) = Pure x
+    goScope = foldBinderProjectionsT (map liftEntry m)
+    liftEntry (k, leaves) = (S k, map (fmap S) leaves)
+
 fromTerm' :: Term' -> Rzk.Term
 fromTerm' t = fromTermWith' vars (defaultVarIdents \\ vars) t
   where vars = freeVars t

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -582,24 +582,30 @@ data Action var
 
 type Action' = Action VarIdent
 
--- | Build the projection-folding map used when rendering: for every in-scope
--- variable bound by a compound pattern, map its display name to the projection
--- paths of its component names (e.g. @π₁@ ↦ @t@, @π₂@ ↦ @s@). Component names
--- are freshened against the names already in use. Variables bound to a single
--- name contribute nothing, so ordinary projections are left untouched.
-binderProjMap
+-- | Freshen the compound (pattern) binders in scope so their component names
+-- avoid the display names already in use and one another. Returns each relevant
+-- variable paired with its freshened binder. Variables bound to a single name
+-- are omitted: they need no projection folding and are displayed normally.
+freshBinders
   :: Eq var
   => (var -> VarIdent)
   -> [(var, VarIdent)]
   -> [(var, Binder)]
-  -> [(VarIdent, [([Proj], VarIdent)])]
-binderProjMap name mapping binders =
-  [ (name v, binderPaths (freshenBinderLeaves taken b))
-  | (v, b) <- binders
-  , binderIsCompound b
-  , v `elem` map fst mapping ]
+  -> [(var, Binder)]
+freshBinders name mapping binders = go (map (name . fst) mapping) compound
   where
-    taken = map (name . fst) mapping
+    compound = [ (v, b) | (v, b) <- binders, binderIsCompound b, v `elem` map fst mapping ]
+    go _    []             = []
+    go used ((v, b) : rest) =
+      let b' = freshenBinderLeaves used b
+      in (v, b') : go (binderLeaves b' ++ used) rest
+
+-- | The projection-folding map for rendering: each pattern-binder variable's
+-- display name mapped to the projection paths of its component names (e.g.
+-- @π₁@ ↦ @t@, @π₂@ ↦ @s@). Ordinary projections (of non-pattern variables) are
+-- left untouched.
+binderProjMap :: (var -> VarIdent) -> [(var, Binder)] -> [(VarIdent, [([Proj], VarIdent)])]
+binderProjMap name fbs = [ (name v, binderPaths b) | (v, b) <- fbs ]
 
 ppTermInContext :: Eq var => TermT var -> TypeCheck var String
 ppTermInContext term =  do
@@ -610,7 +616,8 @@ ppTermInContext term =  do
   origs <- asks varOrigs
   binders <- asks varBinders
   let name = toRzkVarIdent origs
-  return (show (foldBinderProjections (binderProjMap name mapping binders)
+      fbs  = freshBinders name mapping binders
+  return (show (foldBinderProjections (binderProjMap name fbs)
                   (untyped (name <$> term))))
 
 -- | Classify a (WHNF) type as a cube, so cube variables (e.g. @t : 2@) are
@@ -674,8 +681,11 @@ recordHoleShape mname goalTy mshape = do
   varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
   let mapping  = zip (nub (varsList ++ shapeTopeVars ++ map fst locals)) defaultVarIdents
       name v   = fromMaybe "_" (join (lookup v origs) <|> lookup v mapping)
-      render t = foldBinderProjections (binderProjMap name mapping binders) (untyped (name <$> t))
-      entries  = [ HoleEntry (name v) (render (varType info)) | (v, info) <- locals ]
+      fbs      = freshBinders name mapping binders
+      render t = foldBinderProjections (binderProjMap name fbs) (untyped (name <$> t))
+      -- a pattern binder is shown as its pattern, e.g. (t , s); others by name
+      entryName v = maybe (name v) binderDisplayName (lookup v fbs)
+      entries  = [ HoleEntry (entryName v) (render (varType info)) | (v, info) <- locals ]
       flagged  = zip cubeFlags entries
       -- binder name for the shape: the declared name if any, else a default
       shapeBinder   = fromMaybe (fromString "t") (binderName =<< (fst <$> mshape))

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -582,6 +582,25 @@ data Action var
 
 type Action' = Action VarIdent
 
+-- | Build the projection-folding map used when rendering: for every in-scope
+-- variable bound by a compound pattern, map its display name to the projection
+-- paths of its component names (e.g. @π₁@ ↦ @t@, @π₂@ ↦ @s@). Component names
+-- are freshened against the names already in use. Variables bound to a single
+-- name contribute nothing, so ordinary projections are left untouched.
+binderProjMap
+  :: Eq var
+  => (var -> VarIdent)
+  -> [(var, VarIdent)]
+  -> [(var, Binder)]
+  -> [(VarIdent, [([Proj], VarIdent)])]
+binderProjMap name mapping binders =
+  [ (name v, binderPaths (freshenBinderLeaves taken b))
+  | (v, b) <- binders
+  , binderIsCompound b
+  , v `elem` map fst mapping ]
+  where
+    taken = map (name . fst) mapping
+
 ppTermInContext :: Eq var => TermT var -> TypeCheck var String
 ppTermInContext term =  do
   vars <- freeVarsT_ term
@@ -589,7 +608,10 @@ ppTermInContext term =  do
       toRzkVarIdent origs var = fromMaybe "_" $
         join (lookup var origs) <|> lookup var mapping
   origs <- asks varOrigs
-  return (show (untyped (toRzkVarIdent origs <$> term)))
+  binders <- asks varBinders
+  let name = toRzkVarIdent origs
+  return (show (foldBinderProjections (binderProjMap name mapping binders)
+                  (untyped (name <$> term))))
 
 -- | Classify a (WHNF) type as a cube, so cube variables (e.g. @t : 2@) are
 -- shown separately from ordinary term variables in a hole's context.
@@ -637,7 +659,7 @@ recordHoleShape
   :: Eq var
   => Maybe VarIdent
   -> TermT var
-  -> Maybe (Maybe VarIdent, TermT (Inc var))
+  -> Maybe (Binder, TermT (Inc var))
   -> TypeCheck var ()
 recordHoleShape mname goalTy mshape = do
   goal'     <- whnfT goalTy
@@ -645,17 +667,18 @@ recordHoleShape mname goalTy mshape = do
   cubeFlags <- mapM (fmap isCubeType . whnfT . varType . snd) locals
   topes     <- asks (filter (/= topeTopT) . availableTopes)
   origs     <- asks varOrigs
+  binders   <- asks varBinders
   loc       <- asks location
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope
   varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
   let mapping  = zip (nub (varsList ++ shapeTopeVars ++ map fst locals)) defaultVarIdents
       name v   = fromMaybe "_" (join (lookup v origs) <|> lookup v mapping)
-      render t = untyped (name <$> t)
+      render t = foldBinderProjections (binderProjMap name mapping binders) (untyped (name <$> t))
       entries  = [ HoleEntry (name v) (render (varType info)) | (v, info) <- locals ]
       flagged  = zip cubeFlags entries
       -- binder name for the shape: the declared name if any, else a default
-      shapeBinder   = fromMaybe (fromString "t") (mshape >>= fst)
+      shapeBinder   = fromMaybe (fromString "t") (binderName =<< (fst <$> mshape))
       nameInc Z     = shapeBinder
       nameInc (S v) = name v
       goalShape = (\t -> (shapeBinder, untyped (nameInc <$> t))) <$> shapeTope
@@ -676,7 +699,7 @@ recordHoleShape mname goalTy mshape = do
 -- the shape as the hole's goal so the diagnostic shows @(binder : cube | tope)@.
 checkHoleAgainstShape
   :: Eq var
-  => Maybe VarIdent -> Maybe VarIdent -> TermT var -> TermT (Inc var)
+  => Maybe VarIdent -> Binder -> TermT var -> TermT (Inc var)
   -> TypeCheck var (TermT var)
 checkHoleAgainstShape mname orig cube tope = do
   reject <- asks holesAreErrors
@@ -826,7 +849,7 @@ data VarInfo var = VarInfo
   , varValue               :: Maybe (TermT var)
   , varModality            :: TModality
   , modAccum               :: TModality
-  , varOrig                :: Maybe VarIdent
+  , varOrig                :: Binder
   , varIsAssumption        :: Bool -- FIXME: perhaps, introduce something like decl kind?
   , varIsTopLevel          :: Bool
   , varDeclaredAssumptions :: [var]
@@ -974,7 +997,13 @@ varValues :: Context var -> [(var, Maybe (TermT var))]
 varValues = map (fmap varValue) . varInfos
 
 varOrigs :: Context var -> [(var, Maybe VarIdent)]
-varOrigs = map (fmap varOrig) . varInfos
+varOrigs = map (fmap (binderName . varOrig)) . varInfos
+
+-- | The full binder (pattern) of each in-scope variable, used to restore
+-- pattern-binder component names (e.g. @t@\/@s@ for @\\ (t , s) -> …@) when
+-- rendering goals, holes and contexts.
+varBinders :: Context var -> [(var, Binder)]
+varBinders = map (fmap varOrig) . varInfos
 
 varModalities :: Context var -> [(var, TModality)]
 varModalities = map (fmap varModality) . varInfos
@@ -1125,7 +1154,7 @@ collectScopeDecls errs recentVars [] = do
       , declValue = varValue
       , declIsAssumption = varIsAssumption
       , declUsedVars = varDeclaredAssumptions
-      , declLocation = updatePosition (varOrig >>= fmap fst . Rzk.hasPosition . fromVarIdent) <$> loc -- FIXME
+      , declLocation = updatePosition (binderName varOrig >>= fmap fst . Rzk.hasPosition . fromVarIdent) <$> loc -- FIXME
       }
     updatePosition Nothing l       = l
     updatePosition (Just lineNo) l = l { locationLine = Just lineNo }
@@ -1267,7 +1296,7 @@ localDeclPrepared (Decl x ty term isAssumption vars loc) tc = do
     update = addVarInCurrentScope x VarInfo
       { varType = ty
       , varValue = term
-      , varOrig = Just x
+      , varOrig = BinderVar (Just x)
       , varModality  = Id
       , modAccum = Id
       , varIsAssumption = isAssumption
@@ -1809,7 +1838,7 @@ setVariance :: Covariance -> TypeCheck var a -> TypeCheck var a
 setVariance variance = local $ \Context{..} -> Context
   { covariance = variance, .. }
 
-enterScopeContext :: Maybe VarIdent -> TModality -> TermT var -> Maybe (TermT var) -> Context var -> Context (Inc var)
+enterScopeContext :: Binder -> TModality -> TermT var -> Maybe (TermT var) -> Context var -> Context (Inc var)
 enterScopeContext orig md ty val context =
   addVarInCurrentScope Z VarInfo
     { varType   = S <$> ty
@@ -1824,12 +1853,12 @@ enterScopeContext orig md ty val context =
     }
     (S <$> context)
 
-enterScope :: Maybe VarIdent -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
+enterScope :: Binder -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
 enterScope orig ty action = do
   newContext <- asks (enterScopeContext orig Id ty Nothing)
   closeScope orig (runReaderT action newContext)
 
-enterScopeWithBind :: Maybe VarIdent -> TModality -> TermT var -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
+enterScopeWithBind :: Binder -> TModality -> TermT var -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
 enterScopeWithBind orig md ty val action = do
   newContext <- asks (enterScopeContext orig md ty (Just val))
   closeScope orig (runReaderT action newContext)
@@ -1841,11 +1870,11 @@ enterScopeWithBind orig md ty val action = do
 -- error the sub-scope's holes are dropped, which is intended: holes only matter
 -- on the success path (lenient mode), and strict mode wants the error anyway.
 closeScope
-  :: Maybe VarIdent
+  :: Binder
   -> WriterT [HoleInfo] (Except (TypeErrorInScopedContext (Inc var))) b
   -> TypeCheck var b
 closeScope orig inner = do
-  (b, holes) <- lift . lift . withExceptT (ScopedTypeError orig) $ runWriterT inner
+  (b, holes) <- lift . lift . withExceptT (ScopedTypeError (binderName orig)) $ runWriterT inner
   lift (tell holes)
   return b
 
@@ -3083,7 +3112,7 @@ typeRestrictedT ty rs = t
 
 lambdaT
   :: TermT var
-  -> Maybe VarIdent
+  -> Binder
   -> Maybe (TermT var, Maybe (Scope TermT var))
   -> Scope TermT var
   -> TermT var
@@ -3097,7 +3126,7 @@ lambdaT ty orig mparam body = t
       }
 
 
-letT :: TermT var -> Maybe VarIdent -> Maybe (TermT var) -> TermT var -> Scope TermT var -> TermT var
+letT :: TermT var -> Binder -> Maybe (TermT var) -> TermT var -> Scope TermT var -> TermT var
 letT ty orig mparam val body = t
   where
     t = LetT info orig mparam val body
@@ -3107,7 +3136,7 @@ letT ty orig mparam val body = t
       , infoWHNF = Nothing
       }
 
-letModT :: TermT var -> Maybe VarIdent -> TModality -> TModality -> Maybe (TermT var) -> TermT var -> Scope TermT var -> TermT var
+letModT :: TermT var -> Binder -> TModality -> TModality -> Maybe (TermT var) -> TermT var -> Scope TermT var -> TermT var
 letModT ty orig app inn mparam val body = t
   where
     t = LetModT info orig app inn mparam val body
@@ -3171,7 +3200,7 @@ reflT ty mx = t
       }
 
 typeFunT
-  :: Maybe VarIdent
+  :: Binder
   -> TermT var
   -> Maybe (Scope TermT var)
   -> Scope TermT var
@@ -3186,7 +3215,7 @@ typeFunT orig cube mtope ret = t
       }
 
 typeSigmaT
-  :: Maybe VarIdent
+  :: Binder
   -> TermT var
   -> Scope TermT var
   -> TermT var
@@ -3327,24 +3356,24 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
                   typeOf paramType >>= \case
                     -- an argument can be a shape
                     TypeFunT _ty _orig cube _mtope UniverseTopeT{} -> do
-                      mapM_ checkNameShadowing orig
+                      mapM_ checkNameShadowing (binderLeaves orig)
                       enterScope orig cube $ do
                         let tope' = appT topeT (S <$> paramType) (Pure Z)  -- eta expand ty'
                         return (cube, Just tope')
                     _kind -> return (paramType, Nothing)
                 unifyTerms param' paramType
-                mapM_ checkNameShadowing orig
+                mapM_ checkNameShadowing (binderLeaves orig)
                 enterScope orig param' $ do
                   mapM_ (unifyTerms (fromMaybe topeTopT mtope')) mtope
               Just (param, mtope) -> do
                 param'' <- typecheck param =<< typeOf param'
                 unifyTerms param' param''
-                mapM_ checkNameShadowing orig
+                mapM_ checkNameShadowing (binderLeaves orig)
                 enterScope orig param' $ do
                   mtope'' <- typecheck (fromMaybe TopeTop mtope) topeT
                   unifyTerms (fromMaybe topeTopT mtope') mtope''
 
-            mapM_ checkNameShadowing orig
+            mapM_ checkNameShadowing (binderLeaves orig)
             enterScope orig param' $ do
               maybe id localTope mtope' $ do
                 body' <- typecheck body ret
@@ -3352,7 +3381,7 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
 
           _ -> issueTypeError $ TypeErrorUnexpectedLambda term ty
       Let orig annot val body -> do
-        val' <- performing (ActionCheckLetValue orig) $ case annot of
+        val' <- performing (ActionCheckLetValue (binderName orig)) $ case annot of
           Nothing -> infer val
           Just bindType -> do
             bindType' <- typecheck bindType universeT
@@ -3362,7 +3391,7 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
           typecheck body (S <$> ty')
         return (letT ty' orig (Just bindTy) val' body')
       LetMod orig app inn annot val body  -> do
-        val' <- performing (ActionCheckLetValue orig) $ case annot of
+        val' <- performing (ActionCheckLetValue (binderName orig)) $ case annot of
           Nothing -> enterModality app $ infer val
           Just bindType -> do
             bindType' <- infer bindType
@@ -3505,7 +3534,7 @@ infer tt = performing (ActionInfer tt) $ case tt of
       -- Γ ⊢ (l, r) ⇒ (A × B : U)             where A × B = Σ (_ : A), B
       _ -> do
         -- NOTE: infer as a non-dependent pair!
-        return (pairT (typeSigmaT Nothing lt (S <$> rt)) l' r')
+        return (pairT (typeSigmaT (BinderVar Nothing) lt (S <$> rt)) l' r')
 
   First t -> do
     t' <- infer t
@@ -3616,17 +3645,17 @@ infer tt = performing (ActionInfer tt) $ case tt of
           UniverseTopeT{} ->
             issueTypeError $ TypeErrorOther "tope params are illegal"
           _ -> do
-            mapM_ checkNameShadowing orig
+            mapM_ checkNameShadowing (binderLeaves orig)
             b' <- enterScope orig a' $ typecheck b universeT
             return (typeFunT orig a' Nothing b')
       -- an argument can be a cube
       UniverseCubeT{} -> do
-        mapM_ checkNameShadowing orig
+        mapM_ checkNameShadowing (binderLeaves orig)
         b' <- enterScope orig a' $ typecheck b universeT
         return (typeFunT orig a' Nothing b')
       -- an argument can be a shape
       TypeFunT _ty _orig cube mtope UniverseTopeT{} -> do
-        mapM_ checkNameShadowing orig
+        mapM_ checkNameShadowing (binderLeaves orig)
         enterScope orig cube $ do
           let tope' = appT topeT (S <$> a') (Pure Z)  -- eta expand a'
           localTope tope' $ do
@@ -3638,7 +3667,7 @@ infer tt = performing (ActionInfer tt) $ case tt of
 
   TypeFun orig cube (Just tope) ret -> do
     cube' <- typecheck cube cubeT
-    mapM_ checkNameShadowing orig
+    mapM_ checkNameShadowing (binderLeaves orig)
     enterScope orig cube' $ do
       tope' <- typecheck tope topeT
       localTope tope' $ do
@@ -3647,7 +3676,7 @@ infer tt = performing (ActionInfer tt) $ case tt of
 
   TypeSigma orig a b -> do
     a' <- typecheck a universeT
-    mapM_ checkNameShadowing orig
+    mapM_ checkNameShadowing (binderLeaves orig)
     b' <- enterScope orig a' $ typecheck b universeT
     return (typeSigmaT orig a' b')
 
@@ -3700,12 +3729,12 @@ infer tt = performing (ActionInfer tt) $ case tt of
       UniverseCubeT{} -> return Nothing
       -- an argument can be a shape
       TypeFunT _ty _orig cube _mtope UniverseTopeT{} -> do
-        mapM_ checkNameShadowing orig
+        mapM_ checkNameShadowing (binderLeaves orig)
         enterScope orig cube $ do
           let tope' = appT topeT (S <$> ty') (Pure Z)  -- eta expand ty'
           return (Just tope')
       kind -> issueTypeError $ TypeErrorInvalidArgumentType ty kind
-    mapM_ checkNameShadowing orig
+    mapM_ checkNameShadowing (binderLeaves orig)
     enterScope orig ty' $ do
       maybe id localTope mtope $ do
         body' <- infer body
@@ -3713,14 +3742,14 @@ infer tt = performing (ActionInfer tt) $ case tt of
         return (lambdaT (typeFunT orig ty' mtope ret) orig (Just (ty', mtope)) body')
   Lambda orig (Just (cube, Just tope)) body -> do
     cube' <- typecheck cube cubeT
-    mapM_ checkNameShadowing orig
+    mapM_ checkNameShadowing (binderLeaves orig)
     enterScope orig cube' $ do
       tope' <- infer tope
       body' <- localTope tope' $ infer body
       ret <- typeOf body'
       return (lambdaT (typeFunT orig cube' (Just tope') ret) orig (Just (cube', Just tope')) body')
   Let orig annot val body -> do
-    val' <- performing (ActionCheckLetValue orig) $ case annot of
+    val' <- performing (ActionCheckLetValue (binderName orig)) $ case annot of
       Nothing -> infer val
       Just ty -> do
         bindTy <- typecheck ty universeT
@@ -3731,7 +3760,7 @@ infer tt = performing (ActionInfer tt) $ case tt of
       ret <- typeOf body'
       return (letT (substituteT val' ret) orig (Just bindTy) val' body')
   LetMod orig app inn annot val body -> do
-    val' <- performing (ActionCheckLetValue orig) $ case annot of
+    val' <- performing (ActionCheckLetValue (binderName orig)) $ case annot of
       Nothing -> enterModality app $ infer val
       Just bindType -> do
         bindType' <- infer bindType
@@ -3765,13 +3794,13 @@ infer tt = performing (ActionInfer tt) $ case tt of
     tA' <- typecheck tA universeT
     a' <- typecheck a tA'
     let typeOf_C =
-          typeFunT Nothing tA' Nothing $
-            typeFunT Nothing (typeIdT (S <$> a') (Just (S <$> tA')) (Pure Z)) Nothing $
+          typeFunT (BinderVar Nothing) tA' Nothing $
+            typeFunT (BinderVar Nothing) (typeIdT (S <$> a') (Just (S <$> tA')) (Pure Z)) Nothing $
               universeT
     tC' <- typecheck tC typeOf_C
     let typeOf_d =
           appT universeT
-            (appT (typeFunT Nothing (typeIdT a' (Just tA') a') Nothing universeT)
+            (appT (typeFunT (BinderVar Nothing) (typeIdT a' (Just tA') a') Nothing universeT)
               tC' a')
             (reflT (typeIdT a' (Just tA') a') Nothing)
     d' <- typecheck d typeOf_d
@@ -3779,7 +3808,7 @@ infer tt = performing (ActionInfer tt) $ case tt of
     p' <- typecheck p (typeIdT a' (Just tA') x')
     let ret =
           appT universeT
-            (appT (typeFunT Nothing (typeIdT a' (Just tA') x') Nothing universeT)
+            (appT (typeFunT (BinderVar Nothing) (typeIdT a' (Just tA') x') Nothing universeT)
               tC' x')
             p'
     return (idJT ret tA' a' tC' d' x' p')
@@ -4103,7 +4132,7 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
           maybe id localTope mtopeArg $ do
             Just <$> renderForSubShapeSVG mainColor dim (map S xs) Z ret (S <$> f) (S <$> x)  -- FIXME: breaks for 2 * (2 * 2), but works for 2 * 2 * 2 = (2 * 2) * 2
       _ -> traverse (\(p', _) -> renderForSVG mainColor accDim p' t') mp
-    TypeFunT{} | null xs -> enterScope (Just "_") t' $ do
+    TypeFunT{} | null xs -> enterScope (BinderVar (Just "_")) t' $ do
       renderTermSVGFor "blue" 0 (Nothing, []) (Pure Z)  -- use blue for types
 
     _ -> case t' of -- check evaluated term
@@ -4113,7 +4142,7 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
             maybe id localTope mtopeArg $ do
               Just <$> renderForSubShapeSVG mainColor dim (map S xs) Z ret (S <$> f) (S <$> x)  -- FIXME: breaks for 2 * (2 * 2), but works for 2 * 2 * 2 = (2 * 2) * 2
         _ -> traverse (\(p', _) -> renderForSVG mainColor accDim p' t') mp
-      TypeFunT{} | null xs -> enterScope (Just "_") t' $ do
+      TypeFunT{} | null xs -> enterScope (BinderVar (Just "_")) t' $ do
         renderTermSVGFor "blue" 0 (Nothing, []) (Pure Z)  -- use blue for types
 
       _ -> case ty of -- check type of the term

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -353,27 +353,29 @@ ppModality = \case
   Op    -> "ᵒᵖ"
   Id    -> "_id"
 
-ppTypeError' :: TypeError' -> String
-ppTypeError' = \case
+-- | Render a type error, folding pattern-binder projections (e.g. @π₁ x@ back to
+-- the user's @t@) using the supplied map (see 'contextBinders').
+ppTypeError' :: [(VarIdent, [([Proj], VarIdent)])] -> TypeError' -> String
+ppTypeError' pm = \case
   TypeErrorOther msg -> msg
   TypeErrorUnify term expected actual -> block TopDown
     [ "cannot unify expected type"
-    , "  " <> show (untyped expected)
+    , "  " <> ppU (untyped expected)
     , "with actual type"
-    , "  " <> show (untyped actual)
+    , "  " <> ppU (untyped actual)
     , "for term"
-    , "  " <> show (untyped term) ]
+    , "  " <> ppU (untyped term) ]
   TypeErrorUnifyTerms expected actual -> block TopDown
     [ "cannot unify term"
-    , "  " <> show (untyped expected)
+    , "  " <> ppU (untyped expected)
     , "with term"
-    , "  " <> show (untyped actual) ]
+    , "  " <> ppU (untyped actual) ]
   TypeErrorNotPair term ty -> block TopDown
     [ "expected a cube product or dependent pair"
     , "but got type"
-    , "  " <> show (untyped ty)
+    , "  " <> ppU (untyped ty)
     , "for term"
-    , "  " <> show (untyped term)
+    , "  " <> ppU (untyped term)
     , case ty of
         TypeFunT{} -> "\nPerhaps the term is applied to too few arguments?"
         _          -> ""
@@ -381,16 +383,16 @@ ppTypeError' = \case
   TypeErrorNotModal term m ty -> block TopDown
     [ "expected modal type " <> ppModality m <> " ?"
     , "but got type"
-    , "  " <> show (untyped ty)
+    , "  " <> ppU (untyped ty)
     , "for term"
-    , "  " <> show term
+    , "  " <> ppU term
     ]
   TypeErrorModalityMismatch expected actual term -> block TopDown
     [ "modality mismatch"
     , "  expected " <> ppModality expected
     , "  but got  " <> ppModality actual
     , "for term"
-    , "  " <> show term
+    , "  " <> ppU term
     ]
   TypeErrorUnaccessibleVar _var varMod locks -> block TopDown
     [ "unaccessible var with modality " <> ppModality varMod
@@ -399,83 +401,83 @@ ppTypeError' = \case
   TypeErrorNotTypeInModal ty -> block TopDown
     [ "expected a type inside modal type"
     , "but got"
-    , "  " <> show (untyped ty)
+    , "  " <> ppU (untyped ty)
     ]
 
   TypeErrorUnexpectedLambda term ty -> block TopDown
     [ "unexpected lambda abstraction"
-    , "  " <> show term
+    , "  " <> ppU term
     , "when typechecking against a non-function type"
-    , "  " <> show ty
+    , "  " <> ppTyped ty
     ]
   TypeErrorUnexpectedPair term ty -> block TopDown
     [ "unexpected pair"
-    , "  " <> show term
+    , "  " <> ppU term
     , "when typechecking against a type that is not a product or a dependent sum"
-    , "  " <> show ty
+    , "  " <> ppTyped ty
     ]
   TypeErrorUnexpectedRefl term ty -> block TopDown
     [ "unexpected refl"
-    , "  " <> show term
+    , "  " <> ppU term
     , "when typechecking against a type that is not an identity type"
-    , "  " <> show ty
+    , "  " <> ppTyped ty
     ]
 
   TypeErrorNotFunction term ty -> block TopDown
     [ "expected a function or extension type"
     , "but got type"
-    , "  " <> show (untyped ty)
+    , "  " <> ppU (untyped ty)
     , "for term"
-    , "  " <> show (untyped term)
+    , "  " <> ppU (untyped term)
     , case term of
-        AppT _ty f _x -> "\nPerhaps the term\n  " <> show (untyped f) <> "\nis applied to too many arguments?"
+        AppT _ty f _x -> "\nPerhaps the term\n  " <> ppU (untyped f) <> "\nis applied to too many arguments?"
         _ -> ""
     ]
   TypeErrorCannotInferBareLambda term -> block TopDown
     [ "cannot infer the type of the argument"
     , "in lambda abstraction"
-    , "  " <> show term
+    , "  " <> ppU term
     ]
   TypeErrorCannotInferBareRefl term -> block TopDown
     [ "cannot infer the type of term"
-    , "  " <> show term
+    , "  " <> ppU term
     ]
   TypeErrorCannotInferHole term -> block TopDown
     [ "cannot infer the type of a hole"
-    , "  " <> show term
+    , "  " <> ppU term
     , "a hole is only allowed where its type is already known (checking position)"
     ]
   TypeErrorUnsolvedHole mname goal -> block TopDown
     [ "found an unsolved hole" <> maybe "" (\name -> " ?" <> show name) mname
     , "expected type (goal):"
-    , "  " <> show (untyped goal)
+    , "  " <> ppU (untyped goal)
     ]
   TypeErrorUndefined var -> block TopDown
     [ "undefined variable: " <> show (Pure var :: Term') ]
   TypeErrorTopeNotSatisfied topes tope -> block TopDown
     [ "local context is not included in (does not entail) the tope"
-    , "  " <> show (untyped tope)
+    , "  " <> ppU (untyped tope)
     , "in local context (normalised)"
-    , intercalate "\n" (map ("  " <>) (map show topes))] -- FIXME: remove
+    , intercalate "\n" (map ("  " <>) (map ppTyped topes))] -- FIXME: remove
   TypeErrorTopeContextDisjoint tope topes -> block TopDown
     [ "the tope"
-    , "  " <> show (untyped tope)
+    , "  " <> ppU (untyped tope)
     , "is disjoint from the local tope context (their conjunction is the empty tope ⊥),"
     , "so this restriction face or recOR branch is vacuous everywhere"
     , "in local context (normalised)"
-    , intercalate "\n" (map ("  " <>) (map show topes))]
+    , intercalate "\n" (map ("  " <>) (map ppTyped topes))]
   TypeErrorTopesNotEquivalent expected actual -> block TopDown
     [ "expected tope"
-    , "  " <> show (untyped expected)
+    , "  " <> ppU (untyped expected)
     , "but got"
-    , "  " <> show (untyped actual) ]
+    , "  " <> ppU (untyped actual) ]
 
   TypeErrorInvalidArgumentType argType argKind -> block TopDown
     [ "invalid function parameter type"
-    , "  " <> show argType
+    , "  " <> ppU argType
     , "function parameter can be a cube, a shape, or a type"
     , "but given parameter type has type"
-    , "  " <> show (untyped argKind)
+    , "  " <> ppU (untyped argKind)
     ]
 
   TypeErrorDuplicateTopLevel previous lastName -> block TopDown
@@ -489,7 +491,7 @@ ppTypeError' = \case
 
   TypeErrorUnusedVariable name type_ -> block TopDown
     [ "unused variable"
-    , "  " <> Rzk.printTree (getVarIdent name) <> " : " <> show (untyped type_)
+    , "  " <> Rzk.printTree (getVarIdent name) <> " : " <> ppU (untyped type_)
     ]
 
   TypeErrorUnusedUsedVariables vars name -> block TopDown
@@ -501,18 +503,39 @@ ppTypeError' = \case
 
   TypeErrorImplicitAssumption (a, aType) name -> block TopDown
     [ "implicit assumption"
-    , "  " <> Rzk.printTree (getVarIdent a) <> " : " <> show (untyped aType)
+    , "  " <> Rzk.printTree (getVarIdent a) <> " : " <> ppU (untyped aType)
     , "used in definition of"
     , "  " <> Rzk.printTree (getVarIdent name)
     ]
+  where
+    -- render an (untyped) term, folding pattern-binder projections
+    ppU :: Term' -> String
+    ppU = show . foldBinderProjections pm
+    -- render a type-annotated term, folding pattern-binder projections
+    ppTyped :: TermT' -> String
+    ppTyped = show . foldBinderProjectionsT pm
 
+
+-- | The pattern binders in scope, freshened and keyed by their (current) name,
+-- together with the projection-folding map derived from them. Both share the
+-- same freshened component names, so a term's projections and the binder shown
+-- in the context agree.
+contextBinders
+  :: Context VarIdent
+  -> ([(VarIdent, Binder)], [(VarIdent, [([Proj], VarIdent)])])
+contextBinders ctx = (fbs, binderProjMap id fbs)
+  where
+    mapping = [ (v, v) | (v, _) <- varTypes ctx ]
+    fbs     = freshBinders id mapping (varBinders ctx)
 
 ppTypeErrorInContext :: OutputDirection -> TypeErrorInContext VarIdent -> String
 ppTypeErrorInContext dir TypeErrorInContext{..} = block dir
-  [ ppTypeError' typeErrorError
+  [ ppTypeError' pm typeErrorError
   , ""
   , ppContext' dir typeErrorContext
   ]
+  where
+    (_, pm) = contextBinders typeErrorContext
 
 ppTypeErrorInScopedContextWith'
   :: OutputDirection
@@ -720,72 +743,72 @@ checkHoleAgainstShape mname orig cube tope = do
       return (HoleT TypeInfo{ infoType = cube, infoWHNF = Nothing, infoNF = Nothing } mname)
 
 ppSomeAction :: Eq var => [(var, Maybe VarIdent)] -> Int -> Action var -> String
-ppSomeAction origs n action = ppAction n (toRzkVarIdent <$> action)
+ppSomeAction origs n action = ppAction [] n (toRzkVarIdent <$> action)
   where
     vars = nub (foldMap pure action)
     mapping = zip vars defaultVarIdents
     toRzkVarIdent var = fromMaybe "_" $
       join (lookup var origs) <|> lookup var mapping
 
-ppAction :: Int -> Action' -> String
-ppAction n = unlines . map (replicate (2 * n) ' ' <>) . \case
+ppAction :: [(VarIdent, [([Proj], VarIdent)])] -> Int -> Action' -> String
+ppAction pm n = unlines . map (replicate (2 * n) ' ' <>) . \case
   ActionTypeCheck term ty ->
     [ "typechecking"
-    , "  " <> show term
+    , "  " <> ppU term
     , "against type"
-    , "  " <> show (untyped ty) ]
+    , "  " <> ppU (untyped ty) ]
 
   ActionUnify term expected actual ->
     [ "unifying expected type"
-    , "  " <> show (untyped expected)
+    , "  " <> ppU (untyped expected)
     , "with actual type"
-    , "  " <> show (untyped actual)
+    , "  " <> ppU (untyped actual)
     , "for term"
-    , "  " <> show (untyped term) ]
+    , "  " <> ppU (untyped term) ]
 
   ActionUnifyTerms expected actual ->
     [ "unifying term (expected)"
-    , "  " <> show expected
+    , "  " <> ppTyped expected
     , "with term (actual)"
-    , "  " <> show actual ]
+    , "  " <> ppTyped actual ]
 
   ActionInfer term ->
     [ "inferring type for term"
-    , "  " <> show term ]
+    , "  " <> ppU term ]
 
   ActionContextEntailedBy ctxTopes term ->
     [ "checking if local context"
-    , intercalate "\n" (map (("  " <>) . show . untyped) ctxTopes)
+    , intercalate "\n" (map (("  " <>) . ppU . untyped) ctxTopes)
     , "includes (is entailed by) restriction tope"
-    , "  " <> show (untyped term) ]
+    , "  " <> ppU (untyped term) ]
 
   ActionContextEntails ctxTopes term ->
     [ "checking if local context"
-    , intercalate "\n" (map (("  " <>) . show . untyped) ctxTopes)
+    , intercalate "\n" (map (("  " <>) . ppU . untyped) ctxTopes)
     , "is included in (entails) the tope"
-    , "  " <> show (untyped term) ]
+    , "  " <> ppU (untyped term) ]
 
   ActionContextEntailsUnion ctxTopes terms ->
     [ "checking if local context"
-    , intercalate "\n" (map (("  " <>) . show . untyped) ctxTopes)
+    , intercalate "\n" (map (("  " <>) . ppU . untyped) ctxTopes)
     , "is included in (entails) the union of the topes"
-    , intercalate "\n" (map (("  " <>) . show . untyped) terms) ]
+    , intercalate "\n" (map (("  " <>) . ppU . untyped) terms) ]
 
   ActionWHNF term ->
     [ "computing WHNF for term"
-    , "  " <> show term ]
+    , "  " <> ppTyped term ]
 
   ActionNF term ->
     [ "computing normal form for term"
-    , "  " <> show (untyped term) ]
+    , "  " <> ppU (untyped term) ]
 
   ActionCheckCoherence (ltope, lterm) (rtope, rterm) ->
     [ "checking coherence for"
-    , "  " <> show (untyped ltope)
-    , "  |-> " <> show (untyped lterm)
+    , "  " <> ppU (untyped ltope)
+    , "  |-> " <> ppU (untyped lterm)
     , "and"
-    , "  " <> show (untyped rtope)
-    , "  |-> " <> show (untyped rterm) ]
+    , "  " <> ppU (untyped rtope)
+    , "  |-> " <> ppU (untyped rterm) ]
 
   ActionCloseSection Nothing ->
     [ "closing the file"
@@ -797,10 +820,15 @@ ppAction n = unlines . map (replicate (2 * n) ' ' <>) . \case
   ActionCheckLetValue orig ->
     [ "checking the local definition "
         <> maybe "_" (Rzk.printTree . getVarIdent) orig ]
+  where
+    ppU :: Term' -> String
+    ppU = show . foldBinderProjections pm
+    ppTyped :: TermT' -> String
+    ppTyped = show . foldBinderProjectionsT pm
 
 
 traceAction' :: Int -> Action' -> a -> a
-traceAction' n action = trace ("[debug]\n" <> ppAction n action)
+traceAction' n action = trace ("[debug]\n" <> ppAction [] n action)
 
 unsafeTraceAction' :: Int -> Action var -> a -> a
 unsafeTraceAction' n = traceAction' n . unsafeCoerce
@@ -1233,17 +1261,22 @@ ppContext' dir ctx@Context{..} = block dir $ dropWhile null
   , case filter (/= topeTopT) (availableTopes ctx) of
       [] -> "Local tope context is unrestricted (⊤)."
       localTopes' -> namedBlock TopDown "Local tope context:"
-        [ "  " <> show (untyped tope)
+        [ "  " <> ppU (untyped tope)
         | tope <- localTopes' ]
   , ""
   , block dir
-    [ "when " <> ppAction 0 action
+    [ "when " <> ppAction pm 0 action
     | action <- actionStack ]
   , namedBlock TopDown "Definitions in context:"
     [ block dir
-      [ show (Pure x :: Term') <> " : " <> show (untyped ty)
+      [ dispName x <> " : " <> ppU (untyped ty)
       | (x, ty) <- reverse (varTypes ctx) ] ]
   ]
+  where
+    (fbs, pm) = contextBinders ctx
+    ppU = show . foldBinderProjections pm
+    -- a pattern binder is shown as its pattern, e.g. (t , s); others by name
+    dispName x = maybe (show (Pure x :: Term')) (show . binderDisplayName) (lookup x fbs)
 
 doesShadowName :: VarIdent -> TypeCheck var [VarIdent]
 doesShadowName name = asks $ \ctx ->

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -102,3 +102,36 @@ spec = do
           ("A [" `isInfixOf` goal) `shouldBe` True   -- a restricted type, not bare A
           ("↦ a" `isInfixOf` goal) `shouldBe` True   -- the boundary face is present
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A pair-pattern binder \ (t , s) -> ? restores the user's component names:
+    -- the goal and tope context show t / s, not projections (π₁ / π₂) of a fresh
+    -- variable. This is what the game and LSP hole panels display.
+    it "restores pair-pattern binder names in the goal and topes" $ do
+      case holesOf "#lang rzk-1\n#define test : (A : U) -> (x : A) -> ( (t , s) : 2 * 2 | s <= t ) -> A [ t === s |-> x ]\n  := \\ A x (t , s) -> ?\n" of
+        [h] -> do
+          let goal = show (holeGoal h)
+          ("t ≡ s" `isInfixOf` goal) `shouldBe` True
+          ('π' `elem` goal) `shouldBe` False
+          map show (holeTopes h) `shouldContain` ["s ≤ t"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A nested tuple pattern ((t , s) , r) restores all the component names,
+    -- including the doubly-projected one (s = π₂ (π₁ x)).
+    it "restores nested tuple binder names" $ do
+      case holesOf "#lang rzk-1\n#define test : (A : U) -> (x : A) -> ( ((t , s) , r) : (2 * 2) * 2 | r <= s ) -> A [ r === t |-> x ]\n  := \\ A x ((t , s) , r) -> ?\n" of
+        [h] -> do
+          let goal = show (holeGoal h)
+          ("r ≡ t" `isInfixOf` goal) `shouldBe` True
+          ('π' `elem` goal) `shouldBe` False
+          map show (holeTopes h) `shouldContain` ["r ≤ s"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- Guardrail: ordinary projections of a variable that is NOT a pattern binder
+    -- must still print as π₁ / π₂ (only pattern-binder projections are folded).
+    it "leaves ordinary projections of a non-pattern variable as π₁ / π₂" $ do
+      case holesOf "#lang rzk-1\n#define test : (A : U) -> (x : A) -> ( p : 2 * 2 | second p <= first p ) -> A [ first p === second p |-> x ]\n  := \\ A x p -> ?\n" of
+        [h] -> do
+          let goal = show (holeGoal h)
+          ("π₁ p ≡ π₂ p" `isInfixOf` goal) `shouldBe` True
+          map show (holeTopes h) `shouldContain` ["π₂ p ≤ π₁ p"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -113,6 +113,8 @@ spec = do
           ("t ≡ s" `isInfixOf` goal) `shouldBe` True
           ('π' `elem` goal) `shouldBe` False
           map show (holeTopes h) `shouldContain` ["s ≤ t"]
+          -- the cube variable is shown as the pattern, not a fresh variable
+          names (holeCubeVars h) `shouldBe` ["(t, s)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
     -- A nested tuple pattern ((t , s) , r) restores all the component names,
@@ -124,6 +126,7 @@ spec = do
           ("r ≡ t" `isInfixOf` goal) `shouldBe` True
           ('π' `elem` goal) `shouldBe` False
           map show (holeTopes h) `shouldContain` ["r ≤ s"]
+          names (holeCubeVars h) `shouldBe` ["((t, s), r)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
     -- Guardrail: ordinary projections of a variable that is NOT a pattern binder

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -31,6 +31,7 @@ Fixture comments and `regression_for` use stable prose (which judgment fails, wh
 | Docs: sections / implicit | `ill-implicit` | `TypeErrorImplicitAssumption` |
 | Coverage matrix | `ill-unify`, `ill-undefined`, `ill-duplicate`, `ill-not-function`, `happy-check` | Core `TypeError` constructors |
 | Typed holes (strict mode) | `ill-hole-unsolved`, `ill-hole-infer` | A hole is `TypeErrorUnsolvedHole` by default (finished work/CI reject holes); a hole in inference position is `TypeErrorCannotInferHole`. Lenient mode + structured goal/context in `Rzk.HolesSpec`. |
+| Pattern-binder name restoration | `ill-hole-pattern-binder-names` | A pair-pattern lambda `\ (a , b) -> ?` renders its components by name in the strict-mode error: the goal `B (first p)` folds to `B a` and the binder shows as `(a , b)`, not `π₁ x` of a fresh variable. Lenient-mode goals/context covered by `Rzk.HolesSpec`. |
 
 # Test schema
 

--- a/rzk/test/typecheck/cases/ill-hole-pattern-binder-names.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-hole-pattern-binder-names.expect.yaml
@@ -1,0 +1,8 @@
+status: error
+error_tag: TypeErrorUnsolvedHole
+message_contains:
+  - "found an unsolved hole"
+  - "(a, b) : Σ (a : A), B a"
+  - "B a"
+regression_for:
+  - restore-pattern-binder-names

--- a/rzk/test/typecheck/cases/ill-hole-pattern-binder-names.rzk
+++ b/rzk/test/typecheck/cases/ill-hole-pattern-binder-names.rzk
@@ -1,0 +1,9 @@
+#lang rzk-1
+
+-- In strict mode the unsolved-hole error must render pattern-binder names: the
+-- lambda destructures p as (a , b), so the goal B (first p) shows as B a (not
+-- B (π₁ x)), and the binder appears in the context as (a , b), not a fresh
+-- variable. Regression for the pattern-binder name restoration.
+#define bad
+  : (A : U) -> (B : A -> U) -> (p : Σ (a : A) , B a) -> B (first p)
+  := \ A B (a , b) -> ?


### PR DESCRIPTION
When a proof binds a pair pattern, e.g. `\ (t , s) → …`, rzk used to lose the component names. A pair pattern binds a single variable internally, with the components stored as projections of it, so goals, holes and error messages showed `π₁ x₄` and `π₂ x₄` instead of the user's `t` and `s`. This is most visible in the structured hole goals that the LSP hover and the CLI `--json` output.

This PR restores the original names. For example, a hole under a 2-simplex shape now reads

```
goal:
  A [t ≡ s ↦ x]
cube variables:
  (t, s) : 2 × 2
tope context:
  s ≤ t
```

instead of the previous

```
goal:
  A [π₂ x₄ ≡ π₁ x₄ ↦ x]
cube variables:
  x₄ : 2 × 2
tope context:
  π₂ x₄ ≤ π₁ x₄
```

## Approach

The names cannot be recovered by a display-only change, because they are discarded during translation to the core syntax. We therefore carry the pattern structure on the binder and restore the names when rendering.

- We introduce a `Binder` type (a single variable, a pair, or the unit pattern) and use it for the binder slot of the core `TermF` nodes (`TypeFunF`, `TypeSigmaF`, `LetF`, `LambdaF`, `LetModF`). The pattern is purely cosmetic: operationally a pair pattern still binds one variable, with the components as projections, so typechecking is unchanged.
- When rendering, projection chains rooted at a pattern binder are folded back to the recorded component names (`foldBinderProjections`), and the binder itself is shown as the original pattern. Ordinary projections of non-pattern values are left as `π₁` / `π₂`.
- Tuples desugar to nested pairs, so they are handled by the same mechanism (e.g. `((t , s) , r)` restores `t`, `s` and `r`, including the doubly-projected `s = π₂ (π₁ x)`).
- The typechecker threads the binder through the context (`varBinders`), so hole goals, boundaries and contexts pick up the names. A pattern binder is also listed in a hole's local context as the pattern itself, e.g. `(t , s) : 2 × 2`, using the same freshened names as the goal so the two line up.
- Strict-mode type errors fold the names as well. The leaf of an error already carries the full context, whose binders are keyed by the same names the error terms use, so the projection-folding map is derived from the context and threaded through `ppTypeError'`, `ppContext'` and `ppAction`. A goal such as `B (first p)` then reads `B a`, and the binder shows as `(a , b)`. Genuine projections of a non-pattern variable (for instance the Π-type's own binder `p`) are left as `π₁` / `π₂`.

The change to the binder field type flows through the generated pattern synonyms automatically, so the many sites that merely pass the binder through (e.g. `enterScope`, the smart constructors) needed no edits.