### PR TITLE
Drop macos-15-intel from the PR matrix

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -39,14 +39,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Full OS coverage on PRs (the pre-merge gate), tags, and main;
-        # Linux-only on develop pushes, which a PR has already validated on all
-        # OS. The Linux build still produces the artifact downstream jobs use.
+        # Full OS coverage on tags and main. PRs (the pre-merge gate) skip
+        # macos-15-intel: the Intel runner pool is small and slow, its caches
+        # rarely survive, and an Intel-macOS-only breakage is still caught
+        # before users see it, by the tag run here and by the release
+        # workflow. Linux-only on develop pushes, which a PR has already
+        # validated; the Linux build still produces the artifact downstream
+        # jobs use.
         os: >-
-          ${{ (github.event_name == 'pull_request'
-               || github.ref_name == 'main'
+          ${{ (github.ref_name == 'main'
                || startsWith(github.ref, 'refs/tags/'))
               && fromJSON('["ubuntu-latest","windows-latest","macos-15-intel","macos-latest"]')
+              || github.event_name == 'pull_request'
+              && fromJSON('["ubuntu-latest","windows-latest","macos-latest"]')
               || fromJSON('["ubuntu-latest"]') }}
 
     steps:


### PR DESCRIPTION
On PRs, the `macos-15-intel` job routinely dominates the time to green: the Intel runner pool is small (long queues) and its caches rarely survive. What the lane checks on a PR is only the intersection of macOS and x86_64; `macos-latest` already covers macOS behaviour and `ubuntu`/`windows` cover x86_64.

PRs now run `ubuntu-latest`, `windows-latest`, and `macos-latest`. The full four-OS matrix still runs on `main` and on tag pushes, and the release workflow builds the Intel binaries independently, so an Intel-macOS-only breakage is still caught before users see it. Intel macOS release binaries keep shipping unchanged.