### PR TITLE
Check name shadowing without embedding global payloads

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -1795,9 +1795,20 @@ ppContext' dir ctx@Context{..} = block dir $ dropWhile null
     -- a pattern binder is shown as its pattern, e.g. (t , s); others by name
     dispName x = maybe (show (Pure x :: Term')) (show . binderDisplayName) (lookup x fbs)
 
+-- | All display names in scope, read off the raw entries: a binder
+-- ('varOrig') never mentions the scope's variables, so no global payload
+-- needs embedding. Going through 'varOrigs' here instead embedded every
+-- global 'VarInfo' once per new top-level name ('checkTopLevelDuplicate'),
+-- quadratically over a project.
+scopeNames :: Context var -> [VarIdent]
+scopeNames Context{..} = mapMaybe entryName (concatMap scopeVars localScopes)
+  <> mapMaybe entryName (concatMap gscopeVars globalScopes)
+  where
+    entryName :: (v, VarInfo w) -> Maybe VarIdent
+    entryName = binderName . varOrig . snd
+
 doesShadowName :: VarIdent -> TypeCheck var [VarIdent]
-doesShadowName name = asks $ \ctx ->
-  filter (name ==) (mapMaybe snd (varOrigs ctx))
+doesShadowName name = asks (filter (name ==) . scopeNames)
 
 checkTopLevelDuplicate :: VarIdent -> TypeCheck var ()
 checkTopLevelDuplicate name = do


### PR DESCRIPTION
Every `#define` checks its name against everything already in scope (`checkTopLevelDuplicate`). Since the global-scope split (#277) that check embedded every global `VarInfo` into the current scope just to read its display name, once per new top-level name: quadratic embedding over a project.

A binder (`varOrig`) never mentions the scope's variables, so the names can be read off the raw entries directly. The new `scopeNames` does that; `doesShadowName` uses it.

On sHoTT `main`: allocation 39.9 GB → 36.1 GB (−10%), median wall time 14.45 s → 14.00 s (−3%).