### PR TITLE
Respect variance in tope and restriction subtype checks

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -39,6 +39,9 @@ extra-source-files:
     test/typecheck/cases/happy-refl-path.rzk
     test/typecheck/cases/happy-restrict-face-not-contained.rzk
     test/typecheck/cases/happy-shott-simplicial-subcomplexes.rzk
+    test/typecheck/cases/happy-subtype-variance-pi-shape-domain.rzk
+    test/typecheck/cases/happy-subtype-variance-restriction-faces.rzk
+    test/typecheck/cases/happy-subtype-variance-tope-family.rzk
     test/typecheck/cases/happy-tope-high-dim-cubes.rzk
     test/typecheck/cases/happy-tope-nested-rec-or-d4.rzk
     test/typecheck/cases/happy-tope-nested-rec-or-d5.rzk
@@ -92,6 +95,9 @@ extra-source-files:
     test/typecheck/cases/ill-set-option-render.rzk
     test/typecheck/cases/ill-set-option-unknown.rzk
     test/typecheck/cases/ill-set-option-verbosity.rzk
+    test/typecheck/cases/ill-subtype-variance-pi-shape-domain.rzk
+    test/typecheck/cases/ill-subtype-variance-restriction-faces.rzk
+    test/typecheck/cases/ill-subtype-variance-tope-family.rzk
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.rzk
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.rzk
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.rzk
@@ -142,6 +148,9 @@ extra-source-files:
     test/typecheck/cases/happy-refl-path.expect.yaml
     test/typecheck/cases/happy-restrict-face-not-contained.expect.yaml
     test/typecheck/cases/happy-shott-simplicial-subcomplexes.expect.yaml
+    test/typecheck/cases/happy-subtype-variance-pi-shape-domain.expect.yaml
+    test/typecheck/cases/happy-subtype-variance-restriction-faces.expect.yaml
+    test/typecheck/cases/happy-subtype-variance-tope-family.expect.yaml
     test/typecheck/cases/happy-tope-high-dim-cubes.expect.yaml
     test/typecheck/cases/happy-tope-nested-rec-or-d4.expect.yaml
     test/typecheck/cases/happy-tope-nested-rec-or-d5.expect.yaml
@@ -195,6 +204,9 @@ extra-source-files:
     test/typecheck/cases/ill-set-option-render.expect.yaml
     test/typecheck/cases/ill-set-option-unknown.expect.yaml
     test/typecheck/cases/ill-set-option-verbosity.expect.yaml
+    test/typecheck/cases/ill-subtype-variance-pi-shape-domain.expect.yaml
+    test/typecheck/cases/ill-subtype-variance-restriction-faces.expect.yaml
+    test/typecheck/cases/ill-subtype-variance-tope-family.expect.yaml
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d4.expect.yaml
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d5.expect.yaml
     test/typecheck/cases/ill-tope-nested-rec-or-inner-singleton-d6.expect.yaml

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -3289,6 +3289,15 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                           switchVariance $  -- unifying in the negative position!
                             unifyTerms cube cube' -- FIXME: unifyCubes
                           enterScope orig' md cube' $ do
+                            -- The tope checks below are subtyping checks with a fixed
+                            -- direction relative to (subtype, supertype). Which side is
+                            -- the subtype depends on the ambient variance: under
+                            -- Covariant the actual type must be a subtype of the
+                            -- expected one; under Contravariant (inside a domain) the
+                            -- roles are reversed. Invariant is normally handled
+                            -- upstream by running both directions; it is handled here
+                            -- as well for safety.
+                            variance <- asks covariance
                             case ret' of
                               UniverseTopeT{} -> do
                                 -- This is the case for tope families (shapes)
@@ -3300,9 +3309,16 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                                 -- we DO NOT take tope context Φ into account!
                                 expectedTopeNF <- fromMaybe topeTopT <$> traverse nfT mtope
                                 actualTopeNF   <- fromMaybe topeTopT <$> traverse nfT mtope'
-                                actualEntailsExpected <- [plainTope actualTopeNF] `entailM` expectedTopeNF
-                                unless (actualEntailsExpected || containsHole expectedTopeNF || containsHole actualTopeNF) $
-                                  issueTypeError (TypeErrorTopeNotSatisfied [actualTopeNF] expectedTopeNF)
+                                let subEntailsSuper subNF superNF = do
+                                      entails <- [plainTope subNF] `entailM` superNF
+                                      unless (entails || containsHole subNF || containsHole superNF) $
+                                        issueTypeError (TypeErrorTopeNotSatisfied [subNF] superNF)
+                                case variance of
+                                  Covariant     -> subEntailsSuper actualTopeNF expectedTopeNF
+                                  Contravariant -> subEntailsSuper expectedTopeNF actualTopeNF
+                                  Invariant     -> do
+                                    subEntailsSuper actualTopeNF expectedTopeNF
+                                    subEntailsSuper expectedTopeNF actualTopeNF
                               _ -> do
                                 -- this is the case for Π-types and extension types
                                 --
