### PR TITLE
CI: seed Windows/macOS stack caches from develop and clean up PR caches

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,34 @@
+name: Cleanup PR caches
+
+# A closed PR leaves its Actions caches (~2 GiB of stack deps per PR for the
+# Windows/macOS lanes) parked on its refs/pull/N/merge ref, where no other
+# run can restore them. The repo cache quota is 10 GiB, so stale PR caches
+# evict the shared develop-ref caches. Delete a PR's caches when it closes.
+#
+# pull_request_target (not pull_request) so the token keeps write permission
+# for PRs from forks; this is safe because the job never checks out or runs
+# PR code.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    name: "Delete this PR's Actions caches"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧹 Delete caches on refs/pull/${{ github.event.pull_request.number }}/merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh api --paginate \
+            "/repos/${{ github.repository }}/actions/caches?ref=${REF}&per_page=100" \
+            --jq '.actions_caches[].id' \
+          | while read -r id; do
+              gh api --method DELETE "/repos/${{ github.repository }}/actions/caches/${id}" \
+                && echo "deleted cache ${id}"
+            done

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -39,20 +39,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Full OS coverage on tags and main. PRs (the pre-merge gate) skip
-        # macos-15-intel: the Intel runner pool is small and slow, its caches
-        # rarely survive, and an Intel-macOS-only breakage is still caught
-        # before users see it, by the tag run here and by the release
-        # workflow. Linux-only on develop pushes, which a PR has already
-        # validated; the Linux build still produces the artifact downstream
-        # jobs use.
+        # Full OS coverage on tags and main. Everything else (PRs and develop
+        # pushes) skips macos-15-intel: the Intel runner pool is small and
+        # slow, its caches rarely survive, and an Intel-macOS-only breakage
+        # is still caught before users see it, by the tag run here and by the
+        # release workflow. develop pushes build the same trio as PRs even
+        # though a PR has already validated them: GitHub only lets a PR
+        # restore caches created on its own ref or on the base branch, so
+        # without develop-side builds the Windows/macOS stack caches are
+        # never shared and every new PR starts those jobs cold.
         os: >-
           ${{ (github.ref_name == 'main'
                || startsWith(github.ref, 'refs/tags/'))
               && fromJSON('["ubuntu-latest","windows-latest","macos-15-intel","macos-latest"]')
-              || github.event_name == 'pull_request'
-              && fromJSON('["ubuntu-latest","windows-latest","macos-latest"]')
-              || fromJSON('["ubuntu-latest"]') }}
+              || fromJSON('["ubuntu-latest","windows-latest","macos-latest"]') }}
 
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
The Windows and macOS jobs on PRs report "no cache found" because no cache exists where they are allowed to look. A PR can only restore caches created on its own ref or on its base branch, and `develop` pushes built Linux only, so every Windows/macOS stack cache in the repo sits on some other PR's `refs/pull/N/merge` ref, unreachable.

`develop` pushes now build the same three-OS trio as PRs, so the shared develop-ref caches exist and refresh on every merge.

The repo also sits at its 10 GiB cache quota, with each closed PR leaving ~2 GiB of unreachable stack caches behind that evict the useful ones. A new `cache-cleanup.yml` deletes a PR's caches when it closes (`pull_request_target` so the token keeps write permission for fork PRs; the job runs no PR code).