### PR TITLE
Holes: charge only branching eliminators against depth bound

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## Unreleased
+
+Fixed:
+
+- A hole's hint inventory no longer drops a hypothesis or allow-listed lemma whose elimination spine is long. For a goal `#!rzk B` and a lemma `#!rzk deep : A -> A -> A -> A -> A -> A -> A -> A -> B`, the candidate `#!rzk deep ? ? ? ? ? ? ? ?` was silently omitted, because filling each of the eight arguments with a hole spent one unit of the search-depth bound. Filling a function's arguments is a forced spine step, so it no longer counts against the bound; only the genuinely branching eliminators (Σ/cube projections and `#!rzk idJ`) do. This affects only the candidate hints surfaced to the game and the LSP, not the strict `rzk typecheck` path (see [#261](https://github.com/rzk-lang/rzk/pull/261)).
+
 ## v0.9.0 — 2026-06-24
 
 Added:

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -738,29 +738,37 @@ containsHole = \case
 --
 -- The search is driven uniformly by the eliminators a (weak head normal) type
 -- admits (see 'eliminatorsOf'), so adding a new eliminator extends it without
--- touching the search. Depth is bounded by 'maxEliminationDepth'.
+-- touching the search.
+--
+-- A Π-application is a forced spine step — there is exactly one way to fill an
+-- argument (with a hole) — so it extends the spine for free and does not spend
+-- the budget. Only the genuinely branching eliminators (Σ/cube projections and
+-- @idJ@, flagged by 'eliminatorsOf') count against 'maxEliminationDepth'. The
+-- bound therefore limits real search depth, not argument count, so a lemma that
+-- must be applied to many holes is still reached. The free spine terminates
+-- because each application strips one Π binder off a finite type.
 allEliminationsInto
   :: Eq var => TermT var -> TermT var -> TypeCheck var [TermT var]
 allEliminationsInto target = go maxEliminationDepth
   where
     go depth term = do
-      ty   <- typeOf term
-      fits <- fitsInto term ty target
-      deeper <-
-        if depth <= 0
-          then pure []
-          else do
-            elims <- eliminatorsOf ty
-            concat <$> mapM (\wrap -> go (depth - 1) (wrap term)) elims
+      ty    <- typeOf term
+      fits  <- fitsInto term ty target
+      elims <- eliminatorsOf ty
+      let step (SpineStep, wrap) = go depth (wrap term)
+          step (Branching, wrap)
+            | depth <= 0 = pure []
+            | otherwise  = go (depth - 1) (wrap term)
+      deeper <- concat <$> mapM step elims
       pure ([term | fits] <> deeper)
 
--- | How deep an elimination spine 'allEliminationsInto' will build. A temporary
--- fixed bound: seven is enough for the spines seen so far (fully applying a
--- five-argument hypothesis and projecting twice), and a larger bound mostly adds
--- self-referential spines (a built result applied again). It should be made
--- configurable, and likely raised, once there is more evidence of what real
--- goals need. The chain only branches at Σ-types, which are shallow, so the
--- search stays small.
+-- | How many /branching/ eliminators 'allEliminationsInto' will chain. Forced
+-- Π-applications are free (see 'allEliminationsInto'), so this bounds only the
+-- Σ/cube projections and @idJ@ steps, not the argument count of a spine. A
+-- temporary fixed bound: branching is shallow in the goals seen so far (a few
+-- projections), and a larger bound mostly adds self-referential spines (a built
+-- result eliminated again). It should be made configurable once there is more
+-- evidence of what real goals need.
 maxEliminationDepth :: Int
 maxEliminationDepth = 7
 
@@ -784,24 +792,32 @@ fitsInto term ty target = do
   censor (const []) $ local structuralHoleUnify
     ((unify (Just term) target' ty' >> pure True) `catchError` \_ -> pure False)
 
+-- | Whether eliminating a value spends the search budget. A forced
+-- Π-application is a 'SpineStep' — there is one way to fill the argument (with a
+-- hole), so 'allEliminationsInto' applies it for free; a 'Branching' eliminator
+-- (a Σ/cube projection or @idJ@) costs one against 'maxEliminationDepth'.
+data ElimCost = SpineStep | Branching
+  deriving (Eq, Show)
+
 -- | The eliminators a value of the given (weak head normal) type admits, each
--- as a function wrapping the eliminated term. A Π-type is eliminated by
--- application to a fresh hole; a Σ-type by either projection; an identity type
--- by path induction (@idJ@), with the motive and base case left as holes.
+-- as a function wrapping the eliminated term, paired with its 'ElimCost'. A
+-- Π-type is eliminated by application to a fresh hole (a spine step); a Σ-type
+-- by either projection; an identity type by path induction (@idJ@), with the
+-- motive and base case left as holes. The projections and @idJ@ branch.
 -- Anything else admits no simple eliminator.
-eliminatorsOf :: Eq var => TermT var -> TypeCheck var [TermT var -> TermT var]
+eliminatorsOf :: Eq var => TermT var -> TypeCheck var [(ElimCost, TermT var -> TermT var)]
 eliminatorsOf ty =
   case stripTypeRestrictions ty of
     TypeFunT _ty _orig _md param _mtope ret ->
-      pure [ \term -> let h = mkHole param in appT (substituteT h ret) term h ]
+      pure [ (SpineStep, \term -> let h = mkHole param in appT (substituteT h ret) term h) ]
     TypeSigmaT _ty _orig _md a b ->
-      pure [ \term -> firstT a term
-           , \term -> secondT (substituteT (firstT a term) b) term ]
+      pure [ (Branching, \term -> firstT a term)
+           , (Branching, \term -> secondT (substituteT (firstT a term) b) term) ]
     -- A cube point pair (e.g. a pattern-bound @(t , s) : 2 × 2@) projects to its
     -- coordinates; rzk renders those projections back as the pattern names.
     CubeProductT _ty a b ->
-      pure [ \term -> firstT a term
-           , \term -> secondT b term ]
+      pure [ (Branching, \term -> firstT a term)
+           , (Branching, \term -> secondT b term) ]
     -- A path @p : a =_A x@ is eliminated by path induction. The motive
     -- @C : (z : A) → (a =_A z) → U@ is always a function, so we introduce it
     -- straight away as @\\ b q → ?@ rather than leaving it a bare hole: the spine
@@ -825,7 +841,7 @@ eliminatorsOf ty =
           d      = mkHole dType
           motiveAt y p = appT universeT
             (appT (typeFunT (BinderVar Nothing) Id (typeIdT a (Just tA) y) Nothing universeT) c y) p
-      pure [ \p -> idJT (motiveAt x p) tA a c d x p ]
+      pure [ (Branching, \p -> idJT (motiveAt x p) tA a c d x p) ]
     _ -> pure []
   where
     mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -369,6 +369,18 @@ spec = do
       flip oneHole (holesWithLemmas ["concat"] src) $ \h ->
         (names (holeTermVars h) <> names (holeCubeVars h)) `shouldNotContain` ["concat"]
 
+    -- A lemma fully applied to many arguments is offered: filling a function's
+    -- arguments with holes is a forced spine step that does not spend the search
+    -- budget, so the eight-argument `deep` reaches the goal even though its spine
+    -- is longer than `maxEliminationDepth`. (Regression: argument count used to be
+    -- charged against the bound, silently dropping deep lemmas.)
+    it "offers a lemma applied to more arguments than maxEliminationDepth" $
+      let deepSrc = "#lang rzk-1\n#postulate A : U\n#postulate B : U\n"
+                 <> "#postulate deep : A -> A -> A -> A -> A -> A -> A -> A -> B\n"
+                 <> "#define goal : B := ?\n"
+      in flip oneHole (holesWithLemmas ["deep"] deepSrc) $ \h ->
+           cands h `shouldContain` ["deep ? ? ? ? ? ? ? ?"]
+
   describe "holeIntroductions (type-directed introduction forms)" $ do
     let intros = map show . holeIntroductions
 


### PR DESCRIPTION
A hole's candidate hints dropped any lemma that had to be applied to more than seven arguments to reach the goal. Given

```rzk
#postulate deep : A -> A -> A -> A -> A -> A -> A -> A -> B
#define goal : B := ?
```

the goal `B` is met by `deep ? ? ? ? ? ? ? ?`, but that candidate was silently omitted: filling each of the eight arguments with a hole spent one unit of `maxEliminationDepth = 7`, so the spine ran out of budget before it reached `B`.

The bound conflated two things: the length of a deterministic application spine and the depth of the actual search. Filling a function's arguments is forced, so it should be free. We now tag each eliminator from `eliminatorsOf` with an `ElimCost` (`SpineStep` or `Branching`) and charge the bound only for the branching eliminators, which are the Σ/cube projections and `idJ`. A Π-application extends the spine for free, so `deep ? ? ? ? ? ? ? ?` is offered again. The free spine still terminates, since each application strips one Π binder off a finite type.

This affects only the candidate hints surfaced to the game and the LSP, not the strict `rzk typecheck` path. A regression test in `Rzk.HolesSpec` covers the example above.