### PR TITLE
Hole introductions and tope disjunction elimination candidates

### DIFF
--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -526,6 +526,17 @@ binderToPattern (BinderVar (Just x)) = Rzk.PatternVar Nothing (fromVarIdent x)
 binderToPattern (BinderPair l r)     = Rzk.PatternPair Nothing (binderToPattern l) (binderToPattern r)
 binderToPattern BinderUnit           = Rzk.PatternUnit Nothing
 
+-- | A term that prints as the binder's surface pattern, e.g. the point
+-- @(t , s)@. Used to render a /bare/ occurrence of a pattern binder's variable
+-- (one not under a projection, e.g. the point in a shape tope @Δ² (t , s)@) as
+-- the pattern itself rather than the underlying single variable. A
+-- single-variable binder yields that variable.
+binderToTerm :: Binder -> Term VarIdent
+binderToTerm (BinderVar Nothing)  = Pure (fromString "_")
+binderToTerm (BinderVar (Just x)) = Pure x
+binderToTerm (BinderPair l r)     = Pair (binderToTerm l) (binderToTerm r)
+binderToTerm BinderUnit           = Unit
+
 -- | A 'VarIdent' that prints as the binder's surface pattern, e.g. @(t , s)@.
 -- Used to display a pattern binder in a hole's local context as the pattern
 -- itself rather than as the underlying single variable.
@@ -636,10 +647,16 @@ fromScope' x used xs = fromTermWith' (x : used) xs . (>>= f)
 fromScopeBinder' :: Binder -> VarIdent -> [VarIdent] -> [VarIdent] -> Scope Term VarIdent -> Rzk.Term
 fromScopeBinder' binder x used xs scope =
   fromTermWith' (x : used) xs
-    (foldBinderProjections [(x, binderPaths binder)] (scope >>= f))
+    (restorePattern (foldBinderProjections [(x, binderPaths binder)] (scope >>= f)))
   where
     f Z     = Pure x
     f (S z) = Pure z
+    -- After projection chains have been folded to their component names, a bare
+    -- use of a pattern binder's variable (the whole point, e.g. in a shape tope
+    -- @Δ² (t , s)@) still reads as the placeholder; show it as the pattern.
+    restorePattern
+      | binderIsCompound binder = (>>= \v -> if v == x then binderToTerm binder else Pure v)
+      | otherwise               = id
 
 fromTermWith' :: [VarIdent] -> [VarIdent] -> Term' -> Rzk.Term
 fromTermWith' used vars = go

--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -606,6 +606,20 @@ foldBinderProjections m = go
     goScope = foldBinderProjections (map liftEntry m)
     liftEntry (k, leaves) = (S k, map (fmap S) leaves)
 
+-- | Replace bare uses of a pattern binder's variable with the pattern term
+-- (e.g. a whole point @(t , s)@ rather than the underlying single variable, in
+-- a tope @Δ² (t , s)@). Given a map from each (already display-named) variable
+-- to its binder, every free occurrence of a /compound/ binder's variable is
+-- expanded to its pattern. Complements 'foldBinderProjections', which folds
+-- /projections/ of such a variable; run this /after/ folding, so projections
+-- have already become component names and only bare uses remain.
+restorePatternVars :: [(VarIdent, Binder)] -> Term VarIdent -> Term VarIdent
+restorePatternVars binders = (>>= expand)
+  where
+    expand v = case lookup v binders of
+      Just b | binderIsCompound b -> binderToTerm b
+      _                           -> Pure v
+
 -- | Like 'projChain', but for type-annotated terms.
 projChainT :: TermT a -> Maybe ([Proj], a)
 projChainT (FirstT _ t)  = (\(ps, r) -> (ps ++ [PFst], r)) <$> projChainT t

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -729,9 +729,10 @@ fitsInto term ty target = do
 
 -- | The eliminators a value of the given (weak head normal) type admits, each
 -- as a function wrapping the eliminated term. A Π-type is eliminated by
--- application to a fresh hole; a Σ-type by either projection. Anything else
--- admits no simple eliminator.
-eliminatorsOf :: TermT var -> TypeCheck var [TermT var -> TermT var]
+-- application to a fresh hole; a Σ-type by either projection; an identity type
+-- by path induction (@idJ@), with the motive and base case left as holes.
+-- Anything else admits no simple eliminator.
+eliminatorsOf :: Eq var => TermT var -> TypeCheck var [TermT var -> TermT var]
 eliminatorsOf ty =
   case stripTypeRestrictions ty of
     TypeFunT _ty _orig param _mtope ret ->
@@ -744,6 +745,25 @@ eliminatorsOf ty =
     CubeProductT _ty a b ->
       pure [ \term -> firstT a term
            , \term -> secondT b term ]
