### PR TITLE
Check recOR branches against the expected type

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -48,6 +48,7 @@ extra-source-files:
     test/typecheck/cases/ill-duplicate.rzk
     test/typecheck/cases/ill-hole-infer.rzk
     test/typecheck/cases/ill-hole-pattern-binder-names.rzk
+    test/typecheck/cases/ill-hole-recor-branch.rzk
     test/typecheck/cases/ill-hole-unsolved.rzk
     test/typecheck/cases/ill-implicit.rzk
     test/typecheck/cases/ill-interval-no-totality.rzk
@@ -99,6 +100,7 @@ extra-source-files:
     test/typecheck/cases/ill-tope-not-satisfied-tope-family-subtyping.rzk
     test/typecheck/cases/ill-tope-param-lambda.rzk
     test/typecheck/cases/ill-tope-param-typefun.rzk
+    test/typecheck/cases/ill-tope-pattern-binder-bare.rzk
     test/typecheck/cases/ill-tope-recOR-non-discrete.rzk
     test/typecheck/cases/ill-tope-subtle-app-shape-5d.rzk
     test/typecheck/cases/ill-tope-subtle-rec-or-5d-boundary.rzk
@@ -144,6 +146,7 @@ extra-source-files:
     test/typecheck/cases/ill-duplicate.expect.yaml
     test/typecheck/cases/ill-hole-infer.expect.yaml
     test/typecheck/cases/ill-hole-pattern-binder-names.expect.yaml
+    test/typecheck/cases/ill-hole-recor-branch.expect.yaml
     test/typecheck/cases/ill-hole-unsolved.expect.yaml
     test/typecheck/cases/ill-implicit.expect.yaml
     test/typecheck/cases/ill-interval-no-totality.expect.yaml
@@ -195,6 +198,7 @@ extra-source-files:
     test/typecheck/cases/ill-tope-not-satisfied-tope-family-subtyping.expect.yaml
     test/typecheck/cases/ill-tope-param-lambda.expect.yaml
     test/typecheck/cases/ill-tope-param-typefun.expect.yaml
+    test/typecheck/cases/ill-tope-pattern-binder-bare.expect.yaml
     test/typecheck/cases/ill-tope-recOR-non-discrete.expect.yaml
     test/typecheck/cases/ill-tope-subtle-app-shape-5d.expect.yaml
     test/typecheck/cases/ill-tope-subtle-rec-or-5d-boundary.expect.yaml

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -3808,15 +3808,22 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
             return $ modAppT ty' md body'
         _ -> issueTypeError $ TypeErrorNotModal term md ty'
 
