### PR TITLE
Structured JSON for hole goals and context

### DIFF
--- a/rzk/src/Rzk/Diagnostic.hs
+++ b/rzk/src/Rzk/Diagnostic.hs
@@ -28,11 +28,60 @@ data Severity
 
 -- | A structured diagnostic. Independent of any editor protocol: the LSP maps
 -- it to its own @Diagnostic@, and the CLI serialises it as JSON.
+--
+-- == JSON wire format (@rzk typecheck --json@)
+--
+-- This is a stable format that downstream tools (e.g. richer LSP hovers) pin
+-- to. Each diagnostic is an object:
+--
+-- > { "severity": "error" | "warning" | "information" | "hint"
+-- > , "code":     <string>           -- "hole", or a TypeError tag (e.g. "TypeErrorUnify")
+-- > , "location": { "file": <string|null>, "line": <int|null> } | null
+-- > , "message":  <string>           -- human-facing prose (the CLI/LSP display text)
+-- > , "hole":     <HoleData> | null  -- present only for hole diagnostics (see 'HoleData')
+-- > }
+--
+-- The @message@ field is kept for back-compat (the LSP and the CLI human mode
+-- use it). Structured consumers should read the @hole@ object instead of
+-- parsing @message@. For non-hole diagnostics @hole@ is @null@.
 data Diagnostic = Diagnostic
   { diagnosticSeverity :: Severity
   , diagnosticCode     :: String            -- ^ stable category, e.g. @\"TypeErrorUnify\"@ or @\"hole\"@
   , diagnosticLocation :: Maybe LocationInfo -- ^ file + line (line-level granularity)
   , diagnosticMessage  :: String
+  , diagnosticHole     :: Maybe HoleData     -- ^ structured hole payload ('Nothing' for type errors)
+  } deriving (Eq, Show)
+
+-- | The structured payload of a hole diagnostic: the goal and local context as
+-- already-rendered display strings (the same strings the LSP/CLI show, i.e.
+-- @show@ = @printTree@ on the underlying terms). Consumers render hole panels
+-- from these fields directly, without parsing the human-facing @message@.
+--
+-- == JSON wire format
+--
+-- > { "name":     <string|null>                 -- the ?name, if the hole was named
+-- > , "goal":     <string>                       -- the expected type (the goal)
+-- > , "shape":    { "binder": <string>, "tope": <string> } | null
+-- > , "termVars": [ { "name": <string>, "type": <string> }, ... ]
+-- > , "cubeVars": [ { "name": <string>, "type": <string> }, ... ]
+-- > , "topes":    [ <string>, ... ]              -- local tope assumptions (excludes ⊤)
+-- > }
+--
+-- Notes for consumers:
+--
+-- * @shape@ is non-null only for a shape-restricted /argument/ goal, where the
+--   goal reads @(binder : goal | tope)@. For an /extension/ type the boundary is
+--   already part of @goal@ (a restricted type @A [ … ↦ … ]@), and @shape@ is
+--   @null@ — read the boundary out of @goal@.
+-- * @cubeVars@ names can be patterns like @\"(t, s)\"@ (pair-pattern binders);
+--   they are display strings, not single identifiers.
+data HoleData = HoleData
+  { holeDataName     :: Maybe String           -- ^ the @?name@, if named
+  , holeDataGoal     :: String                 -- ^ the goal (expected type)
+  , holeDataShape    :: Maybe (String, String) -- ^ (binder, tope) for a shape-argument goal
+  , holeDataTermVars :: [(String, String)]     -- ^ local hypotheses: (name, type)
+  , holeDataCubeVars :: [(String, String)]     -- ^ local cube variables: (name, type)
+  , holeDataTopes    :: [String]               -- ^ local tope assumptions (excluding ⊤)
   } deriving (Eq, Show)
 
 instance ToJSON Severity where
@@ -56,7 +105,21 @@ instance ToJSON Diagnostic where
     , "code"     .= diagnosticCode
     , "location" .= fmap locationToJSON diagnosticLocation
     , "message"  .= diagnosticMessage
+    , "hole"     .= diagnosticHole
     ]