+    -- A path @p : a =_A x@ is eliminated by path induction. Following the typing
+    -- of 'IdJ', the motive @C : (z : A) → (a =_A z) → U@ and the base case
+    -- @d : C a refl@ are left as holes; the spine @idJ A a C d x p@ then has type
+    -- @C x p@. The motive being a hole, this fits a goal only when the goal has
+    -- that shape — J does not stand in for an arbitrary elimination.
+    TypeIdT _ty a mtA x -> do
+      tA <- maybe (typeOf a) pure mtA
+      let cType = typeFunT (BinderVar Nothing) tA Nothing $
+                    typeFunT (BinderVar Nothing)
+                      (typeIdT (S <$> a) (Just (S <$> tA)) (Pure Z)) Nothing
+                      universeT
+          c     = mkHole cType
+          dType = appT universeT
+                    (appT (typeFunT (BinderVar Nothing) (typeIdT a (Just tA) a) Nothing universeT) c a)
+                    (reflT (typeIdT a (Just tA) a) Nothing)
+          d     = mkHole dType
+          motiveAt y p = appT universeT
+            (appT (typeFunT (BinderVar Nothing) (typeIdT a (Just tA) y) Nothing universeT) c y) p
+      pure [ \p -> idJT (motiveAt x p) tA a c d x p ]
     _ -> pure []
   where
     mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -758,14 +758,17 @@ eliminatorsOf ty =
 --   * a Σ-type or a cube product by a pair of holes (@(? , ?)@);
 --   * an identity type by @refl@, but only when its two endpoints already agree
 --     (otherwise @refl@ would not typecheck);
---   * the unit type by @unit@.
+--   * the unit type by @unit@;
+--   * the tope universe by each tope constructor — @TOP@, @BOT@, @? ≡ ?@,
+--     @? ≤ ?@, @? ∧ ?@, @? ∨ ?@ — so a shape (a hole of type @TOPE@) can be
+--     built up by tapping.
 --
 -- Any other type admits no simple introduction. Unlike 'allEliminationsInto'
--- this does not search: a type has at most one introduction form, read off its
--- (weak head normal) head constructor. Outer type restrictions are stripped
--- first, so an extension type is introduced by the form of its underlying type
--- (its boundary is met by later refinement of the holes, not by the choice of
--- constructor).
+-- this does not search: a type has at most one introduction form (the tope
+-- universe is the one exception), read off its (weak head normal) head
+-- constructor. Outer type restrictions are stripped first, so an extension type
+-- is introduced by the form of its underlying type (its boundary is met by later
+-- refinement of the holes, not by the choice of constructor).
 allIntroductionsOf :: Eq var => TermT var -> TypeCheck var [TermT var]
 allIntroductionsOf target = do
   target' <- stripTypeRestrictions <$> whnfT target
