### PR TITLE
Holes: tolerate unused assumptions when the section has a hole

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -10,6 +10,8 @@ and this project adheres to the
 
 Fixed:
 
+- In lenient (`--allow-holes`) mode, an unused `#!rzk uses` variable is now tolerated whenever the section contains a hole, not only when the hole sits in the declaration itself. For example, with `#!rzk #def in-progress uses (P) : U := ?` and a hole-free wrapper `#!rzk #def check uses (P) : U := in-progress`, the wrapper's `#!rzk uses (P)` reads as unused only because `#!rzk in-progress` is incomplete; it no longer masks the hole the player is meant to see. Strict mode (the default, and CI) still reports a genuinely unused `#!rzk uses` (see [#262](https://github.com/rzk-lang/rzk/pull/262)).
+
 - A hole's hint inventory no longer drops a hypothesis or allow-listed lemma whose elimination spine is long. For a goal `#!rzk B` and a lemma `#!rzk deep : A -> A -> A -> A -> A -> A -> A -> A -> B`, the candidate `#!rzk deep ? ? ? ? ? ? ? ?` was silently omitted, because filling each of the eight arguments with a hole spent one unit of the search-depth bound. Filling a function's arguments is a forced spine step, so it no longer counts against the bound; only the genuinely branching eliminators (Σ/cube projections and `#!rzk idJ`) do. This affects only the candidate hints surfaced to the game and the LSP, not the strict `rzk typecheck` path (see [#261](https://github.com/rzk-lang/rzk/pull/261)).
 
 ## v0.9.0 — 2026-06-24

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1517,9 +1517,11 @@ scopeToDecls :: Eq var => [TypeErrorInScopedContext var] -> ScopeInfo var -> Typ
 scopeToDecls errs ScopeInfo{..} = do
   -- In lenient (hole-checking) mode an as-yet-unfilled hole may still come to
   -- use a declared variable, so we tolerate the unused-variable diagnostics
-  -- wherever such a hole is present: a hole anywhere in the section for an
-  -- unused section assumption, a hole in the declaration itself for an unused
-  -- 'uses' variable. Strict mode (the default, and CI) keeps reporting both.
+  -- wherever such a hole is present anywhere in the section. This covers both an
+  -- unused section assumption and an unused 'uses' variable, and crucially a
+  -- hole-free definition whose body refers to an in-progress (hole-bearing) one:
+  -- its 'uses' reads as unused only because the referenced definition is
+  -- incomplete. Strict mode (the default, and CI) keeps reporting both.
   lenient <- not <$> asks holesAreErrors
   let sectionHasHole = any (maybe False containsHole . varValue . snd) scopeVars
   (decls, errs') <- collectScopeDecls (lenient && sectionHasHole) errs [] scopeVars
@@ -1527,8 +1529,7 @@ scopeToDecls errs ScopeInfo{..} = do
   -- when (null errs) $ do
   unusedErrors <- forM decls $ \Decl{..} -> do
     let unusedUsedVars = declUsedVars `intersect` map fst scopeVars
-        declHasHole    = maybe False containsHole declValue
-    if null errs && not (null unusedUsedVars) && not (lenient && declHasHole)
+    if null errs && not (null unusedUsedVars) && not (lenient && sectionHasHole)
       then do
         err <- local (\c -> c { location = declLocation }) $
           fromTypeError (TypeErrorUnusedUsedVariables unusedUsedVars declName)

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -488,6 +488,15 @@ spec = do
       errTagsOf (usesSection "#define f uses (x) : U\n  := A")
         `shouldContain` ["TypeErrorUnusedUsedVariables"]
 
+    -- A hole-free definition whose body refers to an in-progress (hole-bearing)
+    -- one declares 'uses (x)' that reads as unused only because the referenced
+    -- definition is incomplete. The section has a hole, so it is tolerated (the
+    -- check keys off a hole anywhere in the section, not the declaration alone).
+    it "tolerates an unused 'uses' on a hole-free wrapper of a hole-bearing def" $
+      errTagsOf (usesSection ("#define in-progress uses (x) : U\n  := ?\n"
+                           <> "#define wrapper uses (x) : U\n  := in-progress"))
+        `shouldNotContain` ["TypeErrorUnusedUsedVariables"]
+
   -- The goal cell: when the goal is a renderable shape, the hole carries an SVG
   -- of that shape, drawn from an abstract inhabitant with the proof term hidden
   -- (see 'renderHideTerm'). So the picture shows the given boundary edges with a


### PR DESCRIPTION
In lenient (`--allow-holes`) mode, an in-progress proof that should simply report its hole instead reported a spurious unused-assumption error. Given

```rzk
#assume P : U
#def in-progress uses (P) : U := ?      -- hole-bearing: tolerated
#def check uses (P) : U := in-progress  -- hole-free wrapper: ERROR "unused P"
```

`check` is rejected with *"unused variables P declared as used"*, even though `P` is unused only because `in-progress` is still a hole. PR #249 tolerated an unused `uses` when the declaration's *own* body carried a hole, but not a hole-free definition that refers to a hole-bearing one. The game hits this on every `uses`-bearing level: it pins the goal with a synthetic hole-free wrapper over the player's proof, which is a bare `?` until the level is solved, so the level could not start from `?`.

We now key the tolerance off a hole anywhere in the section rather than the declaration alone, mirroring the unused-section-assumption tolerance just above (both gate on `lenient && sectionHasHole`). A declaration's own hole already puts a hole in its section, so this strictly extends the previous behaviour. Strict mode (the default, and CI) is unchanged and still reports a genuinely unused `uses`, so finished work is unaffected.