### PR TITLE
Render: hide the proof term and draw a hole's goal cell

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -274,12 +274,21 @@ setOption "render" = \case
   "none"  -> localRenderBackend Nothing
   _ -> const $
     issueTypeError $ TypeErrorOther "unknown render backend (use \"svg\", \"latex\", or \"none\")"
+-- | Render the shape only, hiding the proof term (drop the @\<title\>@
+-- everywhere and blank interior labels), so a worked term can be shown as the
+-- cell it builds without giving the term away (see 'renderHideTerm').
+setOption "render-hide-term" = \case
+  "yes" -> localHideTerm True
+  "no"  -> localHideTerm False
+  _ -> const $
+    issueTypeError $ TypeErrorOther "unknown value for \"render-hide-term\" (use \"yes\" or \"no\")"
 setOption optionName = const $ const $
   issueTypeError $ TypeErrorOther ("unknown option " <> show optionName)
 
 unsetOption :: String -> TypeCheck var a -> TypeCheck var a
 unsetOption "verbosity" = localVerbosity (verbosity emptyContext)
 unsetOption "render" = localRenderBackend (renderBackend emptyContext)
+unsetOption "render-hide-term" = localHideTerm (renderHideTerm emptyContext)
 unsetOption optionName = const $
   issueTypeError $ TypeErrorOther ("unknown option " <> show optionName)
 
@@ -1021,6 +1030,10 @@ recordHoleShape mname goalTy mshape = do
   -- the introduction forms for the goal itself (constituents left as holes); the
   -- Π binder is freshened against 'inScopeNames' so it does not shadow.
   introductions <- censor (const []) (allIntroductionsOf goalTy inScopeNames)
+  -- the goal cell: an SVG of the shape the hole must inhabit (an arrow, triangle
+  -- or square), drawn from an abstract inhabitant with the proof term hidden.
+  -- 'Nothing' when the goal is not a renderable shape.
+  diagram <- censor (const []) (renderGoalCellSVG goal')
   lift $ tell
     [ HoleInfo
         { holeName      = mname
@@ -1031,6 +1044,7 @@ recordHoleShape mname goalTy mshape = do
         , holeTopes     = map render topes
         , holeCandidates = map render candidates
         , holeIntroductions = map render introductions
+        , holeDiagram  = diagram
         , holeLocation  = loc
         } ]
 
@@ -1168,6 +1182,14 @@ localVerbosity v = local $ \Context{..} -> Context { verbosity = v, .. }
 localRenderBackend :: Maybe RenderBackend -> TypeCheck var a -> TypeCheck var a
 localRenderBackend v = local $ \Context{..} -> Context { renderBackend = v, .. }
 
+-- | Run the enclosed action with the 'renderHideTerm' policy set.
+localHideTerm :: Bool -> TypeCheck var a -> TypeCheck var a
+localHideTerm v = local $ \ctx -> ctx { renderHideTerm = v }
+
+-- | Render the enclosed action with the proof term hidden (see 'renderHideTerm').
+hidingTerm :: TypeCheck var a -> TypeCheck var a
+hidingTerm = localHideTerm True
+
 data Covariance
   = Covariant     -- ^ Positive position.
   | Contravariant -- ^ Negative position.
@@ -1246,6 +1268,12 @@ data Context var = Context
   , verbosity              :: Verbosity
   , covariance             :: Covariance
   , renderBackend          :: Maybe RenderBackend
+    -- | When rendering a diagram, hide the proof term: drop the @\<title\>@
+    -- (which carries the full term) from every cell and blank the visible label
+    -- of proof-coloured (interior) cells, keeping the given boundary labels. So
+    -- a worked term or an abstract inhabitant of a goal type is shown as the
+    -- shape with its given edges, not the term that fills it.
+  , renderHideTerm     :: Bool
   , holesAreErrors         :: Bool
     -- ^ When 'True' (the default), an unfilled hole is reported as a
     -- 'TypeErrorUnsolvedHole'; finished work (and CI) must have no holes. The
@@ -1303,6 +1331,7 @@ emptyContext = Context
   , verbosity = Normal
   , covariance = Covariant
   , renderBackend = Nothing
+  , renderHideTerm = False
   , holesAreErrors = True
   , deferHoleMismatches = True
   }
