### PR TITLE
TypeCheck: key uses checks off the term, not its WHNF

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -119,6 +119,8 @@ extra-source-files:
     test/typecheck/cases/multimodule-first-error/lib.rzk
     test/typecheck/cases/multimodule-two-ok/lib.rzk
     test/typecheck/cases/multimodule-two-ok/user.rzk
+    test/typecheck/cases/uses-whnf-discarded.rzk
+    test/typecheck/cases/uses-whnf-masked-transitive.rzk
     test/typecheck/cases/happy-check.expect.yaml
     test/typecheck/cases/happy-flip-unflip.expect.yaml
     test/typecheck/cases/happy-interval-basics.expect.yaml
@@ -217,6 +219,8 @@ extra-source-files:
     test/typecheck/cases/literate-fence/expect.yaml
     test/typecheck/cases/multimodule-first-error/expect.yaml
     test/typecheck/cases/multimodule-two-ok/expect.yaml
+    test/typecheck/cases/uses-whnf-discarded.expect.yaml
+    test/typecheck/cases/uses-whnf-masked-transitive.expect.yaml
     test/typecheck/cases/literate-fence/doc.rzk.md
 extra-doc-files:
     README.md

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -167,8 +167,14 @@ typecheckModule path (Rzk.Module _moduleLoc _lang commands) =
         withCommand command $ do
           mapM_ checkDefinedVar (varIdentAt path <$> vars)
           paramDecls <- concat <$> mapM paramToParamDecl params
-          ty' <- typecheck (toTerm' (addParamDecls paramDecls ty)) universeT >>= whnfT
-          term' <- typecheck (toTerm' (addParams params term)) ty' >>= whnfT
+          -- Store the elaborated type and term unreduced, but memoise their
+          -- WHNF on the top node (see 'memoizeWHNF'). Reducing in place would
+          -- discard or expose a variable occurrence, so the section
+          -- unused/implicit-assumption checks (run over the stored type and
+          -- value) would disagree with the term the user wrote; keeping the
+          -- WHNF cached preserves the original one-shot reduction.
+          ty' <- memoizeWHNF =<< typecheck (toTerm' (addParamDecls paramDecls ty)) universeT
+          term' <- memoizeWHNF =<< typecheck (toTerm' (addParams params term)) ty'
           loc <- asks location
           let decl = Decl (varIdentAt path name) ty' (Just term') False (varIdentAt path <$> vars) loc
           fmap (first (decl :)) $
@@ -188,7 +194,7 @@ typecheckModule path (Rzk.Module _moduleLoc _lang commands) =
         withCommand command $ do
           mapM_ checkDefinedVar (varIdentAt path <$> vars)
           paramDecls <- concat <$> mapM paramToParamDecl params
-          ty' <- typecheck (toTerm' (addParamDecls paramDecls ty)) universeT >>= whnfT
+          ty' <- memoizeWHNF =<< typecheck (toTerm' (addParamDecls paramDecls ty)) universeT
           loc <- asks location
           let decl = Decl (varIdentAt path name) ty' Nothing False (varIdentAt path <$> vars) loc
           fmap (first (decl :)) $
@@ -1699,8 +1705,8 @@ localDeclsPrepared (decl : decls) = localDeclPrepared decl . localDeclsPrepared 
 
 localDecl :: Decl VarIdent -> TypeCheck VarIdent a -> TypeCheck VarIdent a
 localDecl (Decl x ty term isAssumption vars loc) tc = do
-  ty' <- whnfT ty
-  term' <- traverse whnfT term
+  ty' <- memoizeWHNF ty
+  term' <- traverse memoizeWHNF term
   localDeclPrepared (Decl x ty' term' isAssumption vars loc) tc
 
 localDeclPrepared :: Decl VarIdent -> TypeCheck VarIdent a -> TypeCheck VarIdent a
@@ -2424,6 +2430,19 @@ tryRestriction = \case
             False -> go rs'
     go rs
   _ -> pure Nothing
