### PR TITLE
Fix recOR tope panic

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -79,6 +79,7 @@ extra-source-files:
     test/typecheck/cases/ill-rec-or-overlap-incoherent.rzk
     test/typecheck/cases/ill-recbot-term-not-function.rzk
     test/typecheck/cases/ill-recbot-term-undefined.rzk
+    test/typecheck/cases/ill-recor-as-tope.rzk
     test/typecheck/cases/ill-recor-coverage-required.rzk
     test/typecheck/cases/ill-recor-guard-disjoint.rzk
     test/typecheck/cases/ill-render-latex-define.rzk
@@ -177,6 +178,7 @@ extra-source-files:
     test/typecheck/cases/ill-rec-or-overlap-incoherent.expect.yaml
     test/typecheck/cases/ill-recbot-term-not-function.expect.yaml
     test/typecheck/cases/ill-recbot-term-undefined.expect.yaml
+    test/typecheck/cases/ill-recor-as-tope.expect.yaml
     test/typecheck/cases/ill-recor-coverage-required.expect.yaml
     test/typecheck/cases/ill-recor-guard-disjoint.expect.yaml
     test/typecheck/cases/ill-render-latex-define.expect.yaml

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -683,6 +683,14 @@ isCubeType = \case
   UniverseCubeT{} -> True
   _               -> False
 
+-- | Is a (WHNF) goal type in the cube or tope layer, so a hole of this type is a
+-- cube point or a tope rather than a term? Used to suppress type-layer-specific
+-- hole candidates (@recOR@, @recBOT@), which cannot inhabit a cube or a tope.
+isCubeOrTopeType :: TermT var -> Bool
+isCubeOrTopeType t = isCubeType t || case t of
+  UniverseTopeT{} -> True
+  _               -> False
+
 -- | Is this term a hole? Holes only exist in lenient mode (see 'allowHoles');
 -- they are opaque placeholders standing for a term of the expected type.
 isHoleT :: TermT var -> Bool