@@ -1714,6 +1743,11 @@ data HoleInfo = HoleInfo
     -- ^ introduction forms for the goal type, built from its head constructor
     -- with the constituents left as holes (see 'allIntroductionsOf'). Already
     -- rendered, like the other fields.
+  , holeDiagram   :: Maybe String
+    -- ^ an SVG of the goal cell, when the goal is a renderable shape (an arrow,
+    -- triangle, or square up to dimension 3): the shape with its given boundary
+    -- edges, drawn from an abstract inhabitant of the goal type with the
+    -- proof term hidden (see 'renderHideTerm'). 'Nothing' for a non-shape goal.
   , holeLocation  :: Maybe LocationInfo
   } deriving (Eq, Show)
 
@@ -4404,6 +4438,17 @@ limitLength n s
   | length s > n = take (n - 1) s <> "…"
   | otherwise    = s
 
+-- | Apply the 'renderHideTerm' policy to a cell's render data: drop the
+-- @\<title\>@ (the full term) from every cell, and blank the visible label of a
+-- proof-coloured (interior) cell. Boundary cells (coloured otherwise) keep
+-- their given labels. A no-op when not hiding.
+hideTermData :: Bool -> String -> RenderObjectData -> RenderObjectData
+hideTermData False _ d = d
+hideTermData True  mainColor d
+  | renderObjectDataColor d == mainColor =
+      d { renderObjectDataLabel = "", renderObjectDataFullLabel = "" }
+  | otherwise = d { renderObjectDataFullLabel = "" }
+
 renderObjectsFor
   :: Eq var
   => String
@@ -4433,7 +4478,8 @@ renderObjectsFor mainColor dim t term = fmap catMaybes $ do
                 | null (nub (freeVars (untyped arg)) \\ nub (freeVars (untyped t))) ->
                     ppTermInContext (Pure z)
               _ -> ppTermInContext term'
