### PR TITLE
Holes: record elimination candidates for a hole

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -697,12 +697,13 @@ allEliminationsInto target = go maxEliminationDepth
             concat <$> mapM (\wrap -> go (depth - 1) (wrap term)) elims
       pure ([term | fits] <> deeper)
 
--- | How deep an elimination spine 'allEliminationsInto' will build. Fully
--- applying a five-argument hypothesis and then projecting twice is depth seven
--- (the deepest spine that arises in practice). A larger bound mostly adds
--- self-referential spines (a built result applied again), so seven is the sweet
--- spot; the chain only branches at Σ-types, which are shallow, so the search
--- stays small.
+-- | How deep an elimination spine 'allEliminationsInto' will build. A temporary
+-- fixed bound: seven is enough for the spines seen so far (fully applying a
+-- five-argument hypothesis and projecting twice), and a larger bound mostly adds
+-- self-referential spines (a built result applied again). It should be made
+-- configurable, and likely raised, once there is more evidence of what real
+-- goals need. The chain only branches at Σ-types, which are shallow, so the
+-- search stays small.
 maxEliminationDepth :: Int
 maxEliminationDepth = 7
 

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -707,21 +707,15 @@ maxEliminationDepth :: Int
 maxEliminationDepth = 7
 
 -- | Whether a term of the given (whnf) type may stand where a value of the
--- @target@ type is expected: the two types unify, with holes acting as
--- wildcards (see the lenient case in 'unifyInCurrentContext'). Two refinements
--- keep the result useful:
+-- @target@ type is expected: the two types unify under 'structuralHoleUnify',
+-- so a hole acts as a wildcard leaf but a structural mismatch around it is still
+-- a mismatch (an under-applied function does not match an extension-type goal,
+-- but a partial application that genuinely fits an ordinary-function goal does).
 --
---   * Outer type restrictions (an extension-type boundary) are stripped from
---     both sides. A boundary is satisfied by later refinement, not by the choice
---     of spine; matching against the restricted goal would reject the very spine
---     that introduces the holes meant to satisfy it (e.g. @f ?@ at a boundary
---     goal).
---   * A coarse head-compatibility guard runs first, so a hole buried in a
---     structurally different type cannot excuse a mismatch and over-offer a
---     spine. An ordinary Π and a shape/extension Π are kept distinct, so an
---     under-applied function (whose result is an ordinary Π) is not offered
---     against an extension-type goal, while a partial application that genuinely
---     fits an ordinary-function goal still is.
+-- Outer type restrictions are stripped from both sides first: an extension-type
+-- boundary is satisfied by later refinement, not by the choice of spine, and
+-- matching against the restricted goal would reject the very spine that
+-- introduces the holes meant to satisfy it (e.g. @f ?@ at a boundary goal).
 --
 -- Holes or constraints recorded while probing are discarded, so this is a pure
 -- yes/no query.
@@ -729,20 +723,8 @@ fitsInto :: Eq var => TermT var -> TermT var -> TermT var -> TypeCheck var Bool
 fitsInto term ty target = do
   ty'     <- stripTypeRestrictions <$> whnfT ty
   target' <- stripTypeRestrictions <$> whnfT target
-  if not (isHoleT ty' || isHoleT target' || headShape ty' == headShape target')
-    then pure False
-    else censor (const [])
-      ((unify (Just term) target' ty' >> pure True) `catchError` \_ -> pure False)
-  where
-    -- A coarse class of a type's outermost shape; matching classes are a
-    -- necessary condition, and 'unify' settles the rest precisely. Ordinary and
-    -- shape/extension Π-types are different classes.
-    headShape t = case t of
-      TypeFunT _ _ _ Nothing _ -> 0 :: Int   -- ordinary Π
-      TypeFunT{}               -> 1          -- shape / extension type
-      TypeSigmaT{}             -> 2
-      TypeIdT{}                -> 3
-      _                        -> 4
+  censor (const []) $ local structuralHoleUnify
+    ((unify (Just term) target' ty' >> pure True) `catchError` \_ -> pure False)
 
 -- | The eliminators a value of the given (weak head normal) type admits, each
 -- as a function wrapping the eliminated term. A Π-type is eliminated by
