### PR TITLE
Add a corpus benchmark harness

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,50 @@
+name: Bench harness
+
+# Keeps bench/bench.hs from bitrotting: compile the Stack script and
+# smoke-test the profile summariser against a fixture with a known answer.
+# No rzk build and no corpus clone: this is a compile-and-parse check only.
+on:
+  push:
+    branches: [develop]
+    paths:
+      - bench/**
+      - .github/workflows/bench.yml
+  pull_request:
+    branches: [develop]
+    paths:
+      - bench/**
+      - .github/workflows/bench.yml
+
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: "Compile bench.hs and smoke-test the summariser"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup Stack
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+
+      - name: 💾 Cache GHC and snapshot packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack
+          key: bench-stack-${{ runner.os }}-${{ hashFiles('bench/bench.hs') }}
+          restore-keys: bench-stack-${{ runner.os }}-
+
+      # `stack script` (unlike shebang execution) takes the snapshot on the
+      # command line; read it from the script's own header to keep one pin.
+      - name: 🔨 Compile bench/bench.hs
+        run: |
+          RESOLVER=$(sed -n 's/^ *--resolver \(.*\)$/\1/p' bench/bench.hs)
+          stack script --snapshot "$RESOLVER" --no-run --compile bench/bench.hs
+
+      - name: 🧪 Smoke-test the profile summariser
+        run: |
+          bench/bench.hs summary bench/testdata/sample.prof \
+            | grep -F 'tope solver share (inherited %time of outermost solver rows): 42.0%'

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,2 +1,3 @@
 corpora/
 results/
+!testdata/sample.prof

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+corpora/
+results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,51 @@
+# rzk benchmark harness
+
+Measures typechecking performance on pinned real-world corpora, so that
+optimisation work and releases carry before/after numbers. The harness is a
+single Haskell Stack script (`bench/bench.hs`, run on the workspace
+resolver); it needs only `stack`, `git`, and a built `rzk`.
+
+## Usage
+
+```sh
+bench/bench.hs run                  # 3 timed full-sHoTT runs, appended to the CSV
+bench/bench.hs run --quick          # prefix subset up to 05-segal-types
+bench/bench.hs run --runs 5 --rts "-N1" --label my-experiment
+bench/bench.hs profile              # profiled build + run, .prof summary
+bench/bench.hs summary FILE.prof    # summarise an existing profile
+bench/bench.hs setup                # just clone/pin the corpus
+```
+
+The rzk binary is the current Stack build by default (`stack build` first);
+set `RZK_BIN=/path/to/rzk` to benchmark any other binary. `profile` builds
+and uses the Stack profiling build (`--profile --ghc-options=-fprof-auto`)
+unless `RZK_BIN` points at one. Note that the `rzk_commit` CSV column
+records the repository `HEAD`; when `RZK_BIN` points at a binary built from
+elsewhere, use `--label` to say what was actually measured.
+
+## What is measured
+
+Each run is a fresh process; metrics come from the GHC RTS one-shot summary
+(`+RTS -t --machine-readable`, which is itself a `Read`-able Haskell
+association list): wall clock, mutator and GC wall time, total allocation,
+maximum live bytes (residency), memory in use, GC count, and wall-clock
+productivity. One CSV row per run is appended to `bench/results/results.csv`
+together with the rzk commit (with a `-dirty` marker for uncommitted source
+changes), rzk version, corpus commit, mode, and RTS options; the median wall
+time is printed.
+
+`profile` runs once under the cost-centre profiler, keeps the `.prof` under
+`bench/results/`, and prints the totals, the top flat cost centres, and the
+tope solver's inherited time share (summing flat times instead would badly
+under-count the solver, whose work is mostly attributed to the term-equality
+and substitution helpers it calls).
+
+## Corpora
+
+Corpora are declared in the `corpora` list at the top of `bench/bench.hs`
+(URL, pinned commit, quick-mode file selection) and cloned on demand into
+`bench/corpora/` (gitignored, as is `bench/results/`). The pin is checked
+out detached and must be clean. `--quick` typechecks an in-order prefix of
+the project instead of the whole corpus; for sHoTT it ends at
+`05-segal-types.rzk.md`, the file with the hardest tope-solver queries. To
+bump a pin, edit the `corpora` list.

--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -1,0 +1,372 @@
+#!/usr/bin/env stack
+{- stack script
+   --resolver lts-24.34
+   --package process
+   --package directory
+   --package filepath
+   --package time
+-}
+{-# LANGUAGE LambdaCase #-}
+
+-- Benchmark harness for the rzk typechecker. See bench/README.md.
+--
+--   bench/bench.hs run     [--quick] [--runs N] [--corpus NAME] [--rts "OPTS"] [--label STR]
+--   bench/bench.hs profile [--quick] [--corpus NAME]
+--   bench/bench.hs setup   [--corpus NAME]
+--
+-- The rzk binary is taken from $RZK_BIN if set, otherwise from the current
+-- Stack build ("run"/"setup") or the current Stack profiling build ("profile").
+
+import           Control.Monad      (forM, unless, when)
+import           Data.Char          (isSpace)
+import           Data.List          (isPrefixOf, isSuffixOf, sort)
+import           Data.Maybe         (fromMaybe)
+import           Data.Time          (defaultTimeLocale, formatTime,
+                                     getCurrentTime)
+import           System.Directory   (createDirectoryIfMissing, doesDirectoryExist,
+                                     doesFileExist, listDirectory, renameFile)
+import           System.Environment (getArgs, lookupEnv)
+import           System.Exit        (ExitCode (..), exitFailure)
+import           System.FilePath    ((</>))
+import           System.IO          (hPutStrLn, stderr)
+import           System.Process     (CreateProcess (..), proc,
+                                     readCreateProcessWithExitCode, readProcess)
+
+-- * Corpora
+
+data Corpus = Corpus
+  { corpusUrl    :: String
+  , corpusCommit :: String
+    -- | Files for --quick mode: directories with a file-name predicate,
+    -- expanded in order (sorted within each directory). A prefix of the
+    -- full project in dependency order.
+  , corpusQuick  :: [(FilePath, String -> Bool)]
+  }
+
+corpora :: [(String, Corpus)]
+corpora =
+  [ ( "sHoTT"
+    , Corpus
+        { corpusUrl    = "https://github.com/rzk-lang/sHoTT.git"
+        , corpusCommit = "5346e43807aad6a2dd17e645a8a6482b52b3cae3"
+          -- up to and including 05-segal-types, the solver-heaviest file
+        , corpusQuick  =
+            [ ("src/hott", const True)
+            , ("src/simplicial-hott", \name -> take 2 name `elem` ["02", "03", "04", "05"])
+            ]
+        }
+    )
+  ]
+
+-- * Options
+
+data Command = Setup | Run | Profile | Summary FilePath
+
+data Options = Options
+  { optQuick  :: Bool
+  , optRuns   :: Int
+  , optCorpus :: String
+  , optRts    :: [String]
+  , optLabel  :: String
+  }
+
+defaultOptions :: Options
+defaultOptions = Options False 3 "sHoTT" [] ""
+
+usage :: IO a
+usage = do
+  hPutStrLn stderr "usage: bench/bench.hs (setup | run | profile) \
+                   \[--quick] [--runs N] [--corpus NAME] [--rts \"OPTS\"] [--label STR]\n\
+                   \       bench/bench.hs summary FILE.prof"
+  exitFailure
+
+parseArgs :: [String] -> IO (Command, Options)
+parseArgs [] = usage
+parseArgs ["summary", file] = pure (Summary file, defaultOptions)
+parseArgs (cmdStr : rest) = do
+  cmd <- case cmdStr of
+    "setup"   -> pure Setup
+    "run"     -> pure Run
+    "profile" -> pure Profile
+    _         -> usage
+  opts <- go defaultOptions rest
+  pure (cmd, opts)
+  where
+    go opts []                     = pure opts
+    go opts ("--quick" : xs)       = go opts { optQuick = True } xs
+    go opts ("--runs" : n : xs)    = go opts { optRuns = read n } xs
+    go opts ("--corpus" : c : xs)  = go opts { optCorpus = c } xs
+    go opts ("--rts" : r : xs)     = go opts { optRts = words r } xs
+    go opts ("--label" : l : xs)   = go opts { optLabel = l } xs
+    go _ (arg : _)                 = do
+      hPutStrLn stderr ("unknown option: " <> arg)
+      usage
+
+-- * Small process helpers
+
+-- | Run a command in a directory; return (exit code, stdout <> stderr).
+runIn :: FilePath -> String -> [String] -> IO (ExitCode, String)
+runIn dir cmd args = do
+  (code, out, err) <-
+    readCreateProcessWithExitCode (proc cmd args) { cwd = Just dir } ""
+  pure (code, out <> err)
+
+-- | Run a command in a directory; die with the output on failure.
+runIn_ :: FilePath -> String -> [String] -> IO ()
+runIn_ dir cmd args = do
+  (code, out) <- runIn dir cmd args
+  case code of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> do
+      hPutStrLn stderr (cmd <> " " <> unwords args <> " failed:")
+      hPutStrLn stderr (unlines (lastN 5 (lines out)))
+      exitFailure
+
+git :: FilePath -> [String] -> IO String
+git dir args = trim <$> readProcess "git" (["-C", dir] ++ args) ""
+
+trim :: String -> String
+trim = dropWhile isSpace . reverse . dropWhile isSpace . reverse
+
+lastN :: Int -> [a] -> [a]
+lastN n xs = drop (length xs - n) xs
+
+-- * Paths and metadata
+
+repoRoot :: IO FilePath
+repoRoot = git "." ["rev-parse", "--show-toplevel"]
+
+rzkBin :: FilePath -> Bool -> IO FilePath
+rzkBin root profiling =
+  lookupEnv "RZK_BIN" >>= \case
+    Just bin -> pure bin
+    Nothing -> do
+      let pathArgs = ["path"] ++ ["--profile" | profiling] ++ ["--local-install-root"]
+      (_, out, _) <- readCreateProcessWithExitCode
+        (proc "stack" pathArgs) { cwd = Just root } ""
+      pure (trim out </> "bin" </> "rzk")
+
+rzkCommit :: FilePath -> IO String
+rzkCommit root = do
+  commit <- git root ["rev-parse", "--short=8", "HEAD"]
+  dirty  <- git root ["status", "--porcelain", "--", "rzk/src", "rzk/grammar", "rzk/app"]
+  pure (commit <> if null dirty then "" else "-dirty")
+
+-- * Corpus management
+
+lookupCorpus :: String -> IO Corpus
+lookupCorpus name = case lookup name corpora of
+  Just c  -> pure c
+  Nothing -> do
+    hPutStrLn stderr ("no such corpus: " <> name
+      <> " (known: " <> unwords (map fst corpora) <> ")")
+    exitFailure
+
+ensureCorpus :: FilePath -> String -> Corpus -> IO FilePath
+ensureCorpus benchDir name Corpus{corpusUrl = url, corpusCommit = commit} = do
+  let dir = benchDir </> "corpora" </> name
+  exists <- doesDirectoryExist (dir </> ".git")
+  unless exists $ do
+    putStrLn ("Cloning " <> name <> " from " <> url <> " ...")
+    runIn_ "." "git" ["clone", "--quiet", url, dir]
+  (haveCommit, _) <- runIn dir "git" ["cat-file", "-e", commit <> "^{commit}"]
+  when (haveCommit /= ExitSuccess) $
+    runIn_ dir "git" ["fetch", "--quiet", "origin"]
+  runIn_ dir "git" ["checkout", "--quiet", "--detach", commit]
+  status <- git dir ["status", "--porcelain"]
+  unless (null status) $ do
+    hPutStrLn stderr ("corpus checkout " <> dir <> " is not clean; refusing to run")
+    exitFailure
+  pure dir
+
+quickFiles :: FilePath -> Corpus -> IO [FilePath]
+quickFiles dir corpus =
+  fmap concat . forM (corpusQuick corpus) $ \(subdir, keep) -> do
+    names <- sort <$> listDirectory (dir </> subdir)
+    pure [ subdir </> name | name <- names, ".rzk.md" `isSuffixOf` name, keep name ]
+
+-- * Timed runs
+
+-- | The @+RTS -t --machine-readable@ one-shot summary is a Haskell-readable
+-- association list (after the leading command-line echo).
+readStats :: FilePath -> IO [(String, String)]
+readStats path = read . unlines . drop 1 . lines <$> readFile path
+
+stat :: String -> [(String, String)] -> String
+stat key stats = fromMaybe ("no such RTS stat: " <> key) (lookup key stats)
+
+csvHeader :: String
+csvHeader = "timestamp,host,rzk_commit,rzk_version,label,corpus,corpus_commit,\
+            \mode,rts,run,wall_s,mut_wall_s,gc_wall_s,alloc_bytes,\
+            \max_live_bytes,mem_in_use_bytes,num_gcs,productivity_wall"
+
+benchRun :: FilePath -> FilePath -> Options -> IO ()
+benchRun root benchDir opts = do
+  corpus <- lookupCorpus (optCorpus opts)
+  corpusDir <- ensureCorpus benchDir (optCorpus opts) corpus
+  let resultsDir = benchDir </> "results"
+      csv = resultsDir </> "results.csv"
+  createDirectoryIfMissing True resultsDir
+  bin <- rzkBin root False
+  binOk <- doesFileExist bin
+  unless binOk $ do
+    hPutStrLn stderr ("rzk binary not found at " <> bin <> " (build first, or set RZK_BIN)")
+    exitFailure
+  version <- trim <$> readProcess bin ["version"] ""
+  commit <- rzkCommit root
+  files <- if optQuick opts then quickFiles corpusDir corpus else pure []
+  csvExists <- doesFileExist csv
+  unless csvExists $ writeFile csv (csvHeader <> "\n")
+
+  let mode = if optQuick opts then "quick" else "full"
+      rts  = if null (optRts opts) then "default" else unwords (optRts opts)
+  putStrLn ("rzk " <> version <> " (" <> commit <> ") on " <> optCorpus opts
+    <> "/" <> mode <> ", " <> show (optRuns opts) <> " run(s), RTS: " <> rts)
+
+  walls <- forM [1 .. optRuns opts] $ \i -> do
+    let statsFile = resultsDir </> ".stats.tmp"
+        args = ["typecheck"] ++ files
+            ++ ["+RTS"] ++ optRts opts
+            ++ ["-t" <> statsFile, "--machine-readable", "-RTS"]
+    (code, out) <- runIn corpusDir bin args
+    case code of
+      ExitSuccess -> pure ()
+      ExitFailure _ -> do
+        hPutStrLn stderr "typecheck FAILED; last lines of output:"
+        hPutStrLn stderr (unlines (lastN 5 (lines out)))
+        exitFailure
+    stats <- readStats statsFile
+    let field = (`stat` stats)
+        row = [ field "total_wall_seconds", field "mut_wall_seconds"
+              , field "GC_wall_seconds", field "allocated_bytes"
+              , field "max_live_bytes", field "max_mem_in_use_bytes"
+              , field "num_GCs", field "productivity_wall_percent" ]
+    timestamp <- formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" <$> getCurrentTime
+    host <- trim <$> readProcess "hostname" ["-s"] ""
+    appendFile csv (commas
+      ([ timestamp, host, commit, version, optLabel opts, optCorpus opts
+       , corpusCommit corpus, mode, rts, show i ] ++ row) <> "\n")
+    putStrLn ("  run " <> show i <> ": wall " <> field "total_wall_seconds"
+      <> "s (mut " <> field "mut_wall_seconds" <> "s, gc " <> field "GC_wall_seconds"
+      <> "s), alloc " <> field "allocated_bytes"
+      <> ", max live " <> field "max_live_bytes")
+    pure (read (field "total_wall_seconds") :: Double)
+
+  putStrLn ("median wall: " <> show (median walls) <> "s   (appended to " <> csv <> ")")
+  where
+    commas = foldr1 (\x acc -> x <> "," <> acc)
+    median xs =
+      let ys = sort xs
+          n  = length ys
+      in if odd n then ys !! (n `div` 2)
+                  else (ys !! (n `div` 2 - 1) + ys !! (n `div` 2)) / 2
+
+-- * Profiled runs
+
+benchProfile :: FilePath -> FilePath -> Options -> IO ()
+benchProfile root benchDir opts = do
+  corpus <- lookupCorpus (optCorpus opts)
+  corpusDir <- ensureCorpus benchDir (optCorpus opts) corpus
+  let resultsDir = benchDir </> "results"
+  createDirectoryIfMissing True resultsDir
+  external <- lookupEnv "RZK_BIN"
+  bin <- case external of
+    Just b  -> pure b
+    Nothing -> do
+      putStrLn "Building the profiling build (stack build --profile --ghc-options=-fprof-auto) ..."
+      runIn_ root "stack" ["build", "--profile", "--ghc-options=-fprof-auto"]
+      rzkBin root True
+  commit <- rzkCommit root
+  files <- if optQuick opts then quickFiles corpusDir corpus else pure []
+  let mode = if optQuick opts then "quick" else "full"
+      prof = resultsDir </> ("rzk-" <> commit <> "-" <> optCorpus opts <> "-" <> mode <> ".prof")
+  putStrLn ("Profiled run on " <> optCorpus opts <> "/" <> mode
+    <> " (this is a few times slower than a plain run) ...")
+  (code, out) <- runIn corpusDir bin (["typecheck"] ++ files ++ ["+RTS", "-p", "-RTS"])
+  case code of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> do
+      hPutStrLn stderr "profiled typecheck FAILED; last lines of output:"
+      hPutStrLn stderr (unlines (lastN 5 (lines out)))
+      exitFailure
+  renameFile (corpusDir </> "rzk.prof") prof
+  putStrLn ("profile written to " <> prof)
+  profSummary prof
+
+-- * Cost-centre profile summary
+
+-- | Print the totals, the top flat cost centres, and the tope solver's
+-- inherited share: the summed inherited %time of the outermost solver rows
+-- in the call tree. Summing the flat (individual) %time instead
+-- under-counts badly, because most of the solver's work is attributed to
+-- the generic helpers it calls (term equality, substitution).
+profSummary :: FilePath -> IO ()
+profSummary path = do
+  content <- lines <$> readFile path
+  mapM_ (putStrLn . trim)
+    [ l | l <- take 8 content, "total time" `isPrefixOf` trim l
+                            || "total alloc" `isPrefixOf` trim l ]
+  case [ i | (i, l) <- zip [0 ..] content, "COST CENTRE" `isPrefixOf` l ] of
+    (flatHeader : treeHeader : _) -> do
+      let topFlat = 20
+          flatSection = takeWhile (not . null . trim)
+            (dropWhile (null . trim) (drop (flatHeader + 1) content))
+      putStrLn ("\ntop " <> show topFlat <> " flat cost centres (individual %time, %alloc):")
+      mapM_ (putStrLn . ("  " <>)) (take topFlat flatSection)
+      let share = solverShare (drop (treeHeader + 1) content)
+      putStrLn ("\ntope solver share (inherited %time of outermost solver rows): "
+        <> show share <> "%")
+    _ -> do
+      hPutStrLn stderr "unrecognised .prof layout"
+      exitFailure
+
+solverNames :: [String]
+solverNames =
+  [ "entailM", "entail", "solveRHSM", "solveRHS", "saturateTopes"
+  , "saturateBottom", "saturateInv", "saturateWith", "allTopePoints" ]
+
+isSolverCentre :: String -> Bool
+isSolverCentre name =
+  base `elem` solverNames || "generateTopes" `isPrefixOf` base
+  where base = takeWhile (/= '.') name
+
+-- | Walk the indented call tree, keeping a stack of (depth, under a solver
+-- row); sum the inherited %time (second-to-last column) of solver rows with
+-- no solver ancestor.
+solverShare :: [String] -> Double
+solverShare = go [] 0
+  where
+    go _ acc [] = fromIntegral (round (acc * 10) :: Integer) / 10
+    go stack acc (line : rest)
+      | null (trim line) = go stack acc rest
+      | otherwise =
+          let depth = length (takeWhile (== ' ') line)
+
+              cols = words line
+              name = concat (take 1 cols)
+              stack' = dropWhile (\(d, _) -> d >= depth) stack
+              underSolver = any snd stack'
+              isSolver = isSolverCentre name
+              acc' = case reverse cols of
+                (_ : inherited : _)
+                  | isSolver && not underSolver
+                  , [(t, "")] <- reads inherited -> acc + t
+                _ -> acc
+          in go ((depth, isSolver || underSolver) : stack') acc' rest
+
+-- * Main
+
+main :: IO ()
+main = do
+  (cmd, opts) <- getArgs >>= parseArgs
+  root <- repoRoot
+  let benchDir = root </> "bench"
+  case cmd of
+    Setup -> do
+      corpus <- lookupCorpus (optCorpus opts)
+      dir <- ensureCorpus benchDir (optCorpus opts) corpus
+      putStrLn ("corpus " <> optCorpus opts <> " ready at " <> dir
+        <> " (" <> corpusCommit corpus <> ")")
+    Run          -> benchRun root benchDir opts
+    Profile      -> benchProfile root benchDir opts
+    Summary file -> profSummary file

--- a/bench/testdata/sample.prof
+++ b/bench/testdata/sample.prof
@@ -1,0 +1,25 @@
+	Sat Jul 12 00:00 2026 Time and Allocation Profiling Report  (Final)
+
+	   rzk +RTS -p -RTS typecheck
+
+	total time  =        1.00 secs   (1000 ticks @ 1000 us, 1 processor)
+	total alloc =   1,000,000 bytes  (excludes profiling overheads)
+
+COST CENTRE     MODULE          SRC                         %time %alloc
+
+==              Free.Scoped     src/Free/Scoped.hs:24        17.9    0.0
+entailM         Rzk.TypeCheck   src/Rzk/TypeCheck.hs:1845     5.0    1.0
+
+                                                                                          individual      inherited
+COST CENTRE       MODULE          SRC                         no.  entries  %time %alloc   %time %alloc
+
+MAIN              MAIN            <built-in>                  128        0    0.1    0.0   100.0  100.0
+ main             Main            app/Main.hs:10              257        0    0.0    0.0    99.0   99.0
+  typecheck       Rzk.TypeCheck   src/Rzk/TypeCheck.hs:100    300     1000    1.0    1.0    60.0   50.0
+   entailM        Rzk.TypeCheck   src/Rzk/TypeCheck.hs:1845   301      500    2.0    1.0    30.0   20.0
+    ==            Free.Scoped     src/Free/Scoped.hs:24       302     9000   10.0    5.0    10.0    5.0
+    solveRHSM     Rzk.TypeCheck   src/Rzk/TypeCheck.hs:2120   303      800    5.0    5.0    15.0   10.0
+   unify          Rzk.TypeCheck   src/Rzk/TypeCheck.hs:2500   304      200    1.0    1.0    20.0   15.0
+    checkTope     Rzk.TypeCheck   src/Rzk/TypeCheck.hs:2219   305      100    1.0    1.0    12.0    8.0
+     entailM      Rzk.TypeCheck   src/Rzk/TypeCheck.hs:1845   306      100    1.0    1.0    10.0    7.0
+  saturateTopes   Rzk.TypeCheck   src/Rzk/TypeCheck.hs:1887   307       50    1.0    1.0     2.0    1.0


### PR DESCRIPTION
Optimisation work and releases need before/after numbers. `bench/bench.hs` is a single Haskell Stack script (workspace resolver, no package changes):

- `run` typechecks a pinned corpus (sHoTT to start) in a fresh process per run and appends RTS metrics (wall clock, mutator/GC split, allocation, max residency) to a CSV ledger keyed by rzk commit and corpus commit
- `--quick` option typechecks an in-order prefix ending at `05-segal-types.rzk.md` for the inner loop
- `profile` produces a cost-centre profile and summarises it (top flat cost centres and the tope solver's inherited time share)
- `summary` does the same for an existing `.prof`

```sh
bench/bench.hs run --quick
```

```
rzk 0.9.1 (6fe3c393) on sHoTT/quick, 3 run(s), RTS: default
  run 1: wall 5.86s (mut 3.31s, gc 2.54s), alloc 17030358624, max live 1236950072
  ...
median wall: 5.86s   (appended to bench/results/results.csv)
```