-          return $ Just (shapeId, RenderObjectData
+          hide <- asks renderHideTerm
+          return $ Just (shapeId, hideTermData hide mainColor RenderObjectData
             { renderObjectDataLabel = label
             , renderObjectDataFullLabel = label
             , renderObjectDataColor =
@@ -4498,7 +4544,8 @@ renderObjectsInSubShapeFor mainColor dim sub super retType f x = fmap catMaybes 
                 | null (nub (freeVars (untyped arg)) \\ [super]) -> return "purple"
               _ -> return mainColor
           False -> return "gray"
-        return $ Just (shapeId, RenderObjectData
+        hide <- asks renderHideTerm
+        return $ Just (shapeId, hideTermData hide mainColor RenderObjectData
           { renderObjectDataLabel = label
           , renderObjectDataFullLabel = label
           , renderObjectDataColor = color
@@ -4601,6 +4648,15 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
 
 renderTermSVG :: Eq var => TermT var -> TypeCheck var (Maybe String)
 renderTermSVG = renderTermSVGFor "red" 0 (Nothing, [])  -- use red for terms by default
+
+-- | Render the goal /cell/ for a (shape) type: introduce an abstract inhabitant
+-- and render it with the proof term hidden. Under a boundary tope an abstract
+-- inhabitant of an extension type reduces to the prescribed face value, so the
+-- cell shows its given edges with a blank interior — the shape to inhabit, not
+-- an answer. 'Nothing' for a non-shape type (a 0-cell or a non-cube goal).
+renderGoalCellSVG :: Eq var => TermT var -> TypeCheck var (Maybe String)
+renderGoalCellSVG ty =
+  hidingTerm $ enterScope (BinderVar (Just "_")) ty $ renderTermSVG' (Pure Z)
 
 renderTermSVG' :: Eq var => TermT var -> TypeCheck var (Maybe String)
 renderTermSVG' t = whnfT t >>= \t' -> typeOf t >>= \case

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -411,3 +411,28 @@ spec = do
     it "still reports an unused 'uses' variable with no hole in the declaration" $
       errTagsOf (usesSection "#define f uses (x) : U\n  := A")
         `shouldContain` ["TypeErrorUnusedUsedVariables"]
+
+  -- The goal cell: when the goal is a renderable shape, the hole carries an SVG
+  -- of that shape, drawn from an abstract inhabitant with the proof term hidden
+  -- (see 'renderHideTerm'). So the picture shows the given boundary edges with a
+  -- blank interior, never the term that would fill it.
+  describe "holeDiagram (goal-cell SVG)" $ do
+    it "renders a shape goal as a labelled, term-free SVG" $ do
+      let src = "#lang rzk-1\n\
+                \#def sq (A : U) (a : A) : U\n\
+                \  := ((t , s) : 2 * 2) -> A [ t === 0_2 |-> a , t === 1_2 |-> a , s === 0_2 |-> a , s === 1_2 |-> a ]\n\
+                \#def fill (A : U) (a : A) : sq A a := ?\n"
+      case holesOf src of
+        [h] -> case holeDiagram h of
+          Just svg -> do
+            ("<svg" `isInfixOf` svg)            `shouldBe` True
+            ("<path" `isInfixOf` svg)           `shouldBe` True  -- a 2-cell (square), not just an arrow
+            (">a</text>" `isInfixOf` svg)       `shouldBe` True  -- the given boundary edge `a`
+            ("<title></title>" `isInfixOf` svg) `shouldBe` True  -- titles blanked: no proof term
+          Nothing -> expectationFailure "expected a goal-cell diagram for a shape goal"
+        hs -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    it "has no diagram for a non-shape goal" $
+      case holesOf "#lang rzk-1\n#define f : (A : U) -> A -> A\n  := \\ A a -> ?\n" of
+        [h] -> holeDiagram h `shouldBe` Nothing
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))


### PR DESCRIPTION
Add a term-hiding render mode. The context flag `renderHideTerm` is set by `#set-option "render-hide-term" = "yes"` (or the internal `hidingTerm` combinator). When it is on, the `<title>` is dropped from every cell and the visible label of a proof-coloured (interior) cell is blanked, while the given boundary labels are kept. So a worked term is shown as the cell it builds with its given edges, not the term that fills it.

Also add `holeDiagram` on `HoleInfo`. When a hole's goal is a renderable shape, the hole now carries an SVG of the goal cell, drawn from an abstract inhabitant of the goal type with the proof term hidden. The key point is that under a boundary tope an abstract inhabitant of an extension type reduces to the prescribed face value, so the cell shows its given edges (for example `f` and `a`) with a blank interior. It is therefore spoiler-free by construction: there is no term, only the shape to inhabit. The field is `Nothing` for a non-shape goal.

## Example

A hole whose goal is a `hom2` (a commutative triangle with given edges `f`, `g`, `h`):

```rzk
#def hom2 (A : U) (x y z : A) (f : hom A x y) (g : hom A y z) (h : hom A x z) : U
  := ((t , s) : Δ²) → A [ s ≡ 0₂ ↦ f t , t ≡ 1₂ ↦ g s , s ≡ t ↦ h s ]
#def fill (A : U) (x y z : A) (f : hom A x y) (g : hom A y z) (h : hom A x z)
  : hom2 A x y z f g h
  := ?
```

Its `holeDiagram` is the triangle below: the three edges are labelled with the given `f`, `g`, `h`, the vertices with `x`, `y`, `z`, the interior is blank, and every `<title>` is empty (so hovering reveals nothing). Coordinates are rounded here for readability.

<img width="215" height="172" alt="Снимок экрана — 2026-06-22 в 22 36 23" src="https://github.com/user-attachments/assets/2783bcdc-0ed5-494e-ad64-8733a2477034" />