+
+instance ToJSON HoleData where
+  toJSON HoleData{..} = object
+    [ "name"     .= holeDataName
+    , "goal"     .= holeDataGoal
+    , "shape"    .= fmap shapeToJSON holeDataShape
+    , "termVars" .= map entryToJSON holeDataTermVars
+    , "cubeVars" .= map entryToJSON holeDataCubeVars
+    , "topes"    .= holeDataTopes
+    ]
+    where
+      shapeToJSON (binder, tope) = object [ "binder" .= binder, "tope" .= tope ]
+      entryToJSON (name, ty)     = object [ "name" .= name, "type" .= ty ]
 
 -- | A stable tag for a type error, used as its diagnostic code. Independent of
 -- the variable type, so it survives the scoped-error unfolding.
@@ -109,6 +172,7 @@ diagnoseTypeError dir err = Diagnostic
   , diagnosticCode     = typeErrorTagInScopedContext err
   , diagnosticLocation = locationOfTypeError err
   , diagnosticMessage  = ppTypeErrorInScopedContext' dir err
+  , diagnosticHole     = Nothing
   }
 
 -- | A structured diagnostic for a hole, carrying the hole's goal and local
@@ -123,7 +187,23 @@ diagnoseHole hole = Diagnostic
   , diagnosticCode     = "hole"
   , diagnosticLocation = holeLocation hole
   , diagnosticMessage  = ppHoleInfo hole
+  , diagnosticHole     = Just (holeData hole)
   }
+
+-- | The structured payload of a hole: its goal and local context rendered to
+-- display strings (the same rendering 'ppHoleInfo' uses, but kept as separate
+-- fields rather than concatenated into prose). See 'HoleData'.
+holeData :: HoleInfo -> HoleData
+holeData HoleInfo{..} = HoleData
+  { holeDataName     = fmap show holeName
+  , holeDataGoal     = show holeGoal
+  , holeDataShape    = fmap (\(s, tope) -> (show s, show tope)) holeGoalShape
+  , holeDataTermVars = map entry holeTermVars
+  , holeDataCubeVars = map entry holeCubeVars
+  , holeDataTopes    = map show holeTopes
+  }
+  where
+    entry e = (show (holeEntryName e), show (holeEntryType e))
 
 -- | Render a hole's goal and local context (the structured query) for display,
 -- separating term variables, cube variables, and tope assumptions.

--- a/rzk/test/Rzk/DiagnosticSpec.hs
+++ b/rzk/test/Rzk/DiagnosticSpec.hs
@@ -46,6 +46,41 @@ spec = do
           ("goal" `isInfixOf` diagnosticMessage d) `shouldBe` True
         ds  -> expectationFailure ("expected one diagnostic, got " <> show (length ds))
 
+  -- The structured hole payload (Rzk.Diagnostic.HoleData) exposes the goal and
+  -- local context as separate rendered strings, so consumers (e.g. richer LSP
+  -- hovers) need not parse the prose `message`. The pair-pattern example is
+  -- reused from Rzk.HolesSpec so these assertions double as a regression that the
+  -- restored binder names (t / s, not π₁ / π₂) survive into the JSON.
+  describe "diagnoseHole structured payload" $ do
+    let pairPattern =
+          "#lang rzk-1\n\
+          \#define test : (A : U) -> (x : A) -> ( (t , s) : 2 * 2 | s <= t ) -> A [ t === s |-> x ]\n\
+          \  := \\ A x (t , s) -> ?\n"
+    it "carries the goal, cube variables and topes as separate fields" $ do
+      case diagnose pairPattern of
+        [d] -> case diagnosticHole d of
+          Just hd -> do
+            holeDataName hd `shouldBe` Nothing
+            holeDataShape hd `shouldBe` Nothing
+            ("t \8801 s" `isInfixOf` holeDataGoal hd) `shouldBe` True   -- t ≡ s
+            map fst (holeDataCubeVars hd) `shouldContain` ["(t, s)"]
+            holeDataTopes hd `shouldContain` ["s \8804 t"]              -- s ≤ t
+          Nothing -> expectationFailure "expected a structured hole payload"
+        ds  -> expectationFailure ("expected one diagnostic, got " <> show (length ds))
+
+    it "encodes the structured hole object in JSON" $ do
+      case diagnose pairPattern of
+        [d] -> do
+          let json = BL8.unpack (encode d)
+          ("\"code\":\"hole\"" `isInfixOf` json) `shouldBe` True
+          ("\"hole\":{" `isInfixOf` json) `shouldBe` True
+          ("\"goal\":" `isInfixOf` json) `shouldBe` True
+          ("\"cubeVars\":" `isInfixOf` json) `shouldBe` True
+          ("\"topes\":" `isInfixOf` json) `shouldBe` True
+          -- restored binder names are present in the wire format
+          ("(t, s)" `isInfixOf` json) `shouldBe` True
+        ds  -> expectationFailure ("expected one diagnostic, got " <> show (length ds))
+
   describe "JSON encoding" $ do
     it "encodes severity, code and message" $ do
       case diagnose "#lang rzk-1\n#check U U : U\n" of