@@ -780,6 +783,15 @@ allIntroductionsOf target = do
       agree <- endpointsAgree a b
       pure [ reflT target' Nothing | agree ]
     TypeUnitT{} -> pure [ unitT ]
+    -- the tope universe: every tope constructor builds a tope, so all are
+    -- introductions of a shape goal. Point arguments (of ≡, ≤) and tope
+    -- arguments (of ∧, ∨) are left as holes.
+    UniverseTopeT{} ->
+      let point = mkHole (mkHole cubeT)  -- a point of an as-yet-unknown cube
+          tope  = mkHole target'         -- a tope (its type is the tope universe)
+       in pure [ topeTopT, topeBottomT
+               , topeEQT  point point, topeLEQT point point
+               , topeAndT tope  tope,  topeOrT  tope  tope ]
     _ -> pure []
   where
     mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -820,6 +820,55 @@ recBottomCandidates = do
   vacuous <- contextEntailsBottom
   pure [ recBottomT | vacuous ]
 
+-- | Whether the local tope context is covered by the union of the given topes —
+-- the coverage obligation of @recOR@ (see 'contextEntailsUnion'), but as a pure
+-- yes\/no query rather than a check that issues an error.
+coverageHolds :: Eq var => [TermT var] -> TypeCheck var Bool
+coverageHolds topes = do
+  contextTopes <- asks localTopesNF
+  topesNF      <- mapM nfTope topes
+  contextTopes `entailM` foldr topeOrT topeBottomT topesNF
+
+-- | Tope case-split moves: ways to build a value of the goal by @recOR@,
+-- splitting the proof over a cover of the local tope context. Three sources,
+-- offered together (the UI ranks and filters):
+--
+--   * each disjunction @ψ ∨ φ@ already in the context becomes
+--     @recOR(ψ ↦ ?, φ ↦ ?)@ — its cover is immediate;
+--   * when the goal is an extension type, its restriction faces are a cover
+--     candidate @recOR(ψ₁ ↦ ?, …)@, offered only when they actually cover the
+--     context (so the move typechecks);
+--   * a generic two-way split @recOR(? ↦ ?, ? ↦ ?)@ with the guards left as
+--     holes, for an unusual split the player fills in by hand.
+--
+-- All three are offered only in a setting where a split makes sense — a cube
+-- variable is in scope, the context has a non-trivial tope, or the goal is a
+-- restricted type — so an ordinary (tope-free) goal is left alone.
+recOrCandidates :: Eq var => TermT var -> TypeCheck var [TermT var]
+recOrCandidates goal = do
+  goalW   <- whnfT goal
+  topes   <- asks (filter (/= topeTopT) . availableTopes)
+  locals  <- asks (filter (not . varIsTopLevel . snd) . varInfos)
+  hasCube <- or <$> mapM (fmap isCubeType . whnfT . varType . snd) locals
+  let stripped     = stripTypeRestrictions goalW
+      mkRecOr gs   = recOrT stripped [ (g, mkHole stripped) | g <- gs ]
+      fromContext  = [ mkRecOr [l, r] | TopeOrT _ l r <- topes ]
+      faces        = case goalW of
+        TypeRestrictedT _ _ rs -> map fst rs
+        _                      -> []
+      isRestricted = case goalW of TypeRestrictedT{} -> True; _ -> False
+      inShape      = hasCube || not (null topes) || isRestricted
+      generic      = [ recOrT stripped [ (mkHole topeT, mkHole stripped)
+                                       , (mkHole topeT, mkHole stripped) ]
+                     | inShape ]
+  fromFaces <- if length faces >= 2
+    then do covered <- coverageHolds faces
+            pure [ mkRecOr faces | covered ]
+    else pure []
+  pure (fromContext <> fromFaces <> generic)
+  where
+    mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
+
 -- | Record the goal and local context at a hole (lenient mode only). The goal,
 -- the local hypotheses, and the tope assumptions are all rendered to
 -- user-facing 'VarIdent' names here — reusing the same resolution as
@@ -855,9 +904,10 @@ recordHoleShape mname goalTy mshape = do
   candidates <- censor (const []) $ do
     elims  <- concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals
     -- context-driven moves (independent of the goal's head and the hypotheses):
-    -- ex falso in a contradictory context.
+    -- ex falso in a contradictory context, and tope case-splits.
     recbot <- recBottomCandidates
-    pure (elims <> recbot)
+    recor  <- recOrCandidates goalTy
+    pure (elims <> recbot <> recor)
   -- the introduction forms for the goal itself (constituents left as holes).
   introductions <- censor (const []) (allIntroductionsOf goalTy)
   let shapeTope     = snd <$> mshape

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -978,7 +978,8 @@ recordHoleShape mname goalTy mshape = do
   let mapping  = zip (nub (varsList ++ shapeTopeVars ++ map fst locals)) defaultVarIdents
       name v   = fromMaybe "_" (join (lookup v origs) <|> lookup v mapping)
       fbs      = freshBinders name mapping binders
-      render t = foldBinderProjections (binderProjMap name fbs) (untyped (name <$> t))
+      render t = restorePatternVars [ (name v, b) | (v, b) <- fbs ]
+                   (foldBinderProjections (binderProjMap name fbs) (untyped (name <$> t)))
       -- a pattern binder is shown as its pattern, e.g. (t , s); others by name
       entryName v = maybe (name v) binderDisplayName (lookup v fbs)
       entries  = [ HoleEntry (entryName v) (render (varType info)) | (v, info) <- locals ]

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -745,22 +745,27 @@ eliminatorsOf ty =
     CubeProductT _ty a b ->
       pure [ \term -> firstT a term
            , \term -> secondT b term ]
-    -- A path @p : a =_A x@ is eliminated by path induction. Following the typing
-    -- of 'IdJ', the motive @C : (z : A) → (a =_A z) → U@ and the base case
-    -- @d : C a refl@ are left as holes; the spine @idJ A a C d x p@ then has type
-    -- @C x p@. The motive being a hole, this fits a goal only when the goal has
-    -- that shape — J does not stand in for an arbitrary elimination.
+    -- A path @p : a =_A x@ is eliminated by path induction. The motive
+    -- @C : (z : A) → (a =_A z) → U@ is always a function, so we introduce it
+    -- straight away as @\\ b q → ?@ rather than leaving it a bare hole: the spine
+    -- @idJ A a (\\ b q → ?) ? x p@ then has type @C x p@, which β-reduces to that
+    -- inner hole — so J fits any goal (the player fills the motive and the base
+    -- case @d : C a refl@). The two holes are the motive predicate and the base.
     TypeIdT _ty a mtA x -> do
       tA <- maybe (typeOf a) pure mtA
-      let cType = typeFunT (BinderVar Nothing) tA Nothing $
-                    typeFunT (BinderVar Nothing)
-                      (typeIdT (S <$> a) (Just (S <$> tA)) (Pure Z)) Nothing
-                      universeT
-          c     = mkHole cType
-          dType = appT universeT
-                    (appT (typeFunT (BinderVar Nothing) (typeIdT a (Just tA) a) Nothing universeT) c a)
-                    (reflT (typeIdT a (Just tA) a) Nothing)
-          d     = mkHole dType
+      let -- the motive predicate body, a type, under the two motive binders
+          cBody  = mkHole universeT
+          cInner = lambdaT (typeFunT (BinderVar Nothing)
+                              (typeIdT (S <$> a) (Just (S <$> tA)) (Pure Z)) Nothing universeT)
+                     (BinderVar (Just (fromString "q"))) Nothing cBody
+          cType  = typeFunT (BinderVar Nothing) tA Nothing $
+                     typeFunT (BinderVar Nothing)
+                       (typeIdT (S <$> a) (Just (S <$> tA)) (Pure Z)) Nothing universeT
+          c      = lambdaT cType (BinderVar (Just (fromString "b"))) Nothing cInner
+          dType  = appT universeT
+                     (appT (typeFunT (BinderVar Nothing) (typeIdT a (Just tA) a) Nothing universeT) c a)
+                     (reflT (typeIdT a (Just tA) a) Nothing)
+          d      = mkHole dType
           motiveAt y p = appT universeT
             (appT (typeFunT (BinderVar Nothing) (typeIdT a (Just tA) y) Nothing universeT) c y) p
       pure [ \p -> idJT (motiveAt x p) tA a c d x p ]

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -748,6 +748,50 @@ eliminatorsOf ty =
   where
     mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
 
+-- | All ways to introduce a value /of/ a goal type by its head constructor,
+-- leaving the constituents as holes. Given a @target@ type, return its
+-- introduction forms:
+--
+--   * a Π-type is introduced by a λ-abstraction over a hole body (@\\ x -> ?@);
+--     the binder is taken from the type, so a pattern domain (e.g. a @Δ²@ point
+--     @(t , s)@) is introduced as @\\ (t , s) -> ?@;
+--   * a Σ-type or a cube product by a pair of holes (@(? , ?)@);
+--   * an identity type by @refl@, but only when its two endpoints already agree
+--     (otherwise @refl@ would not typecheck);
+--   * the unit type by @unit@.
+--
+-- Any other type admits no simple introduction. Unlike 'allEliminationsInto'
+-- this does not search: a type has at most one introduction form, read off its
+-- (weak head normal) head constructor. Outer type restrictions are stripped
+-- first, so an extension type is introduced by the form of its underlying type
+-- (its boundary is met by later refinement of the holes, not by the choice of
+-- constructor).
+allIntroductionsOf :: Eq var => TermT var -> TypeCheck var [TermT var]
+allIntroductionsOf target = do
+  target' <- stripTypeRestrictions <$> whnfT target
+  case target' of
+    TypeFunT _ty orig _param _mtope ret ->
+      pure [ lambdaT target' orig Nothing (mkHole ret) ]
+    TypeSigmaT _ty _orig a b ->
+      let h = mkHole a in pure [ pairT target' h (mkHole (substituteT h b)) ]
+    CubeProductT _ty a b ->
+      pure [ pairT target' (mkHole a) (mkHole b) ]
+    TypeIdT _ty a _tA b -> do
+      agree <- endpointsAgree a b
+      pure [ reflT target' Nothing | agree ]
+    TypeUnitT{} -> pure [ unitT ]
+    _ -> pure []
+  where
+    mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
+
+-- | Whether the two endpoints of an identity type are definitionally equal, so
+-- that @refl@ inhabits it. Like 'fitsInto', any holes or constraints recorded
+-- while probing are discarded, leaving a pure yes\/no query.
+endpointsAgree :: Eq var => TermT var -> TermT var -> TypeCheck var Bool
+endpointsAgree a b =
+  censor (const [])
+    ((unify Nothing a b >> pure True) `catchError` \_ -> pure False)
+
 -- | Record the goal and local context at a hole (lenient mode only). The goal,
 -- the local hypotheses, and the tope assumptions are all rendered to
 -- user-facing 'VarIdent' names here — reusing the same resolution as
@@ -782,6 +826,8 @@ recordHoleShape mname goalTy mshape = do
   -- output, hence 'censor'.
   candidates <- censor (const [])
     (concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals)
+  -- the introduction forms for the goal itself (constituents left as holes).
+  introductions <- censor (const []) (allIntroductionsOf goalTy)
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope
   varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
@@ -807,6 +853,7 @@ recordHoleShape mname goalTy mshape = do
         , holeCubeVars  = [ e | (True,  e) <- flagged ]
         , holeTopes     = map render topes
         , holeCandidates = map render candidates
+        , holeIntroductions = map render introductions
         , holeLocation  = loc
         } ]
 
@@ -1477,6 +1524,10 @@ data HoleInfo = HoleInfo
   , holeCandidates :: [Term']
     -- ^ elimination spines over the local hypotheses whose type fits the goal,
     -- with applied arguments left as holes (see 'allEliminationsInto'). Already
+    -- rendered, like the other fields.
+  , holeIntroductions :: [Term']
+    -- ^ introduction forms for the goal type, built from its head constructor
+    -- with the constituents left as holes (see 'allIntroductionsOf'). Already
     -- rendered, like the other fields.
   , holeLocation  :: Maybe LocationInfo
   } deriving (Eq, Show)

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -748,6 +748,43 @@ eliminatorsOf ty =
   where
     mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
 
+-- | The binder for a λ introduced over a domain type. A binder the type already
+-- gives as a pattern is kept as-is — it carries the user's own names (e.g.
+-- @(t , s)@). Otherwise an /explicit/ (pre-whnf) Σ-type or product domain is
+-- destructured into a fresh pair pattern, recursively for products, so that a
+-- nameless @2 × 2 × 2@ parameter is introduced as @((t1 , t2) , t3)@ rather than
+-- a single opaque variable. Any other domain keeps its single binder.
+--
+-- Leaves are named by what they range over: a cube-product component is a point,
+-- named @t@/@s@-style as @tN@; a Σ component is a term, named @xN@. The names are
+-- display-only (the body is a hole that does not mention them) and carry a
+-- shared running index, so every leaf in the pattern is distinct.
+destructuringBinder :: Binder -> TermT var -> Binder
+destructuringBinder orig param = case orig of
+  BinderPair{} -> orig                 -- already a pattern: keep the user's names
+  _ -> case param of
+    CubeProductT{} -> fst (go 1 param)
+    TypeSigmaT{}   -> fst (go 1 param)
+    _              -> orig             -- not a product/Σ: leave the binder alone
+  where
+    -- a product/Σ becomes a pair; we recurse into a product's components (plain
+    -- types) but not under a Σ's binder (a scope). A leaf is named by its
+    -- enclosing constructor: @tN@ under a cube product, @xN@ under a Σ.
+    go n = \case
+      CubeProductT _ a b ->
+        let (l, n')  = child "t" n  a
+            (r, n'') = child "t" n' b
+        in (BinderPair l r, n'')
+      TypeSigmaT _ _ a _b ->
+        let (l, n') = child "x" n a
+        in (BinderPair l (BinderVar (Just (leaf "x" n'))), n' + 1)
+      _ -> (BinderVar (Just (leaf "t" n)), n + 1)  -- unreached: go is called on products only
+    child pfx n = \case
+      c@CubeProductT{} -> go n c
+      c@TypeSigmaT{}   -> go n c
+      _                -> (BinderVar (Just (leaf pfx n)), n + 1)
+    leaf pfx n = fromString (pfx <> show n :: String)
+
 -- | All ways to introduce a value /of/ a goal type by its head constructor,
 -- leaving the constituents as holes. Given a @target@ type, return its
 -- introduction forms:
@@ -773,8 +810,8 @@ allIntroductionsOf :: Eq var => TermT var -> TypeCheck var [TermT var]
 allIntroductionsOf target = do
   target' <- stripTypeRestrictions <$> whnfT target
   case target' of
-    TypeFunT _ty orig _param _mtope ret ->
-      pure [ lambdaT target' orig Nothing (mkHole ret) ]
+    TypeFunT _ty orig param _mtope ret ->
+      pure [ lambdaT target' (destructuringBinder orig param) Nothing (mkHole ret) ]
     TypeSigmaT _ty _orig a b ->
       let h = mkHole a in pure [ pairT target' h (mkHole (substituteT h b)) ]
     CubeProductT _ty a b ->

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -804,6 +804,22 @@ endpointsAgree a b =
   censor (const [])
     ((unify Nothing a b >> pure True) `catchError` \_ -> pure False)
 
+-- | Whether the local tope context is contradictory (entails ⊥). Reads the
+-- precomputed flag when present, falling back to an entailment check. Used to
+-- decide whether @recBOT@ (ex falso) is available.
+contextEntailsBottom :: Eq var => TypeCheck var Bool
+contextEntailsBottom = asks localTopesEntailBottom >>= \case
+  Just b  -> return b
+  Nothing -> asks localTopesNF >>= (`entailM` topeBottomT)
+
+-- | Ex falso: in a contradictory tope context @recBOT@ inhabits any type, so it
+-- is a candidate for every goal there (and only there — elsewhere it would not
+-- typecheck). Independent of the goal and of the local hypotheses.
+recBottomCandidates :: Eq var => TypeCheck var [TermT var]
+recBottomCandidates = do
+  vacuous <- contextEntailsBottom
+  pure [ recBottomT | vacuous ]
+
 -- | Record the goal and local context at a hole (lenient mode only). The goal,
 -- the local hypotheses, and the tope assumptions are all rendered to
 -- user-facing 'VarIdent' names here — reusing the same resolution as
@@ -836,8 +852,12 @@ recordHoleShape mname goalTy mshape = do
   -- for each local hypothesis, the elimination spines that land in the goal
   -- (arguments left as holes). Probing must not leak holes into the recorded
   -- output, hence 'censor'.
-  candidates <- censor (const [])
-    (concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals)
+  candidates <- censor (const []) $ do
+    elims  <- concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals
+    -- context-driven moves (independent of the goal's head and the hypotheses):
+    -- ex falso in a contradictory context.
+    recbot <- recBottomCandidates
+    pure (elims <> recbot)
   -- the introduction forms for the goal itself (constituents left as holes).
   introductions <- censor (const []) (allIntroductionsOf goalTy)
   let shapeTope     = snd <$> mshape
@@ -2013,9 +2033,7 @@ contextEntailsUnion topes = do
 checkTopeAgainstContext :: Eq var => String -> TermT var -> TypeCheck var ()
 checkTopeAgainstContext what tope = do
   -- a contradictory context is handled elsewhere (recBOT)
-  ctxEntailsBottom <- asks localTopesEntailBottom >>= \case
-    Just b  -> return b
-    Nothing -> asks localTopesNF >>= (`entailM` topeBottomT)
+  ctxEntailsBottom <- contextEntailsBottom
   unless ctxEntailsBottom $ do
     contextTopes <- asks localTopesNF
     let ctxTopes = filter (/= topeTopT) (accessibleTopes contextTopes)
@@ -2825,9 +2843,7 @@ unifyViaDecompose _ _ = issueTypeError (TypeErrorOther "cannot decompose")
 
 unifyInCurrentContext :: Eq var => Maybe (TermT var) -> TermT var -> TermT var -> TypeCheck var ()
 unifyInCurrentContext mterm expected actual = performing action $ do
-  inBottom <- asks localTopesEntailBottom >>= \case
-    Just b  -> return b
-    Nothing -> asks localTopesNF >>= (`entailM` topeBottomT)
+  inBottom <- contextEntailsBottom
   unless inBottom $
     unifyViaDecompose expected actual `catchError` \_ -> do      -- NOTE: this gives a small, but noticeable speedup
       expectedVal <- whnfT expected

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -170,3 +170,51 @@ spec = do
       case holesOf "#lang rzk-1\n#define t : (A : U) -> (P : A -> U) -> (Q : U) -> (h : (a : A) -> P a) -> Q\n  := \\ A P Q h -> ?\n" of
         [h] -> cands h `shouldBe` []
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+  describe "holeIntroductions (type-directed introduction forms)" $ do
+    let intros = map show . holeIntroductions
+
+    -- A function goal is introduced by a λ over a hole body; the binder is
+    -- taken from the type, so a named domain keeps its name.
+    it "introduces a function goal as a λ with a hole body" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> ((n : A) -> A)\n  := \\ A -> ?\n" of
+        [h] -> intros h `shouldBe` ["\\ n → ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A pattern domain (e.g. a cube point) keeps its pattern, so the λ binds
+    -- the pattern rather than a projection.
+    it "introduces a pattern-domain function with the pattern binder" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> ( ((t , s) : 2 × 2) -> A )\n  := \\ A -> ?\n" of
+        [h] -> intros h `shouldBe` ["\\ (t, s) → ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A Σ-type goal is introduced by a pair of holes.
+    it "introduces a Σ goal as a pair of holes" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> (B : A -> U) -> (a : A) -> (b : B a) -> Σ (w : A) , B w\n  := \\ A B a b -> ?\n" of
+        [h] -> intros h `shouldBe` ["(?, ?)"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- An identity type whose endpoints already agree is introduced by refl.
+    it "introduces an identity type with agreeing endpoints by refl" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> (a : A) -> (a =_{A} a)\n  := \\ A a -> ?\n" of
+        [h] -> intros h `shouldBe` ["refl"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- refl is conditional: it is not offered when the endpoints need not agree.
+    it "does not offer refl when the endpoints need not agree" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> (a : A) -> (b : A) -> (a =_{A} b)\n  := \\ A a b -> ?\n" of
+        [h] -> intros h `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- The unit type is introduced by unit.
+    it "introduces the unit type by unit" $ do
+      case holesOf "#lang rzk-1\n#define f : Unit\n  := ?\n" of
+        [h] -> intros h `shouldBe` ["unit"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A goal whose type has no head constructor to introduce (a neutral
+    -- application) offers no introduction.
+    it "offers no introduction for a neutral goal" $ do
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> (B : A -> U) -> (a : A) -> B a\n  := \\ A B a -> ?\n" of
+        [h] -> intros h `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -171,6 +171,19 @@ spec = do
         [h] -> cands h `shouldBe` []
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- In a contradictory tope context (here the shape @t ≡ 0₂ ∧ t ≡ 1₂@, which
+    -- entails ⊥) recBOT inhabits the goal, so it is offered as a candidate.
+    it "offers recBOT in a contradictory tope context" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a : A) : ( (t : 2 | t ≡ 0₂ ∧ t ≡ 1₂) → A )\n  := \\ t → ?\n" of
+        [h] -> cands h `shouldContain` ["recBOT"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A consistent tope context does not offer recBOT.
+    it "does not offer recBOT in a consistent tope context" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a : A) : ( (t : 2 | t ≡ 0₂) → A )\n  := \\ t → ?\n" of
+        [h] -> cands h `shouldNotContain` ["recBOT"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
   describe "holeIntroductions (type-directed introduction forms)" $ do
     let intros = map show . holeIntroductions
 

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -218,3 +218,12 @@ spec = do
       case holesOf "#lang rzk-1\n#define f : (A : U) -> (B : A -> U) -> (a : A) -> B a\n  := \\ A B a -> ?\n" of
         [h] -> intros h `shouldBe` []
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A shape goal (a hole of type TOPE) is introduced by every tope
+    -- constructor, so a shape can be built up by tapping.
+    it "introduces a tope goal by every tope constructor" $ do
+      case holesOf "#lang rzk-1\n#define sh : 2 -> TOPE\n  := \\ t -> ?\n" of
+        [h] -> do
+          show (holeGoal h) `shouldBe` "TOPE"
+          intros h `shouldBe` ["⊤", "⊥", "? ≡ ?", "? ≤ ?", "? ∧ ?", "? ∨ ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -214,11 +214,24 @@ spec = do
         [h] -> intros h `shouldBe` ["\\ n → ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
-    -- A pattern domain (e.g. a cube point) keeps its pattern, so the λ binds
-    -- the pattern rather than a projection.
+    -- A named pattern domain (e.g. a cube point) keeps its pattern, so the λ
+    -- binds the user's names rather than a projection.
     it "introduces a pattern-domain function with the pattern binder" $ do
       case holesOf "#lang rzk-1\n#define f : (A : U) -> ( ((t , s) : 2 × 2) -> A )\n  := \\ A -> ?\n" of
         [h] -> intros h `shouldBe` ["\\ (t, s) → ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A nameless product domain is destructured by default, recursively, with
+    -- cube-point leaves named tN.
+    it "destructures a nameless cube-product domain" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) : ( (2 × 2 × 2) → A ) := ?\n" of
+        [h] -> intros h `shouldBe` ["\\ ((t1, t2), t3) → ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A nameless Σ domain is destructured too, with term leaves named xN.
+    it "destructures a nameless Σ domain" $ do
+      case holesOf "#lang rzk-1\n#def f (A B C : U) : ( (Σ (a : A) , B) → C ) := ?\n" of
+        [h] -> intros h `shouldBe` ["\\ (x1, x2) → ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
     -- A Σ-type goal is introduced by a pair of holes.

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -129,6 +129,17 @@ spec = do
           names (holeCubeVars h) `shouldBe` ["((t, s), r)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A bare use of a pattern binder's point (not a projection) inside a shape
+    -- in the /goal type/ must print as the pattern, not a fresh variable: the
+    -- membership tope of @((t , s) : Δ²) → A@ reads @Δ² (t , s)@, not @Δ² x@.
+    it "restores a pattern point used bare in a goal-type shape tope" $ do
+      case holesOf "#lang rzk-1\n#def Δ² : (2 × 2) → TOPE := \\ (t , s) → s ≤ t\n#def f (A : U) : ( ((t , s) : Δ²) → A ) := ?\n" of
+        [h] -> do
+          let goal = show (holeGoal h)
+          ("| Δ² (t, s))" `isInfixOf` goal) `shouldBe` True
+          ('π' `elem` goal) `shouldBe` False
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- Guardrail: ordinary projections of a variable that is NOT a pattern binder
     -- must still print as π₁ / π₂ (only pattern-binder projections are folded).
     it "leaves ordinary projections of a non-pattern variable as π₁ / π₂" $ do

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -163,6 +163,21 @@ spec = do
           cands h `shouldContain` ["π₂ s"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A path is eliminated by path induction. Over @p : a =_A x@ the spine
+    -- @idJ (A, a, ?, ?, x, p)@ : @C x p@ fits a goal of exactly that shape, with
+    -- the motive and base case left as holes.
+    it "eliminates a path by idJ when the goal has the motive shape" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a x : A) (p : a =_{A} x) (C : (z : A) → (a =_{A} z) → U) (d : C a refl)\n  : C x p := ?\n" of
+        [h] -> cands h `shouldContain` ["idJ (A, a, ?, ?, x, p)"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- idJ is not a stand-in for an arbitrary elimination: over the same path but
+    -- an ordinary goal, the motive hole would not fit, so no idJ spine is offered.
+    it "does not offer idJ for a goal without the motive shape" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a x : A) (p : a =_{A} x) : A := ?\n" of
+        [h] -> filter (isInfixOf "idJ") (cands h) `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- A partial application whose result structurally mismatches the goal is not
     -- offered: matching uses structural (not fully lenient) hole unification, so
     -- the hole in @h ?@ : @P ?@ cannot excuse the mismatch with the goal @Q@.

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -184,6 +184,26 @@ spec = do
         [h] -> cands h `shouldNotContain` ["recBOT"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- In a shape setting (a cube variable in scope) the goal can be built by a
+    -- tope case split; the generic two-way recOR is always available there.
+    it "offers a generic recOR split in a shape setting" $ do
+      case holesOf "#lang rzk-1\n#def Δ¹ : 2 → TOPE := \\ t → TOP\n#def hom (A : U) (x y : A) : U\n  := (t : Δ¹) → A [ t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y ]\n#def mor (A : U) (x y : A) : hom A x y := \\ t → ?\n" of
+        hs | (h:_) <- reverse hs -> cands h `shouldContain` ["recOR (? ↦ ?, ? ↦ ?)"]
+        _ -> expectationFailure "expected at least one hole"
+
+    -- An ordinary, tope-free goal offers no recOR split.
+    it "offers no recOR split for a tope-free goal" $ do
+      case holesOf "#lang rzk-1\n#def plain (A : U) (a : A) : A := ?\n" of
+        [h] -> filter (isInfixOf "recOR") (cands h) `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- On the boundary t ≡ 0₂ ∨ t ≡ 1₂ the faces cover the context, so the goal's
+    -- restriction faces become a concrete recOR split.
+    it "splits on the goal's faces when they cover the context" $ do
+      case holesOf "#lang rzk-1\n#def bdry (A : U) (x y : A)\n  : ( (t : 2 | t ≡ 0₂ ∨ t ≡ 1₂) → A [ t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y ] )\n  := \\ t → ?\n" of
+        [h] -> cands h `shouldContain` ["recOR (t ≡ 0₂ ↦ ?, t ≡ 1₂ ↦ ?)"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
   describe "holeIntroductions (type-directed introduction forms)" $ do
     let intros = map show . holeIntroductions
 

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -163,18 +163,18 @@ spec = do
           cands h `shouldContain` ["π₂ s"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
-    -- A path is eliminated by path induction. Over @p : a =_A x@ the spine
-    -- @idJ (A, a, ?, ?, x, p)@ : @C x p@ fits a goal of exactly that shape, with
-    -- the motive and base case left as holes.
-    it "eliminates a path by idJ when the goal has the motive shape" $ do
-      case holesOf "#lang rzk-1\n#def f (A : U) (a x : A) (p : a =_{A} x) (C : (z : A) → (a =_{A} z) → U) (d : C a refl)\n  : C x p := ?\n" of
-        [h] -> cands h `shouldContain` ["idJ (A, a, ?, ?, x, p)"]
+    -- A path is eliminated by path induction. The motive is introduced straight
+    -- away as a λ, so over @p : a =_A x@ the spine @idJ (A, a, \ b → \ q → ?, ?,
+    -- x, p)@ has a result type that β-reduces to a hole and so fits any goal —
+    -- here an ordinary goal @A@ with the path in scope.
+    it "eliminates a path by idJ, introducing the motive λ" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a x : A) (p : a =_{A} x) : A := ?\n" of
+        [h] -> cands h `shouldContain` ["idJ (A, a, \\ b → \\ q → ?, ?, x, p)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
-    -- idJ is not a stand-in for an arbitrary elimination: over the same path but
-    -- an ordinary goal, the motive hole would not fit, so no idJ spine is offered.
-    it "does not offer idJ for a goal without the motive shape" $ do
-      case holesOf "#lang rzk-1\n#def f (A : U) (a x : A) (p : a =_{A} x) : A := ?\n" of
+    -- With no path in scope there is nothing to eliminate by idJ.
+    it "does not offer idJ without a path hypothesis" $ do
+      case holesOf "#lang rzk-1\n#def f (A : U) (a : A) : A := ?\n" of
         [h] -> filter (isInfixOf "idJ") (cands h) `shouldBe` []
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 


### PR DESCRIPTION
Given a hole, rzk already records the elimination spines over the local hypotheses that fit the goal (`holeCandidates`, #244). This PR adds the dual — the *introduction* forms that build a value *of* the goal — plus a few context-driven moves, so a proof can be assembled constructor by constructor rather than only by taking hypotheses apart.

For a hole whose goal is a triangle, the structured query now reads:

```
goal: ((t, s) : 2 × 2 | Δ² x₁) → A [s ≡ 0₂ ↦ f t, t ≡ 1₂ ↦ g s, s ≡ t ↦ h s]
  introductions:
    \ (t, s) → ?
```

and for a Σ-goal `Σ (w : A), B w` it is `(?, ?)`; for `a =_{A} a` it is `refl` (but nothing for `a =_{A} b`); for `Unit` it is `unit`; and for a shape goal of type `TOPE` it is every tope constructor — `⊤`, `⊥`, `? ≡ ?`, `? ≤ ?`, `? ∧ ?`, `? ∨ ?`.