@@ -1043,6 +1025,14 @@ data Context var = Context
     -- ^ When 'True' (the default), an unfilled hole is reported as a
     -- 'TypeErrorUnsolvedHole'; finished work (and CI) must have no holes. The
     -- lenient mode ('allowHoles') instead records each hole's goal and context.
+  , deferHoleMismatches    :: Bool
+    -- ^ How holes behave during unification, giving three modes overall. With
+    -- 'holesAreErrors' a hole is rejected outright (strict). Otherwise a hole
+    -- always unifies as a leaf; this flag then chooses what happens when the
+    -- /surrounding/ structure disagrees: 'True' (the default) defers — any term
+    -- containing a hole is accepted, for an in-progress sketch — while 'False'
+    -- keeps such a mismatch an error, so only a hole standing in a matching
+    -- structure is accepted ('structuralHoleUnify').
   } deriving (Functor, Foldable)
 
 addVarInCurrentScope :: var -> VarInfo var -> Context var -> Context var
@@ -1089,6 +1079,7 @@ emptyContext = Context
   , covariance = Covariant
   , renderBackend = Nothing
   , holesAreErrors = True
+  , deferHoleMismatches = True
   }
 
 -- | Switch to lenient hole mode: record each hole's goal and context instead
@@ -1096,6 +1087,13 @@ emptyContext = Context
 -- the @--allow-holes@ CLI mode; the default (strict) mode rejects holes.
 allowHoles :: Context var -> Context var
 allowHoles ctx = ctx { holesAreErrors = False }
+
+-- | Within the given action, a hole unifies only as a leaf in an otherwise
+-- matching structure: a structural mismatch around a hole stays an error rather
+-- than being deferred (see 'deferHoleMismatches'). Used to ask whether a term
+-- /could/ have a given type, as opposed to tolerating an in-progress sketch.
+structuralHoleUnify :: Context var -> Context var
+structuralHoleUnify ctx = ctx { deferHoleMismatches = False }
 
 askCurrentScope :: TypeCheck var (ScopeInfo var)
 askCurrentScope = asks localScopes >>= \case
@@ -2801,13 +2799,16 @@ unifyInCurrentContext mterm expected actual = performing action $ do
               _ -> typeOf expected' >>= typeOf >>= \case
                 UniverseCubeT{} -> contextEntails (topeEQT expected' actual')
                 _ -> do
+                  -- A hole stands for a term of the expected type, so a
+                  -- unification that would otherwise fail is deferred when either
+                  -- side still contains an (unfilled) hole — including one nested
+                  -- in a larger term, e.g. @f ?@ checked against an extension-type
+                  -- boundary. 'structuralHoleUnify' turns this off, keeping a
+                  -- structural mismatch around a hole an error. Lazy: only runs on
+                  -- the failure path.
+                  defer <- asks deferHoleMismatches
                   let def = unless (expected' == actual') err
-                      -- A hole stands for a term of the expected type, so a
-                      -- unification that would otherwise fail is deferred when
-                      -- either side still contains an (unfilled) hole — including
-                      -- one nested in a larger term, e.g. @f ?@ checked against an
-                      -- extension-type boundary. Lazy: only runs on the failure path.
-                      holePresent = containsHole expected' || containsHole actual'
+                      holePresent = defer && (containsHole expected' || containsHole actual')
                       err
                         | holePresent = return ()
                         | otherwise =

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Reader
 -- An explicit list: a bare 'Control.Monad.Writer' import also re-exports
 -- 'Data.Monoid' (incl. 'First'/'Last') on some mtl versions, which clashes with
 -- the 'First'/'Last' term patterns from 'Language.Rzk.Free.Syntax'.
