### PR TITLE
Holes: tolerate unused-variable diagnostics in lenient mode

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1401,12 +1401,20 @@ endSection errs = askCurrentScope >>= scopeToDecls errs
 
 scopeToDecls :: Eq var => [TypeErrorInScopedContext var] -> ScopeInfo var -> TypeCheck var ([Decl var], [TypeErrorInScopedContext var])
 scopeToDecls errs ScopeInfo{..} = do
-  (decls, errs') <- collectScopeDecls errs [] scopeVars
+  -- In lenient (hole-checking) mode an as-yet-unfilled hole may still come to
+  -- use a declared variable, so we tolerate the unused-variable diagnostics
+  -- wherever such a hole is present: a hole anywhere in the section for an
+  -- unused section assumption, a hole in the declaration itself for an unused
+  -- 'uses' variable. Strict mode (the default, and CI) keeps reporting both.
+  lenient <- not <$> asks holesAreErrors
+  let sectionHasHole = any (maybe False containsHole . varValue . snd) scopeVars
+  (decls, errs') <- collectScopeDecls (lenient && sectionHasHole) errs [] scopeVars
   -- only issue unused variable errors if there were no errors prior in the section
   -- when (null errs) $ do
   unusedErrors <- forM decls $ \Decl{..} -> do
     let unusedUsedVars = declUsedVars `intersect` map fst scopeVars
-    if null errs && not (null unusedUsedVars)
+        declHasHole    = maybe False containsHole declValue
+    if null errs && not (null unusedUsedVars) && not (lenient && declHasHole)
       then do
         err <- local (\c -> c { location = declLocation }) $
           fromTypeError (TypeErrorUnusedUsedVariables unusedUsedVars declName)
@@ -1480,21 +1488,21 @@ makeAssumptionExplicit assumption@(a, aInfo) ((x, xInfo) : xs) = do
       }
     xs' = map (fmap (insertExplicitAssumptionFor' a (x, xInfo))) xs
 
-collectScopeDecls :: Eq var => [TypeErrorInScopedContext var] -> [(var, VarInfo var)] -> [(var, VarInfo var)] -> TypeCheck var ([Decl var], [TypeErrorInScopedContext var])
-collectScopeDecls errs recentVars (decl@(var, VarInfo{..}) : vars)
+collectScopeDecls :: Eq var => Bool -> [TypeErrorInScopedContext var] -> [(var, VarInfo var)] -> [(var, VarInfo var)] -> TypeCheck var ([Decl var], [TypeErrorInScopedContext var])
+collectScopeDecls tolerateUnused errs recentVars (decl@(var, VarInfo{..}) : vars)
   | varIsAssumption = do
       (used, recentVars') <- makeAssumptionExplicit decl recentVars
       -- only issue unused vars error if there were no other errors previously
       -- when (null errs) $ do
       unusedErr <-
-        if null errs && not used
+        if null errs && not used && not tolerateUnused
           then local (\c -> c { location = varLocation }) $
             pure <$> fromTypeError (TypeErrorUnusedVariable var varType)
           else return []
-      collectScopeDecls (errs <> unusedErr) recentVars' vars
+      collectScopeDecls tolerateUnused (errs <> unusedErr) recentVars' vars
   | otherwise = do
-      collectScopeDecls errs (decl : recentVars) vars
-collectScopeDecls errs recentVars [] = do
+      collectScopeDecls tolerateUnused errs (decl : recentVars) vars
+collectScopeDecls _ errs recentVars [] = do
   loc <- asks location
   return (toDecl loc <$> recentVars, errs)
   where

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -10,6 +10,7 @@ import           Data.List           (isInfixOf)
 import qualified Data.Text           as T
 
 import qualified Language.Rzk.Syntax as Rzk
+import           Rzk.Diagnostic      (typeErrorTagInScopedContext)
 import           Rzk.TypeCheck
 
 import           Test.Hspec
@@ -26,6 +27,17 @@ holesOf src =
 
 names :: [HoleEntry] -> [String]
 names = map (show . holeEntryName)
+
+-- | Parse and typecheck a module in lenient hole mode, returning the
+-- constructor tags of the collected (non-fatal) type errors. Used to assert
+-- which diagnostics fire without depending on their rendered text.
+errTagsOf :: T.Text -> [String]
+errTagsOf src =
+  case Rzk.parseModule src of
+    Left err -> error ("parse error: " <> T.unpack err)
+    Right m  -> case typecheckModulesWithHoles [("<test>", m)] of
+      Left err           -> [typeErrorTagInScopedContext err]
+      Right (_, errs, _) -> map typeErrorTagInScopedContext errs
 
 spec :: Spec
 spec = do
@@ -312,3 +324,31 @@ spec = do
           show (holeGoal h) `shouldBe` "TOPE"
           intros h `shouldBe` ["⊤", "⊥", "? ≡ ?", "? ≤ ?", "? ∧ ?", "? ∨ ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+  -- In lenient (hole-checking) mode a partial proof should still typecheck even
+  -- when it has not yet applied a declared variable: the unfilled hole may be
+  -- where that variable will eventually be used. We tolerate the unused-variable
+  -- diagnostics only while such a hole is present; strict mode (the YAML
+  -- ill-unused-* fixtures) still reports them.
+  describe "unused-variable diagnostics tolerated in lenient hole mode" $ do
+    let section body = "#lang rzk-1\n#section sec\n#variable A : U\n"
+                    <> "#variable unused-var : A\n" <> body <> "\n#end sec\n"
+
+    it "tolerates an unused section assumption when the section has a hole" $
+      errTagsOf (section "#define only-type : U\n  := ?")
+        `shouldNotContain` ["TypeErrorUnusedVariable"]
+
+    it "still reports an unused section assumption with no hole present" $
+      errTagsOf (section "#define only-type : U\n  := A")
+        `shouldContain` ["TypeErrorUnusedVariable"]
+
+    let usesSection body = "#lang rzk-1\n#section sec\n#variable A : U\n"
+                        <> "#variable x : A\n" <> body <> "\n#end sec\n"
+
+    it "tolerates an unused 'uses' variable when the declaration has a hole" $
+      errTagsOf (usesSection "#define f uses (x) : U\n  := ?")
+        `shouldNotContain` ["TypeErrorUnusedUsedVariables"]
+
+    it "still reports an unused 'uses' variable with no hole in the declaration" $
+      errTagsOf (usesSection "#define f uses (x) : U\n  := A")
+        `shouldContain` ["TypeErrorUnusedUsedVariables"]


### PR DESCRIPTION
A partial proof often declares a dependency it has not applied yet — for example `#def f uses (funext) := ?` — and rzk reported the declared variable as *unused*, hard-erroring on the untouched template before any term is written. The unfilled hole is precisely where that variable is expected to be used, so the diagnostic is premature while the proof is still being solved.

In lenient (hole-checking) mode — i.e. `rzk typecheck --allow-holes`, and the in-process query the game and LSP use via `typecheckModulesWithHoles` — we now suppress the two unused-variable errors wherever a relevant hole is present:

- `TypeErrorUnusedVariable` for an unused **section assumption** when the section contains a hole anywhere;
- `TypeErrorUnusedUsedVariables` for an unused **`uses`** variable when the declaration itself contains a hole.

Gating on hole presence is deliberate: a variable that is genuinely unused in a *complete* part of an otherwise-partial module is still reported. Strict mode is unaffected and keeps reporting both, as the existing `ill-unused-assumption` fixture checks.

Surfacing these as proper warnings rather than suppressing them would need a warning channel in the diagnostics layer (today every collected type error is SeverityError); that is left for later.