### PR TITLE
Holes: show the boundary in a recOR branch goal

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -3691,6 +3691,23 @@ modExtractT ty app inn term = t
       , infoWHNF = Nothing
       }
 
+-- | Check a @recOR@ in checking position against a known expected type: each
+-- branch is checked against that type under its guard tope, followed by the
+-- usual pairwise coherence and the coverage obligation. Passing a /restricted/
+-- type pushes the boundary into every branch, so a branch hole reports the
+-- faces it must meet (under its tope) instead of the bare underlying type.
+checkRecOrAgainst :: Eq var => TermT var -> [(Term var, Term var)] -> TypeCheck var (TermT var)
+checkRecOrAgainst expected rs = do
+  rs' <- forM rs $ \(tope, rterm) -> do
+    tope' <- typecheck tope topeT
+    checkTopeAgainstContext "recOR branch guard" tope'
+    localTope tope' $ do
+      rterm' <- typecheck rterm expected
+      return (tope', rterm')
+  sequence_ [ checkCoherence l r | l:rs'' <- tails rs', r <- rs'' ]
+  contextEntailsUnion (map fst rs')
+  return (recOrT expected rs')
+
 typecheck :: Eq var => Term var -> TermT var -> TypeCheck var (TermT var)
 typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
   -- A hole is checked against a known type (this is checking position): in
@@ -3714,17 +3731,24 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
       _ <- infer term
       return recBottomT
 
-    TypeRestrictedT _ty ty' rs -> do
-      term' <- typecheck term ty'
-      -- NOTE: restriction faces need not be contained in the local tope context.
-      -- Each face is checked only on its overlap with the context below, so an
-      -- overhanging face is harmless (we only hint); a face disjoint from the context
-      -- is vacuous, however, and is reported as an error by checkTopeAgainstContext.
-      forM_ rs $ \(tope, rterm) -> do
-        checkTopeAgainstContext "restriction face" tope
-        localTope tope $
-          unifyTerms rterm term'
-      return term'    -- FIXME: correct?
+    tr@(TypeRestrictedT _ty ty' rs) -> case term of
+      -- A recOR against a restricted type: push the restriction into each branch
+      -- instead of stripping it first, so a branch hole reports the boundary
+      -- faces it must satisfy under its guard tope, rather than the bare
+      -- underlying type. Concrete branches still meet the faces, which are
+      -- checked on each branch's overlap with them (see the general case below).
+      RecOr branches -> checkRecOrAgainst tr branches
+      _ -> do
+        term' <- typecheck term ty'
+        -- NOTE: restriction faces need not be contained in the local tope context.
+        -- Each face is checked only on its overlap with the context below, so an
+        -- overhanging face is harmless (we only hint); a face disjoint from the context
+        -- is vacuous, however, and is reported as an error by checkTopeAgainstContext.
+        forM_ rs $ \(tope, rterm) -> do
+          checkTopeAgainstContext "restriction face" tope
+          localTope tope $
+            unifyTerms rterm term'
+        return term'    -- FIXME: correct?
 
     ty' -> case term of
       Lambda orig mparam body ->
@@ -3834,16 +3858,7 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
       -- expected type and recorded, rather than hitting TypeErrorCannotInferHole
       -- via the inference rule. The branch-guard, coherence, and coverage
       -- obligations mirror the inference rule (see the RecOr case of 'infer').
-      RecOr rs -> do
-        rs' <- forM rs $ \(tope, rterm) -> do
-          tope' <- typecheck tope topeT
-          checkTopeAgainstContext "recOR branch guard" tope'
-          localTope tope' $ do
-            rterm' <- typecheck rterm ty'
-            return (tope', rterm')
-        sequence_ [ checkCoherence l r | l:rs'' <- tails rs', r <- rs'' ]
-        contextEntailsUnion (map fst rs')
-        return (recOrT ty' rs')
+      RecOr rs -> checkRecOrAgainst ty' rs
       -- A neutral term is inferred, then its type unified with the expected
       -- one. In lenient (hole-checking) mode a term that still carries an
       -- unfilled hole is a work in progress, so a failure of that final

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -104,6 +104,23 @@ spec = do
           map show (holeTopes h2) `shouldContain` ["s ≤ t"]
         hs  -> expectationFailure ("expected exactly two holes, got " <> show (length hs))
 
+    -- When the recOR is checked against an /extension type/, each branch hole
+    -- reports the boundary it must meet under its tope (the restriction is
+    -- pushed into the branches), rather than the bare underlying type. So the
+    -- player sees, e.g., that the value must equal `f t` on `s ≡ 0₂` and `a` on
+    -- `s ≡ 1₂`, not just `A`.
+    it "shows the extension-type boundary in a recOR branch hole" $ do
+      case holesOf "#lang rzk-1\n#def square (A : U) (a : A) (f : (t : 2) → A)\n  : (t : 2) → (s : 2) → A [ s ≡ 0₂ ↦ f t , s ≡ 1₂ ↦ a ]\n  := \\ t s → recOR ( s ≤ t ↦ ? , t ≤ s ↦ ? )\n" of
+        [h1, h2] -> do
+          let goal1 = show (holeGoal h1)
+          ("A [" `isInfixOf` goal1) `shouldBe` True   -- a restricted type, not bare A
+          ("↦ f t" `isInfixOf` goal1) `shouldBe` True -- the s ≡ 0₂ face is shown
+          ("↦ a" `isInfixOf` goal1) `shouldBe` True   -- the s ≡ 1₂ face is shown
+          map show (holeTopes h1) `shouldContain` ["s ≤ t"]
+          show (holeGoal h2) `shouldBe` goal1          -- both branches carry the same boundary
+          map show (holeTopes h2) `shouldContain` ["t ≤ s"]
+        hs  -> expectationFailure ("expected exactly two holes, got " <> show (length hs))
+
     -- A hole nested inside a larger term (`f ?`) checked against an
     -- extension-type boundary: the boundary face is unified against `f ?`, which
     -- must be deferred rather than reported as a mismatch.


### PR DESCRIPTION
A hole inside a `recOR` branch, where the `recOR` is checked against an extension type `A [ φ ↦ u ]`, reported its goal as the bare underlying type `A`.

The cause is the checking rule for a restricted type. It checked the term against the stripped underlying type and verified the restriction faces separately, so the `recOR`, and the holes in its branches, never saw the restriction. We now push the restriction into the branches: a `recOR` checked against `A [ φ ↦ u ]` has each branch checked against the same restricted type under its guard tope.

For example, the branch holes of

```rzk
#def square (A : U) (a : A) (f : (t : 2) → A)
  : (t : 2) → (s : 2) → A [ s ≡ 0₂ ↦ f t , s ≡ 1₂ ↦ a ]
  := \ t s → recOR ( s ≤ t ↦ ? , t ≤ s ↦ ? )
```

now report the goal `A [ s ≡ 0₂ ↦ f t , s ≡ 1₂ ↦ a ]` (under the branch tope `s ≤ t` or `t ≤ s`) rather than bare `A`.