@@ -3311,8 +3327,15 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                                 -- Ξ | Φ, ψ ⊢ φ
                                 expectedTopeNF <- fromMaybe topeTopT <$> traverse nfT mtope
                                 actualTopeNF   <- fromMaybe topeTopT <$> traverse nfT mtope'
-                                localTope expectedTopeNF $
-                                  contextEntails actualTopeNF
+                                let superEntailsSub superNF subNF =
+                                      localTope superNF $
+                                        contextEntails subNF
+                                case variance of
+                                  Covariant     -> superEntailsSub expectedTopeNF actualTopeNF
+                                  Contravariant -> superEntailsSub actualTopeNF expectedTopeNF
+                                  Invariant     -> do
+                                    superEntailsSub expectedTopeNF actualTopeNF
+                                    superEntailsSub actualTopeNF expectedTopeNF
                             case mterm of
                               Nothing -> unifyTerms ret ret'
                               Just term -> unifyTypes (appT ret' (S <$> term) (Pure Z)) ret ret'
@@ -3404,15 +3427,26 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                       case actual' of
                         TypeRestrictedT _ty' ty' rs' -> do
                           unify mterm ty ty'
-                          sequence_
-                            [ localTope tope $ do
-                                -- FIXME: can do less entails checks?
-                                contextEntails (foldr topeOrT topeBottomT (map fst rs')) -- expected is less specified than actual
-                                forM_ rs' $ \(tope', term') -> do
-                                  localTope tope' $
-                                    unify Nothing term term'
-                            | (tope, term) <- rs
-                            ]
+                          -- The faces of the supertype must be covered by the faces
+                          -- of the subtype (the subtype is at least as specified),
+                          -- with the boundary terms agreeing on overlaps. Which side
+                          -- is the subtype depends on the ambient variance.
+                          variance <- asks covariance
+                          let subCoversSuper subRs superRs = sequence_
+                                [ localTope tope $ do
+                                    -- FIXME: can do less entails checks?
+                                    contextEntails (foldr topeOrT topeBottomT (map fst subRs))
+                                    forM_ subRs $ \(tope', term') -> do
+                                      localTope tope' $
+                                        unify Nothing term term'
+                                | (tope, term) <- superRs
+                                ]
+                          case variance of
+                            Covariant     -> subCoversSuper rs' rs
+                            Contravariant -> subCoversSuper rs rs'
+                            Invariant     -> do
+                              subCoversSuper rs' rs
+                              subCoversSuper rs rs'
                         _ -> err    -- FIXME: need better unification for restrictions
                     TypeModalT _ty m ty ->
                       case actual' of
@@ -3437,7 +3471,6 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                     -- than panicking on an otherwise unexpected shape
                     _ | holePresent -> return ()
                     _ -> panicImpossible "unexpected term in UNIFY"
-
 
   where
     action = case mterm of

--- a/rzk/test/typecheck/cases/happy-subtype-variance-pi-shape-domain.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-pi-shape-domain.expect.yaml
@@ -1,0 +1,3 @@
+status: ok
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/happy-subtype-variance-pi-shape-domain.rzk
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-pi-shape-domain.rzk
@@ -1,0 +1,22 @@
+#lang rzk-1
+
+-- PROBE: should be ACCEPTED (paper rules / dRzk).
+--
+-- Requirement for `g k`:
+--   (f : (t : 2 | t === 0_2) → A) → A  <:  (f : (t : 2 | TOP) → A) → A
+-- By contravariance of Π domains this needs
+--   (t : 2 | TOP) → A  <:  (t : 2 | t === 0_2) → A
+-- which by S-Pi-Shape needs  t === 0_2 ⊢ TOP  — TRUE.
+--
+-- Semantically: g calls its parameter with total functions, and k is
+-- happy to receive them (it only ever applies f on t === 0_2).
+--
+-- A checker whose Π-domain tope check ignores the variance flag checks
+-- TOP ⊢ t === 0_2 (false) and REJECTS.
+
+#def pi-shape-wrong-reject
+  ( A : U)
+  ( g : ((f : (t : 2 | TOP) → A) → A) → A)
+  ( k : (f : (t : 2 | t === 0_2) → A) → A)
+  : A
+  := g k

--- a/rzk/test/typecheck/cases/happy-subtype-variance-restriction-faces.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-restriction-faces.expect.yaml
@@ -1,0 +1,3 @@
+status: ok
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/happy-subtype-variance-restriction-faces.rzk
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-restriction-faces.rzk
@@ -1,0 +1,27 @@
+#lang rzk-1
+
+-- PROBE: should be ACCEPTED (paper rules / dRzk).
+--
+-- Requirement for `g k`:
+--   (x : A [t === 0_2 |-> a]) → A
+--     <:  (x : A [t === 0_2 |-> a, t === 1_2 |-> b]) → A
+-- By contravariance of Π domains this needs
+--   A [t === 0_2 |-> a, t === 1_2 |-> b]  <:  A [t === 0_2 |-> a]
+-- which holds by S-Restr: the single face of the supertype is among the
+-- subtype's faces.
+--
+-- Semantically: g feeds k elements with both boundary promises; k only
+-- relies on the promise at t === 0_2.
+--
+-- A checker whose restriction-face coverage check ignores the variance
+-- flag demands the converse inclusion (false) and REJECTS.
+
+#def restr-wrong-reject
+  ( A : U)
+  ( a : A)
+  ( b : A)
+  ( t : 2)
+  ( g : ((x : A [t === 0_2 |-> a, t === 1_2 |-> b]) → A) → A)
+  ( k : (x : A [t === 0_2 |-> a]) → A)
+  : A
+  := g k

--- a/rzk/test/typecheck/cases/happy-subtype-variance-tope-family.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-tope-family.expect.yaml
@@ -1,0 +1,3 @@
+status: ok
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/happy-subtype-variance-tope-family.rzk
+++ b/rzk/test/typecheck/cases/happy-subtype-variance-tope-family.rzk
@@ -1,0 +1,22 @@
+#lang rzk-1
+
+-- PROBE: should be ACCEPTED (paper rules / dRzk).
+--
+-- Requirement for `g h`:
+--   (φ : (t : 2 | TOP) → TOPE) → A  <:  (φ : (t : 2 | t === 0_2) → TOPE) → A
+-- By contravariance of Π domains this needs
+--   (t : 2 | t === 0_2) → TOPE  <:  (t : 2 | TOP) → TOPE
+-- which by S-TopeFam (covariant domains) needs  t === 0_2 ⊢ TOP  — TRUE.
+--
+-- Semantically: g passes h tope families bounded by t === 0_2; h accepts
+-- any tope family whatsoever (bound TOP), so this is safe.
+--
+-- A checker whose S-TopeFam check ignores the variance flag checks
+-- TOP ⊢ t === 0_2 (false) and REJECTS.
+
+#def tope-fam-wrong-reject
+  ( A : U)
+  ( g : ((φ : (t : 2 | t === 0_2) → TOPE) → A) → A)
+  ( h : (φ : (t : 2 | TOP) → TOPE) → A)
+  : A
+  := g h

--- a/rzk/test/typecheck/cases/ill-subtype-variance-pi-shape-domain.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-pi-shape-domain.expect.yaml
@@ -1,0 +1,4 @@
+status: error
+error_tag: TypeErrorTopeNotSatisfied
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/ill-subtype-variance-pi-shape-domain.rzk
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-pi-shape-domain.rzk
@@ -1,0 +1,22 @@
+#lang rzk-1
+
+-- PROBE: should be REJECTED (paper rules / dRzk).
+--
+-- Requirement for `g k`:  typeof(k) <: dom(typeof(g)), i.e.
+--   (f : (t : 2 | TOP) → A) → A  <:  (f : (t : 2 | t === 0_2) → A) → A
+-- By contravariance of Π domains this needs
+--   (t : 2 | t === 0_2) → A  <:  (t : 2 | TOP) → A
+-- which by S-Pi-Shape needs  TOP ⊢ t === 0_2  — FALSE.
+--
+-- Semantically: g may call its parameter with an f defined only on
+-- t === 0_2; k demands a total f and applies it anywhere.
+--
+-- A checker whose Π-domain tope check ignores the variance flag checks
+-- the converse entailment  t === 0_2 ⊢ TOP  (true) and ACCEPTS.
+
+#def pi-shape-wrong-accept
+  ( A : U)
+  ( g : ((f : (t : 2 | t === 0_2) → A) → A) → A)
+  ( k : (f : (t : 2 | TOP) → A) → A)
+  : A
+  := g k

--- a/rzk/test/typecheck/cases/ill-subtype-variance-restriction-faces.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-restriction-faces.expect.yaml
@@ -1,0 +1,4 @@
+status: error
+error_tag: TypeErrorTopeNotSatisfied
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/ill-subtype-variance-restriction-faces.rzk
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-restriction-faces.rzk
@@ -1,0 +1,27 @@
+#lang rzk-1
+
+-- PROBE: should be REJECTED (paper rules / dRzk).
+--
+-- Requirement for `g k`:
+--   (x : A [t === 0_2 |-> a, t === 1_2 |-> b]) → A
+--     <:  (x : A [t === 0_2 |-> a]) → A
+-- By contravariance of Π domains this needs
+--   A [t === 0_2 |-> a]  <:  A [t === 0_2 |-> a, t === 1_2 |-> b]
+-- which by S-Restr fails: the face t === 1_2 |-> b of the supertype is
+-- not covered by the subtype's faces.
+--
+-- Semantically: g feeds k elements that promise nothing at t === 1_2;
+-- k's type entitles it to compute x ≡ b there.
+--
+-- A checker whose restriction-face coverage check ignores the variance
+-- flag checks the converse inclusion (true) and ACCEPTS.
+
+#def restr-wrong-accept
+  ( A : U)
+  ( a : A)
+  ( b : A)
+  ( t : 2)
+  ( g : ((x : A [t === 0_2 |-> a]) → A) → A)
+  ( k : (x : A [t === 0_2 |-> a, t === 1_2 |-> b]) → A)
+  : A
+  := g k

--- a/rzk/test/typecheck/cases/ill-subtype-variance-tope-family.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-tope-family.expect.yaml
@@ -1,0 +1,4 @@
+status: error
+error_tag: TypeErrorTopeNotSatisfied
+regression_for:
+  - subtype-variance-direction

--- a/rzk/test/typecheck/cases/ill-subtype-variance-tope-family.rzk
+++ b/rzk/test/typecheck/cases/ill-subtype-variance-tope-family.rzk
@@ -1,0 +1,22 @@
+#lang rzk-1
+
+-- PROBE: should be REJECTED (paper rules / dRzk).
+--
+-- Requirement for `g h`:
+--   (φ : (t : 2 | t === 0_2) → TOPE) → A  <:  (φ : (t : 2 | TOP) → TOPE) → A
+-- By contravariance of Π domains this needs
+--   (t : 2 | TOP) → TOPE  <:  (t : 2 | t === 0_2) → TOPE
+-- which by S-TopeFam (covariant domains) needs  TOP ⊢ t === 0_2  — FALSE.
+--
+-- Semantically: g passes h tope families with no bound at all; h's type
+-- promises its φ is bounded by t === 0_2.
+--
+-- A checker whose S-TopeFam check ignores the variance flag checks
+-- t === 0_2 ⊢ TOP (true) and ACCEPTS.
+
+#def tope-fam-wrong-accept
+  ( A : U)
+  ( g : ((φ : (t : 2 | TOP) → TOPE) → A) → A)
+  ( h : (φ : (t : 2 | t === 0_2) → TOPE) → A)
+  : A
+  := g h


### PR DESCRIPTION
The variance flag introduced in #207 is consulted when orienting the arguments of `etaMatch`, but three asymmetric checks inside `unifyInCurrentContext` run in a direction fixed relative to `(expected, actual)` regardless of the ambient variance: the domain entailment of tope-family types, the domain-tope entailment of Π- and extension types, and the face coverage of restriction-vs-restriction comparisons. In a negative position (inside a domain, where the flag is `Contravariant`) each of these checks therefore runs backwards: it rejects programs it should accept and accepts programs it should reject.

For example, the following was accepted, although `g` may call `k` with a function defined only on `t ≡ 0₂`, which `k` then applies at `1₂`:

```rzk
#def pi-shape-wrong-accept
  ( A : U)
  ( g : ((f : (t : 2 | t ≡ 0₂) → A) → A) → A)
  ( k : (f : (t : 2 | TOP) → A) → A)
  : A
  := g k
```

Dually, the analogous term with `TOP` and `t ≡ 0₂` swapped is sound but was rejected. The same wrong-accept/wrong-reject pair exists for tope-family domains and for restriction faces (where the accepted composite lets a caller assume a boundary equation that was never provided).

This PR makes each of the three checks consult the variance flag, phrased in terms of subtype and supertype. `Invariant` positions are already handled upstream by running both directions; they are handled locally as well for safety.

Six regression cases (`*-subtype-variance-*` under `test/typecheck/cases/`) cover both directions at all three sites. The sHoTT is unaffected by the change.