### PR TITLE
Holes: offer allow-listed lemmas as candidates

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -100,8 +100,21 @@ typecheckModulesWithHoles
   :: [(FilePath, Rzk.Module)]
   -> Either (TypeErrorInScopedContext VarIdent)
             ([(FilePath, [Decl'])], [TypeErrorInScopedContext VarIdent], [HoleInfo])
-typecheckModulesWithHoles modules =
-  flatten <$> defaultTypeCheckWithHoles (typecheckModulesWithLocation' modules)
+typecheckModulesWithHoles = typecheckModulesWithHolesAndLemmas []
+
+-- | Like 'typecheckModulesWithHoles', but additionally offers the given named
+-- top-level definitions as hole candidates (each applied to holes when its type
+-- fits the goal). The game passes a level's allow-list of relevant lemmas so
+-- they surface as moves; an empty list reproduces 'typecheckModulesWithHoles'.
+typecheckModulesWithHolesAndLemmas
+  :: [VarIdent]
+  -> [(FilePath, Rzk.Module)]
+  -> Either (TypeErrorInScopedContext VarIdent)
+            ([(FilePath, [Decl'])], [TypeErrorInScopedContext VarIdent], [HoleInfo])
+typecheckModulesWithHolesAndLemmas lemmas modules =
+  flatten <$> defaultTypeCheckWithHoles'
+    (withHintLemmas lemmas (allowHoles emptyContext))
+    (typecheckModulesWithLocation' modules)
   where
     flatten ((decls, errs), holes) = (decls, errs, holes)
 
@@ -998,16 +1011,21 @@ recordHoleShape
 recordHoleShape mname goalTy mshape = do
   goal'     <- whnfT goalTy
   locals    <- asks (filter (not . varIsTopLevel . snd) . varInfos)
+  -- named top-level lemmas the caller allow-listed for hints (see 'hintLemmas').
+  -- They feed the candidate-elimination loop only — not the local context shown
+  -- to the user, since they are global definitions, not local hypotheses.
+  lemmas    <- asks hintLemmas
+  lemmaVars <- asks (filter (\(_, i) -> varIsTopLevel i && maybe False (`elem` lemmas) (binderName (varOrig i))) . varInfos)
   cubeFlags <- mapM (fmap isCubeType . whnfT . varType . snd) locals
   topes     <- asks (filter (/= topeTopT) . availableTopes)
   origs     <- asks varOrigs
   binders   <- asks varBinders
   loc       <- asks location
-  -- for each local hypothesis, the elimination spines that land in the goal
-  -- (arguments left as holes). Probing must not leak holes into the recorded
-  -- output, hence 'censor'.
+  -- for each local hypothesis (and allow-listed lemma), the elimination spines
+  -- that land in the goal (arguments left as holes). Probing must not leak holes
+  -- into the recorded output, hence 'censor'.
   candidates <- censor (const []) $ do
-    elims  <- concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) locals
+    elims  <- concat <$> mapM (\(v, _) -> allEliminationsInto goalTy (Pure v)) (locals ++ lemmaVars)
     -- context-driven moves (independent of the goal's head and the hypotheses):
     -- ex falso in a contradictory context, and tope case-splits. recOR and recBOT
     -- are term-level eliminators, so they are offered only for a term goal — not
@@ -1018,8 +1036,8 @@ recordHoleShape mname goalTy mshape = do
     pure (elims <> recbot <> recor)
   let shapeTope     = snd <$> mshape
       shapeTopeVars = maybe [] (\t -> [ v | S v <- foldr (:) [] t ]) shapeTope
-  varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) locals ++ topes)
-  let mapping  = zip (nub (varsList ++ shapeTopeVars ++ map fst locals)) defaultVarIdents
+  varsList  <- concat <$> mapM freeVarsT_ (goal' : map (varType . snd) (locals ++ lemmaVars) ++ topes)
+  let mapping  = zip (nub (varsList ++ shapeTopeVars ++ map fst (locals ++ lemmaVars))) defaultVarIdents
       name v   = fromMaybe "_" (join (lookup v origs) <|> lookup v mapping)
       fbs      = freshBinders name mapping binders
       render t = restorePatternVars [ (name v, b) | (v, b) <- fbs ]
@@ -1297,6 +1315,11 @@ data Context var = Context
     -- containing a hole is accepted, for an in-progress sketch — while 'False'
     -- keeps such a mismatch an error, so only a hole standing in a matching
     -- structure is accepted ('structuralHoleUnify').
+  , hintLemmas             :: [VarIdent]
+    -- ^ Named top-level definitions a hole's candidate list may draw on, beyond
+    -- the local hypotheses (see 'withHintLemmas'). A caller (the game) supplies
+    -- a small curated allow-list per level; each listed lemma whose type fits
+    -- the goal is then offered, applied to holes (e.g. @concat ? ? ?@).
   } deriving (Functor, Foldable)
 
 addVarInCurrentScope :: var -> VarInfo var -> Context var -> Context var
@@ -1345,6 +1368,7 @@ emptyContext = Context
   , renderHideTerm = False
   , holesAreErrors = True
   , deferHoleMismatches = True
+  , hintLemmas = []
   }
 
 -- | Switch to lenient hole mode: record each hole's goal and context instead
@@ -1352,6 +1376,13 @@ emptyContext = Context
 -- the @--allow-holes@ CLI mode; the default (strict) mode rejects holes.
 allowHoles :: Context var -> Context var
 allowHoles ctx = ctx { holesAreErrors = False }
+
+-- | Allow a hole's candidate list to draw on the given named top-level
+-- definitions (in addition to the local hypotheses). The game supplies the
+-- per-level allow-list; 'recordHoleShape' then offers each listed lemma whose
+-- type fits the goal, applied to holes. See 'hintLemmas'.
+withHintLemmas :: [VarIdent] -> Context var -> Context var
+withHintLemmas lemmas ctx = ctx { hintLemmas = lemmas }
 
 -- | Within the given action, a hole unifies only as a leaf in an otherwise
 -- matching structure: a structural mismatch around a hole stays an error rather

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -14,6 +14,7 @@ import           System.Environment  (lookupEnv)
 import           System.FilePath     ((</>))
 
 import qualified Language.Rzk.Syntax as Rzk
+import           Language.Rzk.Free.Syntax (VarIdent)
 import           Rzk.Diagnostic      (typeErrorTagInScopedContext)
 import           Rzk.TypeCheck
 
@@ -26,6 +27,16 @@ holesOf src =
   case Rzk.parseModule src of
     Left err -> error ("parse error: " <> T.unpack err)
     Right m  -> case typecheckModulesWithHoles [("<test>", m)] of
+      Left err            -> error ("typecheck threw: " <> ppTypeErrorInScopedContext' BottomUp err)
+      Right (_, _, holes) -> holes
+
+-- | Like 'holesOf', but allow-lists the given named top-level lemmas for the
+-- candidate hints (see 'withHintLemmas'\/'typecheckModulesWithHolesAndLemmas').
+holesWithLemmas :: [VarIdent] -> T.Text -> [HoleInfo]
+holesWithLemmas lemmas src =
+  case Rzk.parseModule src of
+    Left err -> error ("parse error: " <> T.unpack err)
+    Right m  -> case typecheckModulesWithHolesAndLemmas lemmas [("<test>", m)] of
       Left err            -> error ("typecheck threw: " <> ppTypeErrorInScopedContext' BottomUp err)
       Right (_, _, holes) -> holes
 
@@ -319,6 +330,44 @@ spec = do
       case holesOf "#lang rzk-1\n#def bdry (A : U) (x y : A)\n  : ( (t : 2 | t ≡ 0₂ ∨ t ≡ 1₂) → A [ t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y ] )\n  := \\ t → ?\n" of
         [h] -> cands h `shouldContain` ["recOR (t ≡ 0₂ ↦ ?, t ≡ 1₂ ↦ ?)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+  describe "holeCandidates with allow-listed lemmas (withHintLemmas)" $ do
+    let cands = map show . holeCandidates
+        -- two top-level lemmas and an off-type one; the goal is the type @B@.
+        src = "#lang rzk-1\n#postulate B : U\n#postulate C : U\n"
+           <> "#postulate concat : B -> B -> B\n#postulate rev : B -> B\n"
+           <> "#postulate elsewhere : C\n#define goal : B := ?\n"
+        oneHole f hs = case hs of
+          [h] -> f h
+          _   -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A top-level definition is not a hole candidate unless it is allow-listed.
+    it "does not offer a top-level lemma that was not allow-listed" $
+      flip oneHole (holesWithLemmas [] src) $ \h ->
+        filter (isInfixOf "concat") (cands h) `shouldBe` []
+
+    -- An allow-listed lemma is offered, applied to holes (fit to the goal).
+    it "offers an allow-listed lemma applied to holes" $
+      flip oneHole (holesWithLemmas ["concat"] src) $ \h ->
+        cands h `shouldContain` ["concat ? ?"]
+
+    -- Each allow-listed lemma is offered independently.
+    it "offers several allow-listed lemmas" $
+      flip oneHole (holesWithLemmas ["concat", "rev"] src) $ \h -> do
+        cands h `shouldContain` ["concat ? ?"]
+        cands h `shouldContain` ["rev ?"]
+
+    -- The allow-list is still fit-filtered: a lemma whose type cannot reach the
+    -- goal (here @elsewhere : C@ against goal @B@) is not offered.
+    it "does not offer an allow-listed lemma whose type does not fit" $
+      flip oneHole (holesWithLemmas ["elsewhere"] src) $ \h ->
+        filter (isInfixOf "elsewhere") (cands h) `shouldBe` []
+
+    -- Lemmas feed the candidate list only, not the local context: an allow-listed
+    -- global does not appear among the hole's term/cube variables.
+    it "keeps allow-listed lemmas out of the local context" $
+      flip oneHole (holesWithLemmas ["concat"] src) $ \h ->
+        (names (holeTermVars h) <> names (holeCubeVars h)) `shouldNotContain` ["concat"]
 
   describe "holeIntroductions (type-directed introduction forms)" $ do
     let intros = map show . holeIntroductions


### PR DESCRIPTION
A hole's candidate list is drawn from the local hypotheses; named top-level definitions are filtered out, so a relevant lemma in scope never surfaces as a move. Given a module with a hole,

```rzk
#lang rzk-1
#postulate B : U
#postulate concat : B -> B -> B
#postulate rev : B -> B
#define goal : B := ?
```

the hole offers no candidates today. A caller can now supply an allow-list of lemmas to draw on:

```haskell
typecheckModulesWithHolesAndLemmas ["concat", "rev"] modules
-- holeCandidates: concat ? ?, rev ?
```

We add a `hintLemmas` allow-list to the context (set by `withHintLemmas`) and thread it through the new `typecheckModulesWithHolesAndLemmas` entry point. The listed top-level definitions feed the candidate-elimination loop alongside the local hypotheses, so the existing pipeline offers each lemma whose type fits the goal, applied to holes. Deciding which lemmas fit needs the typed probes on the hole's live context, which the game cannot reach once a hole is rendered, so the filtering belongs here. The lemmas do not enter the local context shown at the hole, matching stays fit-filtered, and the default empty list leaves strict checking and the LSP path unchanged.