### PR TITLE
Render a bare pattern point in error messages too

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -354,9 +354,10 @@ ppModality = \case
   Id    -> "_id"
 
 -- | Render a type error, folding pattern-binder projections (e.g. @π₁ x@ back to
--- the user's @t@) using the supplied map (see 'contextBinders').
-ppTypeError' :: [(VarIdent, [([Proj], VarIdent)])] -> TypeError' -> String
-ppTypeError' pm = \case
+-- the user's @t@) and showing a bare pattern point as the pattern, using the
+-- context's freshened binders (see 'contextBinders').
+ppTypeError' :: [(VarIdent, Binder)] -> TypeError' -> String
+ppTypeError' fbs = \case
   TypeErrorOther msg -> msg
   TypeErrorUnify term expected actual -> block TopDown
     [ "cannot unify expected type"
@@ -508,12 +509,10 @@ ppTypeError' pm = \case
     , "  " <> Rzk.printTree (getVarIdent name)
     ]
   where
-    -- render an (untyped) term, folding pattern-binder projections
     ppU :: Term' -> String
-    ppU = show . foldBinderProjections pm
-    -- render a type-annotated term, folding pattern-binder projections
+    ppU = ppFoldU fbs
     ppTyped :: TermT' -> String
-    ppTyped = show . foldBinderProjectionsT pm
+    ppTyped = ppFoldT fbs
 
 
 -- | The pattern binders in scope, freshened and keyed by their (current) name,
@@ -528,14 +527,34 @@ contextBinders ctx = (fbs, binderProjMap id fbs)
     mapping = [ (v, v) | (v, _) <- varTypes ctx ]
     fbs     = freshBinders id mapping (varBinders ctx)
 
+-- | Render an (untyped) term for an error or diagnostic message, given the
+-- context's freshened pattern binders: fold a pattern-binder variable's
+-- projections to their component names, then expand a bare use of the variable
+-- to the pattern itself (see 'foldBinderProjections' and 'restorePatternVars').
+-- An empty binder list renders the term as-is.
+ppFoldU :: [(VarIdent, Binder)] -> Term' -> String
+ppFoldU fbs =
+  show . restorePatternVars fbs . foldBinderProjections (binderProjMap id fbs)
+
+-- | Like 'ppFoldU' for a type-annotated term, shown as @term : type@ with the
+-- same folding and pattern restoration applied to both halves.
+ppFoldT :: [(VarIdent, Binder)] -> TermT' -> String
+ppFoldT fbs t0 =
+  case foldBinderProjectionsT (binderProjMap id fbs) t0 of
+    t@Pure{}               -> r t
+    t@(Free (AnnF info _)) -> r t <> " : " <> r (infoType info)
+  where
+    r :: TermT' -> String
+    r = show . restorePatternVars fbs . untyped
+
 ppTypeErrorInContext :: OutputDirection -> TypeErrorInContext VarIdent -> String
 ppTypeErrorInContext dir TypeErrorInContext{..} = block dir
-  [ ppTypeError' pm typeErrorError
+  [ ppTypeError' fbs typeErrorError
   , ""
   , ppContext' dir typeErrorContext
   ]
   where
-    (_, pm) = contextBinders typeErrorContext
+    (fbs, _) = contextBinders typeErrorContext
 
 ppTypeErrorInScopedContextWith'
   :: OutputDirection
@@ -640,8 +659,9 @@ ppTermInContext term =  do
   binders <- asks varBinders
   let name = toRzkVarIdent origs
       fbs  = freshBinders name mapping binders
-  return (show (foldBinderProjections (binderProjMap name fbs)
-                  (untyped (name <$> term))))
+  return (show (restorePatternVars [ (name v, b) | (v, b) <- fbs ]
+                  (foldBinderProjections (binderProjMap name fbs)
+                    (untyped (name <$> term)))))
 
 -- | Classify a (WHNF) type as a cube, so cube variables (e.g. @t : 2@) are
 -- shown separately from ordinary term variables in a hole's context.
@@ -1026,8 +1046,8 @@ ppSomeAction origs n action = ppAction [] n (toRzkVarIdent <$> action)
     toRzkVarIdent var = fromMaybe "_" $
       join (lookup var origs) <|> lookup var mapping
 
-ppAction :: [(VarIdent, [([Proj], VarIdent)])] -> Int -> Action' -> String
-ppAction pm n = unlines . map (replicate (2 * n) ' ' <>) . \case
+ppAction :: [(VarIdent, Binder)] -> Int -> Action' -> String
+ppAction fbs n = unlines . map (replicate (2 * n) ' ' <>) . \case
   ActionTypeCheck term ty ->
     [ "typechecking"
     , "  " <> ppU term
@@ -1098,9 +1118,9 @@ ppAction pm n = unlines . map (replicate (2 * n) ' ' <>) . \case
         <> maybe "_" (Rzk.printTree . getVarIdent) orig ]
   where
     ppU :: Term' -> String
-    ppU = show . foldBinderProjections pm
+    ppU = ppFoldU fbs
     ppTyped :: TermT' -> String
-    ppTyped = show . foldBinderProjectionsT pm
+    ppTyped = ppFoldT fbs
 
 
 traceAction' :: Int -> Action' -> a -> a
@@ -1557,7 +1577,7 @@ ppContext' dir ctx@Context{..} = block dir $ dropWhile null
         | tope <- localTopes' ]
   , ""
   , block dir
-    [ "when " <> ppAction pm 0 action
+    [ "when " <> ppAction fbs 0 action
     | action <- actionStack ]
   , namedBlock TopDown "Definitions in context:"
     [ block dir
@@ -1565,8 +1585,8 @@ ppContext' dir ctx@Context{..} = block dir $ dropWhile null
       | (x, ty) <- reverse (varTypes ctx) ] ]
   ]
   where
-    (fbs, pm) = contextBinders ctx
-    ppU = show . foldBinderProjections pm
+    (fbs, _) = contextBinders ctx
+    ppU = ppFoldU fbs
     -- a pattern binder is shown as its pattern, e.g. (t , s); others by name
     dispName x = maybe (show (Pure x :: Term')) (show . binderDisplayName) (lookup x fbs)
 

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -32,6 +32,7 @@ Fixture comments and `regression_for` use stable prose (which judgment fails, wh
 | Coverage matrix | `ill-unify`, `ill-undefined`, `ill-duplicate`, `ill-not-function`, `happy-check` | Core `TypeError` constructors |
 | Typed holes (strict mode) | `ill-hole-unsolved`, `ill-hole-infer` | A hole is `TypeErrorUnsolvedHole` by default (finished work/CI reject holes); a hole in inference position is `TypeErrorCannotInferHole`. Lenient mode + structured goal/context in `Rzk.HolesSpec`. |
 | Pattern-binder name restoration | `ill-hole-pattern-binder-names` | A pair-pattern lambda `\ (a , b) -> ?` renders its components by name in the strict-mode error: the goal `B (first p)` folds to `B a` and the binder shows as `(a , b)`, not `π₁ x` of a fresh variable. Lenient-mode goals/context covered by `Rzk.HolesSpec`. |
+| Bare pattern point in tope | `ill-tope-pattern-binder-bare` | A pattern-bound point used bare (not projected) in a shape's membership tope renders as the pattern: a type error's local tope context shows `Δ² (t , s)`, not `Δ² x₁`. Complements the projection-folding restoration above. |
 
 # Test schema
 

--- a/rzk/test/typecheck/cases/ill-tope-pattern-binder-bare.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-tope-pattern-binder-bare.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorUndefined
+message_contains:
+  - "Local tope context:"
+  - "Δ² (t, s)"
+regression_for:
+  - render-bare-pattern-point

--- a/rzk/test/typecheck/cases/ill-tope-pattern-binder-bare.rzk
+++ b/rzk/test/typecheck/cases/ill-tope-pattern-binder-bare.rzk
@@ -1,0 +1,11 @@
+#lang rzk-1
+
+-- A pattern-bound point used bare in a shape's membership tope must render as
+-- the pattern (Δ² (t , s)) in a type error's local tope context, not as a fresh
+-- variable (Δ² x₁). The undefined body forces an error whose context shows the
+-- tope. Regression for the bare-pattern rendering fix.
+#def Δ² : (2 × 2) → TOPE
+  := \ (t , s) → s ≤ t
+
+#def bad (A : U) (x : A) : ( ((t , s) : Δ²) → A )
+  := \ (t , s) → nonexistent


### PR DESCRIPTION
fresh placeholder in its "Local tope context", even though the hole query (#245) already renders it as the pattern:

```
Local tope context:
    Δ² x₁          →     Δ² (t, s)
```

#245 fixed this for the structured hole query (a hole's goal, tope context, and hypotheses), via `restorePatternVars`: after projection chains are folded to component names (`π₁ x ↦ t`), a *bare* use of the whole point — one not under a projection, e.g. in a shape's membership tope `Δ² (t , s)` — is expanded to the pattern. The type-error renderer is a separate path and was left showing `Δ² x₁`. This PR routes it through the same restoration.

The error renderers folded projections with the derived projection map alone (`pm`), which has no way to reconstruct a pattern. They now thread the context's freshened binders (`fbs`, already returned by `contextBinders`) and render every term through two helpers — `ppFoldU` for untyped terms and `ppFoldT` for type-annotated ones — that fold projections and then apply `restorePatternVars`. `ppFoldT` mirrors the `TermT'` show (`term : type`), restoring both halves. `ppTypeError'` and `ppAction` take `fbs` in place of `pm` (deriving `pm` internally); `ppContext'` and `ppTermInContext` already had `fbs` in scope.