-import           Control.Monad.Writer     (WriterT, runWriterT, tell)
+import           Control.Monad.Writer     (WriterT, censor, runWriterT, tell)
 import           Data.Bifoldable          (bifoldr)
 import           Data.Bifunctor           (first)
 import           Data.List                (intercalate, intersect, nub, partition,
@@ -670,6 +670,101 @@ containsHole = \case
   Pure{}              -> False
   Free (AnnF _ termf) -> bifoldr ((||) . containsHole) ((||) . containsHole) False termf
 
+-- | All ways to eliminate a hypothesis into a value usable at a goal. Given a
+-- @target@ type and a hypothesis /term/ (e.g. @Pure v@ for a context variable),
+-- return every elimination spine over that term whose type fits the target (or
+-- a subtype of it). Arguments introduced by application are left as holes for
+-- the caller to fill later. A value that already fits is returned as-is; a
+-- function is applied to holes; a Σ-type (or anything that unfolds to one, e.g.
+-- @is-contr@) is projected, possibly repeatedly — so e.g.
+-- @first (first (is-segal-A ? ? ? ? ?))@ is discovered.
+--
+-- The search is driven uniformly by the eliminators a (weak head normal) type
+-- admits (see 'eliminatorsOf'), so adding a new eliminator extends it without
+-- touching the search. Depth is bounded by 'maxEliminationDepth'.
+allEliminationsInto
+  :: Eq var => TermT var -> TermT var -> TypeCheck var [TermT var]
+allEliminationsInto target = go maxEliminationDepth
+  where
+    go depth term = do
+      ty   <- typeOf term
+      fits <- fitsInto term ty target
+      deeper <-
+        if depth <= 0
+          then pure []
+          else do
+            elims <- eliminatorsOf ty
+            concat <$> mapM (\wrap -> go (depth - 1) (wrap term)) elims
+      pure ([term | fits] <> deeper)
+
+-- | How deep an elimination spine 'allEliminationsInto' will build. Fully
+-- applying a five-argument hypothesis and then projecting twice is depth seven
+-- (the deepest spine that arises in practice). A larger bound mostly adds
+-- self-referential spines (a built result applied again), so seven is the sweet
+-- spot; the chain only branches at Σ-types, which are shallow, so the search
+-- stays small.
+maxEliminationDepth :: Int
+maxEliminationDepth = 7
+
+-- | Whether a term of the given (whnf) type may stand where a value of the
+-- @target@ type is expected: the two types unify, with holes acting as
+-- wildcards (see the lenient case in 'unifyInCurrentContext'). Two refinements
+-- keep the result useful:
+--
+--   * Outer type restrictions (an extension-type boundary) are stripped from
+--     both sides. A boundary is satisfied by later refinement, not by the choice
+--     of spine; matching against the restricted goal would reject the very spine
+--     that introduces the holes meant to satisfy it (e.g. @f ?@ at a boundary
+--     goal).
+--   * A coarse head-compatibility guard runs first, so a hole buried in a
+--     structurally different type cannot excuse a mismatch and over-offer a
+--     spine. An ordinary Π and a shape/extension Π are kept distinct, so an
+--     under-applied function (whose result is an ordinary Π) is not offered
+--     against an extension-type goal, while a partial application that genuinely
+--     fits an ordinary-function goal still is.
+--
+-- Holes or constraints recorded while probing are discarded, so this is a pure
+-- yes/no query.
+fitsInto :: Eq var => TermT var -> TermT var -> TermT var -> TypeCheck var Bool
+fitsInto term ty target = do
+  ty'     <- stripTypeRestrictions <$> whnfT ty
+  target' <- stripTypeRestrictions <$> whnfT target
+  if not (isHoleT ty' || isHoleT target' || headShape ty' == headShape target')
+    then pure False
+    else censor (const [])
+      ((unify (Just term) target' ty' >> pure True) `catchError` \_ -> pure False)
+  where
+    -- A coarse class of a type's outermost shape; matching classes are a
+    -- necessary condition, and 'unify' settles the rest precisely. Ordinary and
+    -- shape/extension Π-types are different classes.
+    headShape t = case t of
+      TypeFunT _ _ _ Nothing _ -> 0 :: Int   -- ordinary Π
+      TypeFunT{}               -> 1          -- shape / extension type
+      TypeSigmaT{}             -> 2
+      TypeIdT{}                -> 3
+      _                        -> 4
+
+-- | The eliminators a value of the given (weak head normal) type admits, each
+-- as a function wrapping the eliminated term. A Π-type is eliminated by
+-- application to a fresh hole; a Σ-type by either projection. Anything else
+-- admits no simple eliminator.
+eliminatorsOf :: TermT var -> TypeCheck var [TermT var -> TermT var]
+eliminatorsOf ty =
+  case stripTypeRestrictions ty of
+    TypeFunT _ty _orig param _mtope ret ->
+      pure [ \term -> let h = mkHole param in appT (substituteT h ret) term h ]
+    TypeSigmaT _ty _orig a b ->
+      pure [ \term -> firstT a term
+           , \term -> secondT (substituteT (firstT a term) b) term ]
+    -- A cube point pair (e.g. a pattern-bound @(t , s) : 2 × 2@) projects to its
+    -- coordinates; rzk renders those projections back as the pattern names.
+    CubeProductT _ty a b ->
+      pure [ \term -> firstT a term
+           , \term -> secondT b term ]
+    _ -> pure []
+  where
+    mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
+
 -- | Record the goal and local context at a hole (lenient mode only). The goal,
 -- the local hypotheses, and the tope assumptions are all rendered to
 -- user-facing 'VarIdent' names here — reusing the same resolution as
@@ -699,6 +794,11 @@ recordHoleShape mname goalTy mshape = do
   origs     <- asks varOrigs
   binders   <- asks varBinders
   loc       <- asks location
+  -- for each local hypothesis, the elimination spines that land in the goal
+  -- (arguments left as holes). Probing must not leak holes into the recorded
+  -- output, hence 'censor'.
+  candidates <- censor (const [])
+    (concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals)
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope
   varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
@@ -723,6 +823,7 @@ recordHoleShape mname goalTy mshape = do
         , holeTermVars  = [ e | (False, e) <- flagged ]
         , holeCubeVars  = [ e | (True,  e) <- flagged ]
         , holeTopes     = map render topes
+        , holeCandidates = map render candidates
         , holeLocation  = loc
         } ]
 
