### PR TITLE
Remove per-query overhead from entailM

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1842,6 +1842,15 @@ traceStartAndFinish :: Show a => String -> a -> a
 traceStartAndFinish tag = trace ("start [" <> tag <> "]") .
   (\x -> trace ("finish [" <> tag <> "] with " <> show x) x)
 
+-- | Monadic 'all' that stops at the first failing element.
+allM :: Monad m => (a -> m Bool) -> [a] -> m Bool
+allM p = go
+  where
+    go []     = return True
+    go (x:xs) = p x >>= \case
+      False -> return False
+      True  -> go xs
+
 entailM :: Eq var => [ModalTope var] -> TermT var -> TypeCheck var Bool
 entailM modalTopes goal = do
   -- genTopes <- generateTopesForPointsM (allTopePoints goal)
@@ -1853,7 +1862,7 @@ entailM modalTopes goal = do
   prettyTope <- ppTermInContext goal
   traceTypeCheck Debug
     ("entail " <> intercalate ", " prettyTopes <> " |- " <> prettyTope) $
-      and <$> mapM (`solveRHSM` goal) topes'''
+      allM (`solveRHSM` goal) topes'''
 
 
 generateTopesForModalCubeVarsM :: Eq var => TypeCheck var [ModalTope var]
@@ -2157,9 +2166,9 @@ solveRHSM modalTopes goal =
       | solveRHS topes (topeEQT l r) -> return True
       | solveRHS topes (topeEQT l cube2_0T) -> return True
       | solveRHS topes (topeEQT r cube2_1T) -> return True
-    TopeAndT _ l r -> (&&)
-      <$> solveRHSM modalTopes l
-      <*> solveRHSM modalTopes r
+    TopeAndT _ l r -> solveRHSM modalTopes l >>= \case
+      False -> return False
+      True  -> solveRHSM modalTopes r
     _ | goal `elem` topes -> return True
     TopeInvT{} -> do
       goal' <- nfTope goal
@@ -2172,9 +2181,10 @@ solveRHSM modalTopes goal =
         TopeUninvT{} -> return False
         _            -> solveRHSM modalTopes goal'
     TopeOrT  _ l r -> do
-      l' <- solveRHSM modalTopes l
-      r' <- solveRHSM modalTopes r
-      if (l' || r')
+      found <- solveRHSM modalTopes l >>= \case
+        True  -> return True
+        False -> solveRHSM modalTopes r
+      if found
         then return True
         else do
           lems <- generateTopesForPointsM (allTopePoints goal)
@@ -2183,10 +2193,10 @@ solveRHSM modalTopes goal =
               withTope t = hidden ++ saturateTopes [] (plainTope t : accessible)
 
           case lems' of
