### PR TITLE
Holes: freshen the introduction binder against scope

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -851,12 +851,18 @@ destructuringBinder orig param = case orig of
 -- constructor. Outer type restrictions are stripped first, so an extension type
 -- is introduced by the form of its underlying type (its boundary is met by later
 -- refinement of the holes, not by the choice of constructor).
-allIntroductionsOf :: Eq var => TermT var -> TypeCheck var [TermT var]
-allIntroductionsOf target = do
+--
+-- The λ binder of a Π-introduction is freshened against @inScope@ (the names
+-- already visible at the hole), so introducing over a type whose own definition
+-- reuses an in-scope name (e.g. @hom@, whose internal binder is @t@) yields
+-- @\\ t₁ -> ?@ rather than a @t@ that shadows the existing one.
+allIntroductionsOf :: Eq var => TermT var -> [VarIdent] -> TypeCheck var [TermT var]
+allIntroductionsOf target inScope = do
   target' <- stripTypeRestrictions <$> whnfT target
   case target' of
     TypeFunT _ty orig param _mtope ret ->
-      pure [ lambdaT target' (destructuringBinder orig param) Nothing (mkHole ret) ]
+      let binder = freshenBinderLeaves inScope (destructuringBinder orig param)
+       in pure [ lambdaT target' binder Nothing (mkHole ret) ]
     TypeSigmaT _ty _orig a b ->
       let h = mkHole a in pure [ pairT target' h (mkHole (substituteT h b)) ]
     CubeProductT _ty a b ->
@@ -990,8 +996,6 @@ recordHoleShape mname goalTy mshape = do
     recbot <- recBottomCandidates
     recor  <- recOrCandidates goalTy
     pure (elims <> recbot <> recor)
-  -- the introduction forms for the goal itself (constituents left as holes).
-  introductions <- censor (const []) (allIntroductionsOf goalTy)
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope
   varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
@@ -1009,6 +1013,14 @@ recordHoleShape mname goalTy mshape = do
       nameInc Z     = shapeBinder
       nameInc (S v) = name v
       goalShape = (\t -> (shapeBinder, untyped (nameInc <$> t))) <$> shapeTope
+      -- names already visible at the hole, which an introduced binder must not
+      -- shadow: each local hypothesis by its display name, or the leaves of a
+      -- pattern hypothesis.
+      inScopeNames = [ nm | (v, _) <- locals
+                          , nm <- maybe [name v] binderLeaves (lookup v fbs) ]
+  -- the introduction forms for the goal itself (constituents left as holes); the
+  -- Π binder is freshened against 'inScopeNames' so it does not shadow.
+  introductions <- censor (const []) (allIntroductionsOf goalTy inScopeNames)
   lift $ tell
     [ HoleInfo
         { holeName      = mname

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -265,6 +265,15 @@ spec = do
         [h] -> intros h `shouldBe` ["\\ n → ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- The λ binder is freshened so it does not shadow a name already in scope.
+    -- Here the goal unfolds to `(t : 2) -> A`, whose binder `t` (taken from
+    -- `endo`'s definition, mirroring `hom`) clashes with the in-scope cube
+    -- variable `t`; the introduction binds `t₁` instead of a shadowing `t`.
+    it "freshens the λ binder so it does not shadow an in-scope name" $ do
+      case holesOf "#lang rzk-1\n#define endo : U -> U\n  := \\ A -> (t : 2) -> A\n#define f : (A : U) -> (t : 2) -> endo A\n  := \\ A t -> ?\n" of
+        [h] -> intros h `shouldBe` ["\\ t₁ → ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- A named pattern domain (e.g. a cube point) keeps its pattern, so the λ
     -- binds the user's names rather than a projection.
     it "introduces a pattern-domain function with the pattern binder" $ do


### PR DESCRIPTION
The Π-introduction form offered for a hole took its binder name straight from the goal type's bound variable. When that name already named something in scope, the introduced binder shadowed it. A type whose own definition reuses a common name (e.g. `hom A x y := (t : 2) -> A`) introduced `\ t -> ?` over a context that already had a `t`, so the body's references to the outer `t` silently resolved to the inner one.

`allIntroductionsOf` now takes the names already visible at the hole and freshens the λ binder against them, reusing the existing `freshenBinderLeaves` / `refreshVar` machinery (the same one that freshens pattern binders for display). So introducing over `(t : 2) -> …` in a context that already binds `t` yields `\ t₁ -> ?` rather than a shadowing `\ t -> ?`. This applies to pattern domains too: each generated leaf name is freshened against the in-scope set.

`recordHoleShape` computes that in-scope set from the local hypotheses (a pattern hypothesis contributes its leaf names) and passes it in. The set deliberately excludes top-level definitions: a binder shadowing a global is a separate, already-tolerated concern handled by `checkNameShadowing`. A goal with no clash is unaffected and keeps the type's own binder name (so the existing introduction tests are unchanged).