+
+-- | Memoise a term's WHNF on its top node without reducing the term itself.
+--
+-- The returned term has the same (unreduced) structure, so free-variable and
+-- @uses@ detection see exactly what the user wrote, while a later 'whnfT' is
+-- O(1) via the cached 'infoWHNF'. Used when storing a definition's elaborated
+-- type and value, where an in-place reduction could otherwise discard or
+-- expose a variable occurrence.
+memoizeWHNF :: Eq var => TermT var -> TypeCheck var (TermT var)
+memoizeWHNF t@Pure{} = pure t
+memoizeWHNF t@(Free (AnnF info f)) = do
+  w <- whnfT t
+  pure (Free (AnnF info { infoWHNF = Just w } f))
 
 -- | Compute a typed term to its WHNF.
 --

--- a/rzk/test/typecheck/cases/uses-whnf-discarded.expect.yaml
+++ b/rzk/test/typecheck/cases/uses-whnf-discarded.expect.yaml
@@ -1,0 +1,3 @@
+status: ok
+regression_for:
+  - uses-checks-key-off-actual-term-not-whnf

--- a/rzk/test/typecheck/cases/uses-whnf-discarded.rzk
+++ b/rzk/test/typecheck/cases/uses-whnf-discarded.rzk
@@ -1,0 +1,18 @@
+#lang rzk-1
+
+-- An assumption whose only occurrence sits in a redex that weak head
+-- normalisation discards (here the argument to a constant function) is still
+-- a genuine use: the section unused-variable check must see the term the user
+-- wrote, not its WHNF. Before the fix, `b` was reported as an unused variable.
+
+#section sec-whnf-discarded
+
+#variable A : U
+#variable a : A
+#variable b : A
+
+#define pick
+  : A
+  := (\ (_ : A) → a) b
+
+#end sec-whnf-discarded

--- a/rzk/test/typecheck/cases/uses-whnf-masked-transitive.expect.yaml
+++ b/rzk/test/typecheck/cases/uses-whnf-masked-transitive.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorImplicitAssumption
+message_contains:
+  - "implicit assumption"
+  - "used in definition of"
+regression_for:
+  - uses-checks-key-off-actual-term-not-whnf

--- a/rzk/test/typecheck/cases/uses-whnf-masked-transitive.rzk
+++ b/rzk/test/typecheck/cases/uses-whnf-masked-transitive.rzk
@@ -1,0 +1,22 @@
+#lang rzk-1
+
+-- A transitive dependency on a section assumption that weak head normalisation
+-- would otherwise hide. `d2`'s value `first (unit , d1)` mentions `d1`, whose
+-- type `a =_{A} a` depends on the assumption `a`; reducing the value to `unit`
+-- discards `d1` and so masks the dependency. Keying the use check off the term
+-- the user wrote catches it: `d2` implicitly relies on `a` and must say so.
+
+#section sec-whnf-masked
+
+#variable A : U
+#variable a : A
+
+#define d1
+  : a =_{A} a
+  := refl
+
+#define d2
+  : Unit
+  := first (unit , d1)
+
+#end sec-whnf-masked


### PR DESCRIPTION
When closing a section, rzk decides which assumptions a definition uses from the stored type and value, which until now were kept in weak head normal form. Reduction can drop or expose a variable, so the verdict could disagree with the written term. The following section was rejected, because `(\ (_ : A) -> a) b` reduces to `a` and the only occurrence of `b` was lost:

```rzk
#lang rzk-1

#section sec

#variable A : U
#variable a : A
#variable b : A

#define pick
  : A
  := (\ (_ : A) → a) b   -- error (before this PR): unused variable b

#end sec
```

Conversely, a value that reduces away a sibling definition could hide a genuine transitive dependency on an assumption, leaving it undeclared and uncaught.

We now store the elaborated type and value unreduced, memoising their WHNF on the top node so a later `whnfT` stays cheap. Two regression fixtures cover both directions. The change surfaces a few genuine `uses (...)` annotations that were missing in sHoTT, added in a small companion change there.