-        -- FIXME: this does not make typechecking faster, why?
---      RecOr rs -> do
---        rs' <- forM rs $ \(tope, rterm) -> do
---          tope' <- typecheck tope topeT
---          contextEntailedBy tope'
---          localTope tope' $ do
---            rterm' <- typecheck rterm ty
---            return (tope', rterm')
---        return (recOrT ty rs')
+      -- In checking position the common type is already known, so we push it
+      -- into every branch instead of inferring each one and unifying. This is
+      -- what lets a bare hole branch (recOR(φ ↦ ?, …)) be checked against the
+      -- expected type and recorded, rather than hitting TypeErrorCannotInferHole
+      -- via the inference rule. The branch-guard, coherence, and coverage
+      -- obligations mirror the inference rule (see the RecOr case of 'infer').
+      RecOr rs -> do
+        rs' <- forM rs $ \(tope, rterm) -> do
+          tope' <- typecheck tope topeT
+          checkTopeAgainstContext "recOR branch guard" tope'
+          localTope tope' $ do
+            rterm' <- typecheck rterm ty'
+            return (tope', rterm')
+        sequence_ [ checkCoherence l r | l:rs'' <- tails rs', r <- rs'' ]
+        contextEntailsUnion (map fst rs')
+        return (recOrT ty' rs')
       _ -> do
         term' <- infer term
         inferredType <- typeOf term'

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -62,6 +62,19 @@ spec = do
         [h] -> show (holeGoal h) `shouldBe` "A"
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A bare hole in each recOR branch: the checking-direction recOR rule pushes
+    -- the common type (A) into every branch, so both holes are recorded against A
+    -- with their branch tope in context. Without that rule the recOR is elaborated
+    -- by inference and the branch holes fail with TypeErrorCannotInferHole.
+    it "records a hole in each recOR branch against the common type" $ do
+      case holesOf "#lang rzk-1\n#define square : (A : U) -> A -> (2 × 2) -> A\n  := \\ A a (t , s) -> recOR ( t ≤ s ↦ ? , s ≤ t ↦ ? )\n" of
+        [h1, h2] -> do
+          show (holeGoal h1) `shouldBe` "A"
+          show (holeGoal h2) `shouldBe` "A"
+          map show (holeTopes h1) `shouldContain` ["t ≤ s"]
+          map show (holeTopes h2) `shouldContain` ["s ≤ t"]
+        hs  -> expectationFailure ("expected exactly two holes, got " <> show (length hs))
+
     -- A hole nested inside a larger term (`f ?`) checked against an
     -- extension-type boundary: the boundary face is unified against `f ?`, which
     -- must be deferred rather than reported as a mismatch.

--- a/rzk/test/typecheck/cases/ill-hole-recor-branch.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-hole-recor-branch.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorUnsolvedHole
+message_contains:
+  - "found an unsolved hole"
+  - "A"
+regression_for:
+  - holes-recOR-branch-checking-position

--- a/rzk/test/typecheck/cases/ill-hole-recor-branch.rzk
+++ b/rzk/test/typecheck/cases/ill-hole-recor-branch.rzk
@@ -1,0 +1,10 @@
+#lang rzk-1
+
+-- A hole in a recOR branch is in checking position: the common type of the
+-- recOR (here A) is pushed into every branch, so the branch holes are checked
+-- against A. In the default (strict) mode this is reported as an unsolved hole.
+-- Before the recOR checking rule existed, the recOR was elaborated by inference
+-- and a bare hole branch failed with TypeErrorCannotInferHole instead.
+#define square (A : U) (a : A)
+  : (2 × 2) → A
+  := \ (t , s) → recOR ( t ≤ s ↦ ? , s ≤ t ↦ ? )

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.expect.yaml
@@ -1,5 +1,5 @@
 status: error
-error_tag: TypeErrorUnifyTerms
+error_tag: TypeErrorUnify
 message_contains:
   - "cannot unify"
 regression_for:

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.rzk
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.rzk
@@ -2,8 +2,8 @@
 
 -- Ill counterpart to `happy-tope-nested-rec-or-d4.rzk`: **identical** nested binary `recOR`
 -- except the **rightmost leaf** along the all-`1₂` corner (`t0 ≡ 1₂`, …, `t3 ≡ 1₂`),
--- where `u` is replaced by `unit`, so the branch infers `Unit` instead of `U` and
--- `recOR` inference fails only after processing the full tree (see error at innermost branch).
+-- where `u` is replaced by `unit`. The type-level `recOR` is checked against `U`, so
+-- the bad leaf is caught directly when its `unit` (of type `Unit`) is checked against `U`.
 
 #define u : U := Unit
 

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.expect.yaml
@@ -1,5 +1,5 @@
 status: error
-error_tag: TypeErrorUnifyTerms
+error_tag: TypeErrorUnify
 message_contains:
   - "cannot unify"
 regression_for:

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.rzk
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.rzk
@@ -2,8 +2,8 @@
 
 -- Ill counterpart to `happy-tope-nested-rec-or-d5.rzk`: **identical** nested binary `recOR`
 -- except the **rightmost leaf** along the all-`1₂` corner (`t0 ≡ 1₂`, …, `t4 ≡ 1₂`),
--- where `u` is replaced by `unit`, so the branch infers `Unit` instead of `U` and
--- `recOR` inference fails only after processing the full tree (see error at innermost branch).
+-- where `u` is replaced by `unit`. The type-level `recOR` is checked against `U`, so
+-- the bad leaf is caught directly when its `unit` (of type `Unit`) is checked against `U`.
 
 #define u : U := Unit
 

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.expect.yaml
@@ -1,5 +1,5 @@
 status: error
-error_tag: TypeErrorUnifyTerms
+error_tag: TypeErrorUnify
 message_contains:
   - "cannot unify"
 regression_for:

--- a/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.rzk
+++ b/rzk/test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.rzk
@@ -2,8 +2,8 @@
 
 -- Ill counterpart to `happy-tope-nested-rec-or-d6.rzk`: **identical** nested binary `recOR`
 -- except the **rightmost leaf** along the all-`1₂` corner (`t0 ≡ 1₂`, …, `t5 ≡ 1₂`),
--- where `u` is replaced by `unit`, so the branch infers `Unit` instead of `U` and
--- `recOR` inference fails only after processing the full tree (see error at innermost branch).
+-- where `u` is replaced by `unit`. The type-level `recOR` is checked against `U`, so
+-- the bad leaf is caught directly when its `unit` (of type `Unit`) is checked against `U`.
 
 #define u : U := Unit
 

--- a/rzk/test/typecheck/cases/ill-tope-not-satisfied-rec-or-boundary-equiv.rzk
+++ b/rzk/test/typecheck/cases/ill-tope-not-satisfied-rec-or-boundary-equiv.rzk
@@ -2,7 +2,9 @@
 
 -- After the branches of `recOR`, the checker requires the local tope context to be
 -- covered by (to entail) the disjunction of branch guard topes (`contextEntailsUnion`).
--- With only `⊤` on `t : 2`, the boundary `t ≡ 0 ∨ t ≡ 1` is not entailed.
+-- With only `⊤` on `t : 2`, the boundary `t ≡ 0 ∨ t ≡ 1` is not entailed. The branches
+-- are the type `Unit` (a valid type in U) so the type-level recOR is well-formed up to
+-- the coverage obligation, which is what this fixture pins down.
 
 #define boundaryUnit (t : 2) : U
-  := recOR( t === 0_2 |-> unit, t === 1_2 |-> unit )
+  := recOR( t === 0_2 |-> Unit, t === 1_2 |-> Unit )


### PR DESCRIPTION
In checking position the common type of a `recOR` is already known, but the checker had no checking rule for `recOR`, so the term fell through to the inference rule. That rule infers each branch (`inferAs universeT`), which cannot infer a bare hole: a branch like `recOR(φ ↦ ?, …)` failed with `TypeErrorCannotInferHole` instead of putting the hole in checking position. So a hole inside a `recOR` branch was never checked against the expected type, even in lenient mode.