-            TopeOrT _ t1 t2 : _ -> do
-              l'' <- solveRHSM (withTope t1) goal
-              r'' <- solveRHSM (withTope t2) goal
-              return (l'' && r'')
+            TopeOrT _ t1 t2 : _ ->
+              solveRHSM (withTope t1) goal >>= \case
+                False -> return False
+                True  -> solveRHSM (withTope t2) goal
             _ -> return False
     _ -> return False
 

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1858,11 +1858,14 @@ entailM modalTopes goal = do
   let topes'    = nubTermT (modalTopes <> discreteAxioms)
       topes''   = simplifyLHSwithDisjunctions topes'
   topes'''  <- mapM (fmap (saturateTopes (allTopePoints goal) . saturateBottom) . saturateInv) topes''
-  prettyTopes <- mapM ppTermInContext (map tTope (saturateTopes (allTopePoints goal) (simplifyLHS topes')))
-  prettyTope <- ppTermInContext goal
-  traceTypeCheck Debug
-    ("entail " <> intercalate ", " prettyTopes <> " |- " <> prettyTope) $
-      allM (`solveRHSM` goal) topes'''
+  asks verbosity >>= \case
+    Debug -> do
+      prettyTopes <- mapM ppTermInContext (map tTope (saturateTopes (allTopePoints goal) (simplifyLHS topes')))
+      prettyTope <- ppTermInContext goal
+      traceTypeCheck Debug
+        ("entail " <> intercalate ", " prettyTopes <> " |- " <> prettyTope) $
+          allM (`solveRHSM` goal) topes'''
+    _ -> allM (`solveRHSM` goal) topes'''
 
 
 generateTopesForModalCubeVarsM :: Eq var => TypeCheck var [ModalTope var]

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1318,6 +1318,13 @@ data ModalTope var = ModalTope
 
 data Context var = Context
   { localScopes            :: [ScopeInfo var]
+  , localDiscreteTopes     :: [ModalTope var]
+    -- ^ Discreteness axioms for the flat cube variables in scope (a flat
+    -- point of @2@ or @I@ is an endpoint). Maintained incrementally at
+    -- binder entry (see 'enterScopeMaybe'), so 'entailM' does not rescan
+    -- the whole context on every entailment query. A variable's modality
+    -- is fixed at binding time ('addModalityToScope' only touches
+    -- 'modAccum'), so entries never need to be revised.
   , localTopes             :: [ModalTope var]
   , localTopesNF           :: [ModalTope var]
   , localTopesNFUnion      :: [[ModalTope var]]
@@ -1386,6 +1393,7 @@ emptyTopeContext =
 emptyContext :: Context var
 emptyContext = Context
   { localScopes = [ScopeInfo Nothing []]
+  , localDiscreteTopes = []
   , localTopes = emptyTopeContext
   , localTopesNF = emptyTopeContext
   , localTopesNFUnion = [emptyTopeContext]
@@ -1868,21 +1876,8 @@ entailM modalTopes goal = do
     _ -> allM (`solveRHSM` goal) topes'''
 
 
-generateTopesForModalCubeVarsM :: Eq var => TypeCheck var [ModalTope var]
-generateTopesForModalCubeVarsM = do
-  infos <- asks varInfos
-  fmap (nubTermT . concat) $ forM infos $ \(var, info) ->
-    case varModality info of
-      Flat -> do
-        whnfT (varType info) >>= \case
-          Cube2T{} -> do
-            let pt = Pure var
-            return [plainTope (topeOrT (topeEQT pt cube2_0T) (topeEQT pt cube2_1T))]
-          CubeIT{} -> do
-            let pt = Pure var
-            return [plainTope (topeOrT (topeEQT pt cubeI_0T) (topeEQT pt cubeI_1T))]
-          _ -> return []
-      _ -> return []
+generateTopesForModalCubeVarsM :: TypeCheck var [ModalTope var]
+generateTopesForModalCubeVarsM = asks localDiscreteTopes
 
 entailTraceM :: Eq var => [ModalTope var] -> TermT var -> TypeCheck var Bool
 entailTraceM modalTopes goal = do
@@ -2355,15 +2350,25 @@ enterScopeContext orig md ty val context =
     }
     (S <$> context)
 
-enterScopeMaybe :: Binder -> TModality -> TermT var -> Maybe (TermT var) -> TypeCheck (Inc var) b -> TypeCheck var b
+enterScopeMaybe :: Eq var => Binder -> TModality -> TermT var -> Maybe (TermT var) -> TypeCheck (Inc var) b -> TypeCheck var b
 enterScopeMaybe orig md ty mval action = do
+  mDiscrete <- case md of
+    Flat -> whnfT ty >>= \case
+      Cube2T{} -> pure (Just (topeOrT (topeEQT z cube2_0T) (topeEQT z cube2_1T)))
+      CubeIT{} -> pure (Just (topeOrT (topeEQT z cubeI_0T) (topeEQT z cubeI_1T)))
+      _        -> pure Nothing
+    _ -> pure Nothing
   newContext <- asks (enterScopeContext orig md ty mval)
-  closeScope orig (runReaderT action newContext)
+  let newContext' = newContext
+        { localDiscreteTopes = maybe id ((:) . plainTope) mDiscrete (localDiscreteTopes newContext) }
+  closeScope orig (runReaderT action newContext')
+  where
+    z = Pure Z
 
-enterScope :: Binder -> TModality -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
+enterScope :: Eq var => Binder -> TModality -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
 enterScope orig md ty = enterScopeMaybe orig md ty Nothing
 
-enterScopeWithBind :: Binder -> TModality -> TermT var -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
+enterScopeWithBind :: Eq var => Binder -> TModality -> TermT var -> TermT var -> TypeCheck (Inc var) b -> TypeCheck var b
 enterScopeWithBind orig md ty val = enterScopeMaybe orig md ty (Just val)
 
 -- | Run a sub-scope computation and lift it back to the enclosing scope: close


### PR DESCRIPTION
`entailM` runs on every tope entailment query, so any tope-heavy code pays its overhead: every extension type application, `recOR`, and restriction check, tens of thousands of times per project. Two pieces of per-query work did not belong there:

1. `entailM` pretty-printed the saturated tope context and the goal for a Debug trace **even at normal verbosity**, where the strings are discarded. Now the payload is only built when verbosity is `Debug`.

2. `entailM` regenerated the discreteness axioms for flat cube variables (a flat point of `2` or `I` is an endpoint, needed e.g. for `(t : ♭ 2)` binders) by walking the entire context with a WHNF per variable. The walk grows with the number of top-level definitions, so in a large project every tope check in the thousandth `#def` scanned all preceding ones, and on modality-free code it returns nothing every time. The axioms are now kept in a `Context` field extended at binder entry; a variable's modality is fixed at binding time, so the entries never need revising, and they keep their previous order, so solver behaviour is unchanged.

Together with #272, sHoTT typechecks about 35% faster in wall-clock time.