### PR TITLE
Holes: tolerate a WIP term whose type only fails around a hole

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -3844,10 +3844,24 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
         sequence_ [ checkCoherence l r | l:rs'' <- tails rs', r <- rs'' ]
         contextEntailsUnion (map fst rs')
         return (recOrT ty' rs')
+      -- A neutral term is inferred, then its type unified with the expected
+      -- one. In lenient (hole-checking) mode a term that still carries an
+      -- unfilled hole is a work in progress, so a failure of that final
+      -- unification is tolerated: the holes recorded while inferring the term
+      -- stand (they were committed before this point), and we accept the term
+      -- rather than rejecting the whole sketch. The mismatch is typically
+      -- incidental to the missing pieces — e.g. an extension-type boundary face
+      -- that only fails to line up because an argument hole sits in the wrong
+      -- place (`f t` vs `x`), where neither side is itself a hole, so the
+      -- per-term deferral in 'unifyInCurrentContext' cannot see it. Strict mode
+      -- (the default, and CI) still rejects the mismatch.
       _ -> do
         term' <- infer term
         inferredType <- typeOf term'
-        unifyTypes term' ty' inferredType
+        lenient <- not <$> asks holesAreErrors
+        if lenient && containsHole term'
+          then unifyTypes term' ty' inferredType `catchError` \_ -> return ()
+          else unifyTypes term' ty' inferredType
         return term'
 
 inferAs :: Eq var => TermT var -> Term var -> TypeCheck var (TermT var)

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -7,7 +7,11 @@
 module Rzk.HolesSpec (spec) where
 
 import           Data.List           (isInfixOf)
+import           Data.Maybe          (fromMaybe)
 import qualified Data.Text           as T
+import qualified Data.Text.IO        as T (readFile)
+import           System.Environment  (lookupEnv)
+import           System.FilePath     ((</>))
 
 import qualified Language.Rzk.Syntax as Rzk
 import           Rzk.Diagnostic      (typeErrorTagInScopedContext)
@@ -38,6 +42,19 @@ errTagsOf src =
     Right m  -> case typecheckModulesWithHoles [("<test>", m)] of
       Left err           -> [typeErrorTagInScopedContext err]
       Right (_, errs, _) -> map typeErrorTagInScopedContext errs
+
+-- | Like 'holesOf'/'errTagsOf', but reads a module from @test/files/@ (so a
+-- large example need not be inlined). Honours @RZK_TEST_ROOT@ like the other
+-- specs. Returns the recorded holes and the collected error tags.
+checkFile :: FilePath -> IO ([HoleInfo], [String])
+checkFile name = do
+  root <- fromMaybe "." <$> lookupEnv "RZK_TEST_ROOT"
+  src  <- T.readFile (root </> "test" </> "files" </> name)
+  case Rzk.parseModule src of
+    Left err -> error ("parse error: " <> T.unpack err)
+    Right m  -> case typecheckModulesWithHoles [(name, m)] of
+      Left err           -> error ("typecheck threw: " <> ppTypeErrorInScopedContext' BottomUp err)
+      Right (_, errs, hs) -> pure (hs, map typeErrorTagInScopedContext errs)
 
 spec :: Spec
 spec = do
@@ -94,6 +111,22 @@ spec = do
       case holesOf "#lang rzk-1\n#define t : (A : U) -> (f : A -> A) -> (a : A) -> (t : 2) -> A [ t === 0_2 |-> a ]\n  := \\ A f a t -> f ?\n" of
         [h] -> show (holeGoal h) `shouldBe` "A"
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A genuinely completable work-in-progress term is tolerated. The example
+    -- (the Yoneda game's square-transformation level) feeds an incomplete
+    -- `codomain-square A is-segal-A a b (f ?) ? ? ? ?` where a value of
+    -- `hom A (f t) a` is wanted. Inferring it records the holes, but the final
+    -- check of its type then unifies two extension-type boundaries, and a
+    -- *hole-free* face comparison fails — so the existing per-term deferral
+    -- cannot see that a hole is involved, and the whole def was rejected with
+    -- TypeErrorUnifyTerms. We now tolerate it and keep the recorded holes. The
+    -- companion `…-complete` definition fills the holes and typechecks, so the
+    -- holes really can be filled to make the same term check (it is not a dead
+    -- end). See test/files/holes-wip-square.rzk.
+    it "tolerates a completable WIP term whose type only fails around a hole" $ do
+      (holes, errs) <- checkFile "holes-wip-square.rzk"
+      errs `shouldBe` []          -- the WIP def is tolerated, the complete one checks
+      length holes `shouldBe` 5   -- the five holes of square-transformation-wip
 
     -- A hole used as the argument of a shape-restricted function: the
     -- shape-membership tope (psi ?) mentions the hole and cannot be decided, so

--- a/rzk/test/files/holes-wip-square.rzk
+++ b/rzk/test/files/holes-wip-square.rzk
@@ -1,0 +1,79 @@
+#lang rzk-1
+
+-- A work-in-progress proof that exercises lenient hole-checking. The Segal
+-- prelude below is the standard sHoTT one (as used in the Yoneda game). The
+-- two square-transformation definitions share the same goal:
+--
+--   * `wip` leaves the codomain-square arguments as holes and is therefore
+--     incomplete. Inferring it records the holes, but the final check of its
+--     type against the expected `hom A (f t) a` then unifies two extension-type
+--     boundaries and a *hole-free* face comparison fails. In strict mode this is
+--     an error; in lenient mode we tolerate it and keep the recorded holes.
+--
+--   * `complete` fills those holes (the start hole with `0₂`, since `f 0₂ ≡ x`,
+--     and then `y f v t`). It typechecks, so `wip` is genuinely completable:
+--     the holes can be filled to make the same term typecheck.
+
+#def Δ¹
+  : 2 → TOPE
+  := \ t → TOP
+#def Δ²
+  : ( 2 × 2) → TOPE
+  := \ (t , s) → s ≤ t
+#def hom (A : U) (x y : A)
+  : U
+  := (t : Δ¹) → A [ t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y ]
+#def id-hom (A : U) (x : A)
+  : hom A x x
+  := \ t → x
+#def hom2 (A : U) (x y z : A)
+  ( f : hom A x y) (g : hom A y z) (h : hom A x z)
+  : U
+  := ((t , s) : Δ²) → A [ s ≡ 0₂ ↦ f t , t ≡ 1₂ ↦ g s , s ≡ t ↦ h s ]
+#def is-contr (A : U)
+  : U
+  := Σ (x : A) , ((y : A) → x = y)
+#def is-segal (A : U)
+  : U
+  := (x : A) → (y : A) → (z : A) → (f : hom A x y) → (g : hom A y z)
+   → is-contr (Σ (h : hom A x z) , hom2 A x y z f g h)
+#def comp-is-segal
+  ( A : U) (is-segal-A : is-segal A) (x y z : A)
+  ( f : hom A x y) (g : hom A y z)
+  : hom A x z
+  := first (first (is-segal-A x y z f g))
+#def witness-comp-is-segal
+  ( A : U) (is-segal-A : is-segal A) (x y z : A)
+  ( f : hom A x y) (g : hom A y z)
+  : hom2 A x y z f g (comp-is-segal A is-segal-A x y z f g)
+  := second (first (is-segal-A x y z f g))
+#def comp-id-witness (A : U) (x y : A) (f : hom A x y)
+  : hom2 A x y y f (id-hom A y) f
+  := \ (t , s) → f t
+#def codomain-square
+  ( A : U) (is-segal-A : is-segal A) (a b x y : A)
+  ( f : hom A x y) (v : hom A y a)
+  : ( t : Δ¹) → (s : Δ¹) → A [ t ≡ 0₂ ↦ comp-is-segal A is-segal-A x y a f v s
+                             , t ≡ 1₂ ↦ v s
+                             , s ≡ 0₂ ↦ f t
+                             , s ≡ 1₂ ↦ a ]
+  := \ t s →
+       recOR
+       ( s ≤ t ↦ (witness-comp-is-segal A is-segal-A x y a f v) (t , s)
+       , t ≤ s ↦ (comp-id-witness A x a (comp-is-segal A is-segal-A x y a f v)) (s , t))
+
+#def square-transformation-wip
+  ( A : U) (is-segal-A : is-segal A) (a : A) (b : A) (x : A) (y : A)
+  ( f : hom A x y) (v : hom A y a)
+  ( ϕ : (z : A) → hom A z a → hom A z b)
+  : ( t : Δ¹) → hom A (f t) b [ t ≡ 0₂ ↦ ϕ x (comp-is-segal A is-segal-A x y a f v)
+                              , t ≡ 1₂ ↦ ϕ y v ]
+  := \ t → ϕ (f t) (codomain-square A is-segal-A a b (f ?) ? ? ? ?)
+
+#def square-transformation-complete
+  ( A : U) (is-segal-A : is-segal A) (a : A) (b : A) (x : A) (y : A)
+  ( f : hom A x y) (v : hom A y a)
+  ( ϕ : (z : A) → hom A z a → hom A z b)
+  : ( t : Δ¹) → hom A (f t) b [ t ≡ 0₂ ↦ ϕ x (comp-is-segal A is-segal-A x y a f v)
+                              , t ≡ 1₂ ↦ ϕ y v ]
+  := \ t → ϕ (f t) (codomain-square A is-segal-A a b x y f v t)


### PR DESCRIPTION
In lenient (hole-checking) mode, the bidirectional subsumption rule infers a term's type and then unifies it with the expected type. We now tolerate a failure of that unification when the term still carries an unfilled hole. The holes recorded while inferring the term stand, and we accept the term instead of rejecting the whole sketch. Strict mode (the default, and CI) is unaffected, since a hole there is already an error. A hole-free term with a genuine mismatch still errors.

For example, with the standard Segal prelude in scope, the partial term

```rzk
#def square-transformation
  ( A : U) (is-segal-A : is-segal A) (a b x y : A)
  ( f : hom A x y) (v : hom A y a)
  ( ϕ : (z : A) → hom A z a → hom A z b)
  : ( t : Δ¹) → hom A (f t) b [ t ≡ 0₂ ↦ ϕ x (comp-is-segal A is-segal-A x y a f v)
                              , t ≡ 1₂ ↦ ϕ y v ]
  := \ t → ϕ (f t) (codomain-square A is-segal-A a b (f ?) ? ? ? ?)
```

was rejected with `TypeErrorUnifyTerms` before this change, even though inferring it records five holes. We now record those holes instead. Filling them, with the start hole `0₂` (so that `f 0₂ ≡ x`) and then `y`, `f`, `v`, `t`, gives `codomain-square A is-segal-A a b x y f v t`, and the same definition typechecks. So the holes really can be filled to complete the proof.