### PR TITLE
Add upper bounds on all dependencies

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -12,6 +12,10 @@ Fixed:
 
 - A hole's hint inventory no longer drops a hypothesis or allow-listed lemma whose elimination spine is long. For a goal `#!rzk B` and a lemma `#!rzk deep : A -> A -> A -> A -> A -> A -> A -> A -> B`, the candidate `#!rzk deep ? ? ? ? ? ? ? ?` was silently omitted, because filling each of the eight arguments with a hole spent one unit of the search-depth bound. Filling a function's arguments is a forced spine step, so it no longer counts against the bound; only the genuinely branching eliminators (Σ/cube projections and `#!rzk idJ`) do. This affects only the candidate hints surfaced to the game and the LSP, not the strict `rzk typecheck` path (see [#261](https://github.com/rzk-lang/rzk/pull/261)).
 
+Packaging:
+
+- Add upper bounds on all dependencies, as Hackage asks for. The bounds are at the next super-major version, so a new GHC's boot libraries (`array`, `bytestring`, `directory`, `mtl`, `template-haskell`, `text`) and the pinned Nix/GHCJS package set both stay in range without a Hackage revision on every minor dependency bump. The loose lower bounds are unchanged, so the GHCJS path still resolves (see [#259](https://github.com/rzk-lang/rzk/issues/259), [#134](https://github.com/rzk-lang/rzk/issues/134)).
+
 ## v0.9.0 — 2026-06-24
 
 Added:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -51,20 +51,24 @@ when:
 # GHC-9.6.3-coherent floors live in cabal.project's `constraints:` block,
 # which is read by cabal but not by cabal2nix → Nix.
 dependencies:
+  # Upper bounds are at the next super-major, so a new GHC's boot libraries
+  # (array, bytestring, directory, mtl, template-haskell, text) and the
+  # Nix/GHCJS package set both stay in range without a Hackage revision on
+  # every minor dependency bump.
   # Loose lower bound so the GHCJS path (miso's pinned package set ships
   # aeson 1.x) resolves; the GHC-era floor (aeson >= 2) lives in
   # cabal.project, which cabal2nix does not read.
-  aeson: ">= 1.4"
-  array: ">= 0.5.3.0"
+  aeson: ">= 1.4 && < 3"
+  array: ">= 0.5.3.0 && < 1"
   base: ">= 4.7 && < 5"
-  bifunctors: ">= 5.5.3"
-  bytestring: ">= 0.10.8.2"
-  directory: ">= 1.2.7.0"
-  Glob: ">= 0.9.3"
-  mtl: ">= 2.2.2"
-  template-haskell: ">= 2.14.0.0"
-  text: ">= 1.2.3.1"
-  yaml: ">= 0.11.0.0"
+  bifunctors: ">= 5.5.3 && < 6"
+  bytestring: ">= 0.10.8.2 && < 1"
+  directory: ">= 1.2.7.0 && < 2"
+  Glob: ">= 0.9.3 && < 1"
+  mtl: ">= 2.2.2 && < 3"
+  template-haskell: ">= 2.14.0.0 && < 3"
+  text: ">= 1.2.3.1 && < 3"
+  yaml: ">= 0.11.0.0 && < 1"
 
 ghc-options:
   - -Wall
@@ -101,15 +105,15 @@ library:
         - Language.Rzk.VSCode.Lsp
         - Language.Rzk.VSCode.Tokenize
       dependencies:
-        aeson: ">= 2.0.0.0"
-        co-log-core: ">= 0.3.2.0"
-        data-default-class: ">= 0.1.2.0"
-        filepath: ">= 1.4.100.0"
-        lens: ">= 5.0.1"
-        lsp: ">= 2.4.0.0"
-        lsp-types: ">= 2.1.1.0"
-        mtl: ">= 2.3.1"
-        stm: ">= 2.5.1.0"
+        aeson: ">= 2.0.0.0 && < 3"
+        co-log-core: ">= 0.3.2.0 && < 1"
+        data-default-class: ">= 0.1.2.0 && < 1"
+        filepath: ">= 1.4.100.0 && < 2"
+        lens: ">= 5.0.1 && < 6"
+        lsp: ">= 2.4.0.0 && < 3"
+        lsp-types: ">= 2.1.1.0 && < 3"
+        mtl: ">= 2.3.1 && < 3"
+        stm: ">= 2.5.1.0 && < 3"
 
 executables:
   rzk:
@@ -124,8 +128,8 @@ executables:
     when:
       - condition: "!impl(ghcjs)"
         dependencies:
-          with-utf8: ">= 1.0.3.0"
-          optparse-generic: ">= 1.4.7"
+          with-utf8: ">= 1.0.3.0 && < 2"
+          optparse-generic: ">= 1.4.7 && < 2"
 
 tests:
   rzk-test:
@@ -136,14 +140,14 @@ tests:
       - -rtsopts
       - -with-rtsopts=-N
     build-tools:
-      hspec-discover:hspec-discover: ">= 0"
+      hspec-discover:hspec-discover: ">= 2.7 && < 3"
+    # aeson and yaml come from the top-level dependencies (with bounds); listing
+    # them here too would shadow those with an unbounded entry.
     dependencies:
-      - aeson
-      - filepath
+      - filepath >= 1.4 && < 2
       - rzk
-      - hspec
-      - hspec-discover
-      - yaml
+      - hspec >= 2.7 && < 3
+      - hspec-discover >= 2.7 && < 3
 
   doctests:
     source-dirs: test
@@ -151,8 +155,8 @@ tests:
     other-modules: []
     dependencies:
       base: ">= 4.11.0.0 && < 5.0"
-      doctest-parallel: ">= 0.3"
+      doctest-parallel: ">= 0.3 && < 1"
       rzk:
-      Glob: ">= 0.9.3"
-      QuickCheck: ">= 2.14"
-      template-haskell: ">= 2.14.0.0"
+      Glob: ">= 0.9.3 && < 1"
+      QuickCheck: ">= 2.14 && < 3"
+      template-haskell: ">= 2.14.0.0 && < 3"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -264,17 +264,17 @@ library
       DeriveDataTypeable
   ghc-options: -Wall -Wcompat -Widentities -Werror=missing-fields -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-depends:
-      Glob >=0.9.3
-    , aeson >=1.4
-    , array >=0.5.3.0
+      Glob >=0.9.3 && <1
+    , aeson >=1.4 && <3
+    , array >=0.5.3.0 && <1
     , base >=4.7 && <5
-    , bifunctors >=5.5.3
-    , bytestring >=0.10.8.2
-    , directory >=1.2.7.0
-    , mtl >=2.2.2
-    , template-haskell >=2.14.0.0
-    , text >=1.2.3.1
-    , yaml >=0.11.0.0
+    , bifunctors >=5.5.3 && <6
+    , bytestring >=0.10.8.2 && <1
+    , directory >=1.2.7.0 && <2
+    , mtl >=2.2.2 && <3
+    , template-haskell >=2.14.0.0 && <3
+    , text >=1.2.3.1 && <3
+    , yaml >=0.11.0.0 && <1
   default-language: Haskell2010
   if flag(lsp) && !impl(ghcjs)
     cpp-options: -DLSP_ENABLED
@@ -287,15 +287,15 @@ library
         Language.Rzk.VSCode.Lsp
         Language.Rzk.VSCode.Tokenize
     build-depends:
-        aeson >=2.0.0.0
-      , co-log-core >=0.3.2.0
-      , data-default-class >=0.1.2.0
-      , filepath >=1.4.100.0
-      , lens >=5.0.1
-      , lsp >=2.4.0.0
-      , lsp-types >=2.1.1.0
-      , mtl >=2.3.1
-      , stm >=2.5.1.0
+        aeson >=2.0.0.0 && <3
+      , co-log-core >=0.3.2.0 && <1
+      , data-default-class >=0.1.2.0 && <1
+      , filepath >=1.4.100.0 && <2
+      , lens >=5.0.1 && <6
+      , lsp >=2.4.0.0 && <3
+      , lsp-types >=2.1.1.0 && <3
+      , mtl >=2.3.1 && <3
+      , stm >=2.5.1.0 && <3
 
 executable rzk
   main-is: Main.hs
@@ -309,25 +309,25 @@ executable rzk
       DeriveDataTypeable
   ghc-options: -Wall -Wcompat -Widentities -Werror=missing-fields -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      Glob >=0.9.3
-    , aeson >=1.4
-    , array >=0.5.3.0
+      Glob >=0.9.3 && <1
+    , aeson >=1.4 && <3
+    , array >=0.5.3.0 && <1
     , base >=4.7 && <5
-    , bifunctors >=5.5.3
-    , bytestring >=0.10.8.2
-    , directory >=1.2.7.0
-    , mtl >=2.2.2
+    , bifunctors >=5.5.3 && <6
+    , bytestring >=0.10.8.2 && <1
+    , directory >=1.2.7.0 && <2
+    , mtl >=2.2.2 && <3
     , rzk
-    , template-haskell >=2.14.0.0
-    , text >=1.2.3.1
-    , yaml >=0.11.0.0
+    , template-haskell >=2.14.0.0 && <3
+    , text >=1.2.3.1 && <3
+    , yaml >=0.11.0.0 && <1
   default-language: Haskell2010
   if flag(lsp) && !impl(ghcjs)
     cpp-options: -DLSP_ENABLED
   if !impl(ghcjs)
     build-depends:
-        optparse-generic >=1.4.7
-      , with-utf8 >=1.0.3.0
+        optparse-generic >=1.4.7 && <2
+      , with-utf8 >=1.0.3.0 && <2
 
 test-suite doctests
   type: exitcode-stdio-1.0
@@ -338,20 +338,20 @@ test-suite doctests
       DeriveDataTypeable
   ghc-options: -Wall -Wcompat -Widentities -Werror=missing-fields -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-depends:
-      Glob >=0.9.3
-    , QuickCheck >=2.14
-    , aeson >=1.4
-    , array >=0.5.3.0
+      Glob >=0.9.3 && <1
+    , QuickCheck >=2.14 && <3
+    , aeson >=1.4 && <3
+    , array >=0.5.3.0 && <1
     , base >=4.11.0.0 && <5.0
-    , bifunctors >=5.5.3
-    , bytestring >=0.10.8.2
-    , directory >=1.2.7.0
-    , doctest-parallel >=0.3
-    , mtl >=2.2.2
+    , bifunctors >=5.5.3 && <6
+    , bytestring >=0.10.8.2 && <1
+    , directory >=1.2.7.0 && <2
+    , doctest-parallel >=0.3 && <1
+    , mtl >=2.2.2 && <3
     , rzk
-    , template-haskell >=2.14.0.0
-    , text >=1.2.3.1
-    , yaml >=0.11.0.0
+    , template-haskell >=2.14.0.0 && <3
+    , text >=1.2.3.1 && <3
+    , yaml >=0.11.0.0 && <1
   default-language: Haskell2010
   if flag(lsp) && !impl(ghcjs)
     cpp-options: -DLSP_ENABLED
@@ -373,23 +373,23 @@ test-suite rzk-test
       DeriveDataTypeable
   ghc-options: -Wall -Wcompat -Widentities -Werror=missing-fields -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
-      hspec-discover:hspec-discover
+      hspec-discover:hspec-discover >=2.7 && <3
   build-depends:
-      Glob >=0.9.3
-    , aeson
-    , array >=0.5.3.0
+      Glob >=0.9.3 && <1
+    , aeson >=1.4 && <3
+    , array >=0.5.3.0 && <1
     , base >=4.7 && <5
-    , bifunctors >=5.5.3
-    , bytestring >=0.10.8.2
-    , directory >=1.2.7.0
-    , filepath
-    , hspec
-    , hspec-discover
-    , mtl >=2.2.2
+    , bifunctors >=5.5.3 && <6
+    , bytestring >=0.10.8.2 && <1
+    , directory >=1.2.7.0 && <2
+    , filepath >=1.4 && <2
+    , hspec >=2.7 && <3
+    , hspec-discover >=2.7 && <3
+    , mtl >=2.2.2 && <3
     , rzk
-    , template-haskell >=2.14.0.0
-    , text >=1.2.3.1
-    , yaml
+    , template-haskell >=2.14.0.0 && <3
+    , text >=1.2.3.1 && <3
+    , yaml >=0.11.0.0 && <1
   default-language: Haskell2010
   if flag(lsp) && !impl(ghcjs)
     cpp-options: -DLSP_ENABLED


### PR DESCRIPTION
Hackage warns that `rzk` ships without upper bounds on its dependencies (`Glob`, `aeson`, `array`, `bifunctors`, `bytestring`, `directory`, `mtl`, `template-haskell`, `text`, `yaml`, and the LSP/test deps). This adds them on every component, so the next release can be published without the warning.

The bounds are at the next super-major version rather than the next PVP major:

```
text             >= 1.2.3.1 && < 3      (resolved: 2.1.3)
template-haskell >= 2.14.0.0 && < 3     (resolved: 2.22)
aeson            >= 1.4 && < 3          (resolved: 2.2; GHCJS path uses 1.x)
lsp              >= 2.4.0.0 && < 3       (resolved: 2.7)
```

The loose lower bounds are left untouched, so the GHCJS path (whose pinned Nixpkgs ships older packages, e.g. aeson 1.x) still resolves — only upper bounds are added. The redundant unbounded `aeson`/`yaml` entries on the test suite are dropped, since both already come from the top-level dependencies with bounds.

Closes #259 and #134.