@@ -1001,9 +1009,12 @@ recordHoleShape mname goalTy mshape = do
   candidates <- censor (const []) $ do
     elims  <- concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals
     -- context-driven moves (independent of the goal's head and the hypotheses):
-    -- ex falso in a contradictory context, and tope case-splits.
-    recbot <- recBottomCandidates
-    recor  <- recOrCandidates goalTy
+    -- ex falso in a contradictory context, and tope case-splits. recOR and recBOT
+    -- are term-level eliminators, so they are offered only for a term goal — not
+    -- when the hole is a cube point or a tope, where they cannot appear.
+    let termLayer = not (isCubeOrTopeType goal')
+    recbot <- if termLayer then recBottomCandidates    else pure []
+    recor  <- if termLayer then recOrCandidates goalTy else pure []
     pure (elims <> recbot <> recor)
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -2800,8 +2800,11 @@ nfTope tt = performing (ActionNF tt) $ fmap termIsNF $ case tt of
   IdJT{} -> panicImpossible "idJ eliminator in the tope layer"
   TypeRestrictedT{} -> panicImpossible "extension types in the tope layer"
 
-  RecOrT{} -> panicImpossible "recOR in the tope layer"
-  RecBottomT{} -> panicImpossible "recBOT in the tope layer"
+  -- A recOR/recBOT is a term-level eliminator, never a tope. It should have
+  -- been rejected before reaching here (see the RecOr case of 'typecheck'); as
+  -- a safety net for any other path, report a type error rather than panicking.
+  RecOrT{} -> issueTypeError $ TypeErrorOther "a recOR cannot appear in the tope layer"
+  RecBottomT{} -> issueTypeError $ TypeErrorOther "a recBOT cannot appear in the tope layer"
 
 -- | Compute a typed term to its NF.
 --
@@ -3892,7 +3895,13 @@ typecheck term ty = performing (ActionTypeCheck term ty) $ case term of
       -- expected type and recorded, rather than hitting TypeErrorCannotInferHole
       -- via the inference rule. The branch-guard, coherence, and coverage
       -- obligations mirror the inference rule (see the RecOr case of 'infer').
-      RecOr rs -> checkRecOrAgainst ty' rs
+      -- A recOR is a term-level eliminator, not a tope; rejecting it when it is
+      -- checked against the tope universe (e.g. in another recOR's branch guard)
+      -- keeps it out of the tope layer, where it would otherwise hit a panic.
+      RecOr rs -> case ty' of
+        UniverseTopeT{} -> issueTypeError $
+          TypeErrorOther "a recOR cannot be used as a tope"
+        _ -> checkRecOrAgainst ty' rs
       -- A neutral term is inferred, then its type unified with the expected
       -- one. In lenient (hole-checking) mode a term that still carries an
       -- unfilled hole is a work in progress, so a failure of that final

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -292,6 +292,21 @@ spec = do
         hs | (h:_) <- reverse hs -> cands h `shouldContain` ["recOR (? ↦ ?, ? ↦ ?)"]
         _ -> expectationFailure "expected at least one hole"
 
+    -- recOR and recBOT are term-level eliminators, so a hole whose goal is a cube
+    -- point or a tope is never offered them — even in a setting (a cube variable
+    -- in scope) that does offer a recOR split for a term goal.
+    let recCands = filter (\s -> isInfixOf "recOR" s || isInfixOf "recBOT" s) . cands
+    it "does not offer recOR/recBOT for a cube goal" $
+      -- `?` is a cube point (goal `2`) fed to a shape function, with a cube
+      -- variable `s` in scope (which would offer a recOR split for a term goal).
+      case holesOf "#lang rzk-1\n#def c (A : U) (s : 2) (g : (t : 2) -> A) : A := g ?\n" of
+        [h] -> recCands h `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+    it "does not offer recOR/recBOT for a tope goal" $
+      case holesOf "#lang rzk-1\n#def p (A : U) (t : 2) : TOPE := ?\n" of
+        [h] -> recCands h `shouldBe` []
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- An ordinary, tope-free goal offers no recOR split.
     it "offers no recOR split for a tope-free goal" $ do
       case holesOf "#lang rzk-1\n#def plain (A : U) (a : A) : A := ?\n" of

--- a/rzk/test/typecheck/cases/ill-recor-as-tope.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-recor-as-tope.expect.yaml
@@ -1,0 +1,6 @@
+status: error
+error_tag: TypeErrorOther
+message_contains:
+  - "recOR cannot be used as a tope"
+regression_for:
+  - recOR-in-tope-layer-panic

--- a/rzk/test/typecheck/cases/ill-recor-as-tope.rzk
+++ b/rzk/test/typecheck/cases/ill-recor-as-tope.rzk
@@ -1,0 +1,8 @@
+#lang rzk-1
+
+-- A recOR in another recOR's branch-guard (tope) position must be rejected as a
+-- type error, not crash the tope-layer normaliser. Regression for the reported
+-- "PANIC! Impossible happened (recOR in the tope layer)" (a recOR reaching
+-- nfTope), surfaced by the Yoneda game.
+#def bad (A : U) (a : A) : (2 × 2) → A
+  := \ (t , s) → recOR ( recOR ( s ≤ t ↦ s ≤ t , t ≤ s ↦ t ≤ s ) ↦ a , ⊤ ↦ a )


### PR DESCRIPTION
A `recOR` in another `recOR`'s branch-guard (tope) position drove the tope-layer normaliser into a `recOR` it cannot handle, raising `PANIC! Impossible happened (recOR in the tope layer)`:

```rzk
:= \ (t , s) → recOR ( recOR ( ? ↦ ? , ? ↦ ? ) ↦ ? , ? ↦ ? )
```

A `recOR` (and `recBOT`) is a term-level eliminator, never a tope. We now reject a `recOR` checked against the tope universe with a type error, and `nfTope` reports a type error for a `recOR`/`recBOT` rather than calling `panicImpossible`, so such a term never panics.

We also stop the hole inventory from offering a `recOR`/`recBOT` candidate when the goal is a cube point or a tope, since neither can be inhabited by one.