### PR TITLE
Compare the underlying types of identity types

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -3327,10 +3327,19 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                           enterScope orig' md a' $ unify Nothing b b'
                         _ -> err
 
-                    TypeIdT _ty x _tA y ->
+                    TypeIdT _ty x tA y ->
                       case actual' of
-                        TypeIdT _ty' x' _tA' y' -> do
-                          -- unify Nothing tA tA' -- TODO: do we need this check?
+                        TypeIdT _ty' x' tA' y' -> do
+                          -- The underlying types must be compared: without this
+                          -- check the routine equates identity types over
+                          -- different types whenever the endpoints unify,
+                          -- accepting e.g. a free homotopy (a path in the type
+                          -- of functions) where an endpoint-fixing one (a path
+                          -- in a hom-type) is expected. Compared invariantly:
+                          -- subtyping between the underlying types must not
+                          -- leak into equality of identity types over them.
+                          mapM_ (\(t1, t2) -> setVariance Invariant (unify Nothing t1 t2))
+                            ((,) <$> tA <*> tA')
                           unify Nothing x x'
                           unify Nothing y y'
                         _ -> err

--- a/rzk/test/typecheck/cases/ill-unify-id-free-path.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-unify-id-free-path.expect.yaml
@@ -1,0 +1,6 @@
+status: error
+error_tag: TypeErrorUnifyTerms
+message_contains:
+  - cannot unify
+regression_for:
+  - unify-id-compares-underlying-types

--- a/rzk/test/typecheck/cases/ill-unify-id-free-path.rzk
+++ b/rzk/test/typecheck/cases/ill-unify-id-free-path.rzk
@@ -1,0 +1,20 @@
+#lang rzk-1
+
+-- Identity types over different types must not be unified even when their
+-- endpoints agree. Here `hom A x y` is a subtype of `Δ¹ → A` (its elements are
+-- exactly the functions with the given boundary), so `f` and `g` inhabit both;
+-- but a path in `(t : Δ¹) → A` is a free homotopy, while a path in
+-- `hom A x y` fixes the endpoints. Accepting `q` below transports a free
+-- homotopy into the endpoint-fixing path type, which is unsound. rzk used to
+-- accept this (the type components of the identity types were not compared).
+#define Δ¹ : (2 → TOPE)
+  := \ t → TOP
+
+#define hom (A : U) (x y : A)
+  : U
+  := (t : Δ¹) → A [t ≡ 0₂ ↦ x, t ≡ 1₂ ↦ y]
+
+#define narrow (A : U) (x y : A) (f g : hom A x y)
+  (q : f =_{(t : Δ¹) → A} g)
+  : f =_{hom A x y} g
+  := q


### PR DESCRIPTION
The `TypeIdT` case of `unifyInCurrentContext` never compared the underlying types of two identity types (a `TODO` in the source), so identity types over different types were equated whenever their endpoints unified. For example, a free homotopy (a path in `Δ¹ → A`) was accepted where an endpoint-fixing one (a path in `hom A x y`) is expected:

```rzk
#def free-htpy-as-fixed
  ( A : U)
  ( x y : A)
  ( f g : hom A x y)
  ( p : f =_{Δ¹ → A} g)
  : f =_{hom A x y} g
  := p
```

This PR compares the underlying types, invariantly, so that subtyping does not leak into equality of identity types. Adds the `ill-unify-id-free-path` regression test.

**Depends on rzk-lang/sHoTT#172.** The sHoTT corpus relies on the missing comparison (or better type inference) in benign instances of the same pattern (a pair synthesised at a non-dependent Σ, compared through `Id` against the dependent one).