@@ -53,4 +88,11 @@ spec = do
           let json = BL8.unpack (encode d)
           ("\"severity\":\"error\"" `isInfixOf` json) `shouldBe` True
           ("\"code\":\"TypeErrorNotFunction\"" `isInfixOf` json) `shouldBe` True
+        ds  -> expectationFailure ("expected one diagnostic, got " <> show (length ds))
+
+    it "emits a null hole field for a type-error diagnostic" $ do
+      case diagnose "#lang rzk-1\n#check U U : U\n" of
+        [d] -> do
+          diagnosticHole d `shouldBe` Nothing
+          ("\"hole\":null" `isInfixOf` BL8.unpack (encode d)) `shouldBe` True
         ds  -> expectationFailure ("expected one diagnostic, got " <> show (length ds))


### PR DESCRIPTION
`rzk typecheck --json` previously emitted each hole's goal and local context only as the pre-formatted `message` string. Tools that want to render a hole panel — the goal, the context, the tope assumptions, the boundary — had to parse human-facing prose to do it. This PR adds an optional structured payload alongside `message`, so those pieces are exposed as separate, already-rendered fields.

## What changed

`Rzk.Diagnostic` gains a `HoleData` record and a `diagnosticHole :: Maybe HoleData` field on `Diagnostic`:

- `diagnoseHole` fills `diagnosticHole` from the existing `HoleInfo` (no typechecker changes — the data is already user-name-resolved and De Bruijn-independent there).
- `diagnoseTypeError` leaves it `Nothing`. Type errors stay message-only this round, keeping the scope tight; their structure is far less consumed than holes.
- The `ToJSON Diagnostic` instance emits a `"hole"` object when present and `null` otherwise.
- `diagnosticMessage` is kept verbatim, so the LSP and the CLI human mode are unaffected. `app/Main.hs` needs no change — it just `encode`s the list.

The fields are rendered display strings (`show` = `printTree`, the same text the LSP and CLI already show), not the AST. Consumers want the strings.

## Wire format

```json
{ "severity": "warning", "code": "hole",
  "location": {"file": "...", "line": 2},
  "message": "Hole at ...\n  goal: ...",
  "hole": {
    "name": null,
    "goal": "A [t ≡ s ↦ x]",
    "shape": null,
    "termVars": [{"name":"x","type":"A"}, {"name":"A","type":"U"}],
    "cubeVars": [{"name":"(t, s)","type":"2 × 2"}],
    "topes":    ["s ≤ t"]
  } }
```

The schema is documented in the `Rzk.Diagnostic` module haddock and treated as a stable format. Two boundary cases are worth noting for consumers:

- For an *extension* type the boundary is already part of `goal` (a restricted type `A [ … ↦ … ]`), and `shape` is `null` — read the boundary out of `goal`.
- `shape` is non-null only for a shape-restricted *argument* goal, where it reads `{"binder": …, "tope": …}` and `goal` is the bare cube.
- `cubeVars` names can be patterns like `(t, s)` (pair-pattern binders) after #242 — these are display strings, not single identifiers.