@@ -1374,6 +1475,10 @@ data HoleInfo = HoleInfo
   , holeTermVars  :: [HoleEntry]     -- ^ local hypotheses whose type is not a cube
   , holeCubeVars  :: [HoleEntry]     -- ^ local cube variables (type is a cube)
   , holeTopes     :: [Term']         -- ^ local tope assumptions (excluding ⊤)
+  , holeCandidates :: [Term']
+    -- ^ elimination spines over the local hypotheses whose type fits the goal,
+    -- with applied arguments left as holes (see 'allEliminationsInto'). Already
+    -- rendered, like the other fields.
   , holeLocation  :: Maybe LocationInfo
   } deriving (Eq, Show)
 

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -162,3 +162,11 @@ spec = do
           cands h `shouldContain` ["π₁ s"]
           cands h `shouldContain` ["π₂ s"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A partial application whose result structurally mismatches the goal is not
+    -- offered: matching uses structural (not fully lenient) hole unification, so
+    -- the hole in @h ?@ : @P ?@ cannot excuse the mismatch with the goal @Q@.
+    it "does not offer a structurally mismatched partial application" $ do
+      case holesOf "#lang rzk-1\n#define t : (A : U) -> (P : A -> U) -> (Q : U) -> (h : (a : A) -> P a) -> Q\n  := \\ A P Q h -> ?\n" of
+        [h] -> cands h `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -138,3 +138,27 @@ spec = do
           ("π₁ p ≡ π₂ p" `isInfixOf` goal) `shouldBe` True
           map show (holeTopes h) `shouldContain` ["π₂ p ≤ π₁ p"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+  describe "holeCandidates (type-directed elimination candidates)" $ do
+    let cands = map show . holeCandidates
+
+    -- A hypothesis that already has the goal type is offered as-is.
+    it "offers a hypothesis of the goal type directly" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> A -> A\n  := \\ A a -> ?\n" of
+        [h] -> cands h `shouldContain` ["a"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A function is offered fully applied, with its argument left as a hole;
+    -- the under-applied function itself is not a move.
+    it "applies a function, leaving the argument as a hole" $ do
+      case holesOf "#lang rzk-1\n#define h : (A : U) -> (B : U) -> (A -> B) -> A -> B\n  := \\ A B g a -> ?\n" of
+        [h] -> cands h `shouldContain` ["g ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A Σ-typed hypothesis is eliminated by projection to reach the goal.
+    it "projects a Σ-typed hypothesis to reach the goal" $ do
+      case holesOf "#lang rzk-1\n#define k : (A : U) -> (s : Σ (a : A) , A) -> A\n  := \\ A s -> ?\n" of
+        [h] -> do
+          cands h `shouldContain` ["π₁ s"]
+          cands h `shouldContain` ["π₂ s"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))


### PR DESCRIPTION
A hole's `HoleInfo` now carries `holeCandidates`: the elimination spines over the local hypotheses whose type fits the goal, with applied arguments left as holes. They are computed in `recordHoleShape`, where the context is available and definitions can be unfolded cheaply, and rendered like the other fields.

For the Segal composition, the hole

```rzk
#def compose
  (A : U) (is-segal-A : is-segal A) (x y z : A)
  (f : hom A x y) (g : hom A y z)
  : hom A x z
  := ?
```

records the single candidate

```
π₁ (π₁ (is-segal-A ? ? ? ? ?))
```

found by unfolding `is-segal A` to its five arguments and `is-contr (Σ …)` result, then projecting twice. Smaller examples:

| hypothesis | goal | candidates |
| --- | --- | --- |
| `a : A` | `A` | `a` |
| `g : A → B` | `B` | `g ?` |
| `s : Σ (a : A) , A` | `A` | `π₁ s`, `π₂ s` |

The search, `allEliminationsInto`, is driven uniformly by the eliminators a weak head normal type admits, so a new eliminator extends it without touching the search:

```haskell
eliminatorsOf ty = case stripTypeRestrictions ty of
  TypeFunT _ _ param _ ret -> pure [ \t -> appT (substituteT (hole param) ret) t (hole param) ]
  TypeSigmaT _ _ a b       -> pure [ \t -> firstT a t, \t -> secondT (substituteT (firstT a t) b) t ]
  CubeProductT _ a b       -> pure [ \t -> firstT a t, \t -> secondT b t ]
  _                        -> pure []
```

Matching needs a `unify` that is neither strict nor fully lenient about holes, so the second commit adds a third mode (`deferHoleMismatches` / `structuralHoleUnify`), giving:

1. strict — a hole is a type error (finished work, CI);
2. structural — a hole unifies as a leaf, but a structural mismatch around it stays an error;
3. lenient — any term containing a hole is accepted, tolerating an in-progress sketch.

Candidate matching runs in mode 2, so e.g. `is-segal-A ? ? ?` (an under-applied function) is rejected against the `hom` goal, whereas a hole standing in a matching structure (`hom A ? ?` against `hom A x z`) is accepted. Mode 3 stays the default, so ordinary hole-mode typechecking is unchanged. Before matching, outer type restrictions are stripped from both sides — an extension-type boundary is met by later refinement, not by the choice of spine.