### PR TITLE
Language Server reporting checking progress

### DIFF
--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -107,6 +107,7 @@ library:
         - Language.Rzk.VSCode.ReferenceIndex
       dependencies:
         aeson: ">= 2.0.0.0 && < 3"
+        async: ">= 2.2 && < 3"
         co-log-core: ">= 0.3.2.0 && < 1"
         containers: ">= 0.6 && < 1"
         data-default-class: ">= 0.1.2.0 && < 1"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -305,6 +305,7 @@ library
         Language.Rzk.VSCode.ReferenceIndex
     build-depends:
         aeson >=2.0.0.0 && <3
+      , async >=2.2 && <3
       , co-log-core >=0.3.2.0 && <1
       , containers >=0.6 && <1
       , data-default-class >=0.1.2.0 && <1

--- a/rzk/src/Language/Rzk/VSCode/Env.hs
+++ b/rzk/src/Language/Rzk/VSCode/Env.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Language.Rzk.VSCode.Env where
 
+import           Control.Concurrent.Async   (Async, async, cancel)
 import           Control.Concurrent.STM
+import           Control.Exception          (catch)
 import           Control.Monad.Reader
 import qualified Data.Map.Strict            as Map
 import qualified Data.Text                  as T
@@ -8,6 +11,7 @@ import           Language.LSP.Server
 import           Language.Rzk.Free.Syntax   (VarIdent)
 import           Language.Rzk.Syntax        (Module)
 import qualified Language.Rzk.VSCode.Config as RzkConfig
+import           Language.Rzk.VSCode.Logging
 import qualified Language.Rzk.VSCode.ReferenceIndex as RefInd
 import           Rzk.TypeCheck              (Decl', TypeErrorInScopedContext)
 
@@ -52,18 +56,42 @@ emptyReferenceIndexCache = ReferenceIndexCache Map.empty Nothing
 data RzkEnv = RzkEnv
   { rzkEnvTypecheckCache      :: TVar RzkTypecheckCache
   , rzkEnvReferenceIndexCache :: TVar ReferenceIndexCache
+  , rzkEnvTypecheckWorker     :: TVar (Maybe (Async ()))
+    -- ^ The thread running the current project typecheck, if any.
   }
 
 defaultRzkEnv :: IO RzkEnv
 defaultRzkEnv = do
   typecheckCache <- newTVarIO []
   referenceIndexCache <- newTVarIO emptyReferenceIndexCache
+  typecheckWorker <- newTVarIO Nothing
   return RzkEnv
     { rzkEnvTypecheckCache = typecheckCache
     , rzkEnvReferenceIndexCache = referenceIndexCache
+    , rzkEnvTypecheckWorker = typecheckWorker
     }
 
 type LSP = LspT RzkConfig.ServerConfig (ReaderT RzkEnv IO)
+
+-- | Run the given action (a project typecheck) on a fresh worker thread,
+-- cancelling the previous worker first. Cancellation waits for the old
+-- worker to stop, so it can no longer write to the caches once the new
+-- one starts. Typechecking runs on a worker so that the handler dispatch
+-- thread stays responsive: 'lsp' dispatches messages sequentially, so a
+-- multi-second re-check run directly in a notification handler would
+-- block every later request (e.g. formatting on save).
+spawnTypecheckWorker :: LSP () -> LSP ()
+spawnTypecheckWorker action = do
+  lspEnv <- getLspEnv
+  rzkEnv <- lift ask
+  let run act = runReaderT (runLspT lspEnv act) rzkEnv
+  liftIO $ do
+    oldWorker <- atomically $ swapTVar (rzkEnvTypecheckWorker rzkEnv) Nothing
+    mapM_ cancel oldWorker
+    worker <- async $
+      run action `catch` \(_ :: ProgressCancelledException) ->
+        run (logInfo (T.pack "Typechecking was cancelled by the client"))
+    atomically $ writeTVar (rzkEnvTypecheckWorker rzkEnv) (Just worker)
 
 cacheTypecheckedModules :: RzkTypecheckCache -> LSP ()
 cacheTypecheckedModules cache = lift $ do

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -24,7 +24,7 @@ module Language.Rzk.VSCode.Handlers (
 import           Control.Applicative           ((<|>))
 import           Control.Exception             (SomeException, evaluate, try)
 import           Control.Lens
-import           Control.Monad                 (forM, forM_, when)
+import           Control.Monad                 (forM, forM_, unless, when)
 import           Control.Monad.Except          (ExceptT (ExceptT),
                                                 MonadError (throwError),
                                                 modifyError, runExceptT)
@@ -33,7 +33,6 @@ import           Data.Default.Class
 import           Data.List                     (find, intercalate, isSuffixOf,
                                                 nub, sort, (\\))
 import qualified Data.Map.Strict               as Map
-import qualified Data.List.NonEmpty            as NE
 import           Data.Maybe                    (fromMaybe, isNothing)
 import qualified Data.Text                     as T
 import qualified Data.Yaml                     as Yaml
@@ -148,8 +147,7 @@ typecheckFromConfigFile = do
           rawPaths <- liftIO $ globDir (map compile (include config)) rootPath
           let paths = concatMap sort rawPaths
 
-          typecheckedCachedModules <- getCachedTypecheckedModules
-          let cachedModules = map (\(path, RzkCachedModule{..}) -> (path, cachedModuleDecls)) typecheckedCachedModules
+          cachedModules <- getCachedTypecheckedModules
           let cachedPaths = map fst cachedModules
               modifiedFiles = paths \\ cachedPaths
 
@@ -157,56 +155,80 @@ typecheckFromConfigFile = do
           logDebug (tshow (length modifiedFiles) <> " files have been modified")
 
           (parseErrors, parsedModules) <- liftIO $ collectErrors <$> parseFiles modifiedFiles
-          -- Run in lenient hole mode so holes are collected (and surfaced as
-          -- hints) rather than reported as errors while editing.
-          tcResults <- liftIO $ try $ evaluate $
-            defaultTypeCheckWithHoles (typecheckModulesWithLocationIncremental cachedModules parsedModules)
-
-          (typeErrors, holeInfos) <- case tcResults of
-            Left (ex :: SomeException) -> do
-              -- Just a warning to be logged in the "Output" panel and not shown to the user as an error message
-              --  because exceptions are expected when the file has invalid syntax
-              logWarning ("Encountered an exception while typechecking:\n" <> tshow ex)
-              return ([], [])
-            Right (Left err) -> do
-              logError ("An impossible error happened! Please report a bug:\n" <> T.pack (ppTypeErrorInScopedContext' BottomUp err))
-              return ([err], [])    -- sort of impossible
-            Right (Right ((checkedModules, errors), foundHoles)) -> do
-                -- cache well-typed modules
-                logInfo (tshow (length checkedModules) <> " modules successfully typechecked")
-                logInfo (tshow (length errors) <> " errors found")
-                logInfo (tshow (length foundHoles) <> " holes found")
-                let checkedModules' = map (\(path, decls) -> (path, RzkCachedModule decls (filter ((== path) . filepathOfTypeError) errors))) checkedModules
-                cacheTypecheckedModules checkedModules'
-                return (errors, foundHoles)
-
-          -- Reset all published diags
-          -- TODO: remove this after properly grouping by path below, after which there can be an empty list of errors
-          -- TODO: handle clearing diagnostics for files that got removed from the project (rzk.yaml)
-          forM_ modifiedFiles $ \path -> do
-            publishDiagnostics 0 (filePathToNormalizedUri path) Nothing (partitionBySource [])
 
           -- Report parse errors to the client
           forM_ parseErrors $ \(path, err) -> do
             publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing (partitionBySource [diagnosticOfParseError err])
 
-          -- Report typechecking errors and holes to the client, grouped by file
-          -- so all diagnostics for a file are published in a single call
-          -- (publishDiagnostics replaces a source's diagnostics per URI, so
-          -- publishing them one at a time would clobber all but the last).
-          let errDiagnostics  = [ (filepathOfTypeError err, diagnosticOfTypeError err)
-                                | err <- typeErrors ]
-              holeDiagnostics = [ (path, diagnosticOfHole hole)
-                                | hole <- holeInfos
-                                , Just path <- [holeLocation hole >>= locationFilePath] ]
-              -- group by file path (NE.groupAllWith sorts then groups, and
-              -- yields NonEmpty groups so taking the key is total)
-              diagnosticsByFile =
-                map (\grp -> (fst (NE.head grp), map snd (NE.toList grp))) $
-                NE.groupAllWith fst (errDiagnostics <> holeDiagnostics)
-          forM_ diagnosticsByFile $ \(path, diags) ->
-            publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing (partitionBySource diags)
+          -- Typecheck the modified modules one at a time on top of the cached
+          -- prefix, reporting progress to the client. Each module is cached
+          -- and its diagnostics are published as soon as it is checked, so a
+          -- cancelled run keeps the modules it has finished and the next run
+          -- continues from there.
+          unless (null parsedModules) $
+            withProgress "rzk typechecking" Nothing Cancellable $ \reportProgress ->
+              checkModules reportProgress rootPath cachedModules parsedModules
   where
+    checkModules
+      :: (ProgressAmount -> LSP ())
+      -> FilePath                -- ^ Workspace root (for progress messages).
+      -> RzkTypecheckCache       -- ^ Cached results for the unchanged prefix.
+      -> [(FilePath, Module)]    -- ^ Modified modules, in project order.
+      -> LSP ()
+    checkModules reportProgress rootPath cache modules = go (0 :: Int) cache modules
+      where
+        total = length modules
+
+        go _ _ [] = return ()
+        go i checked ((path, module_) : rest) = do
+          reportProgress (ProgressAmount
+            (Just (fromIntegral (100 * i `div` total)))
+            (Just (T.pack (makeRelative rootPath path))))
+          -- Run in lenient hole mode so holes are collected (and surfaced as
+          -- hints) rather than reported as errors while editing.
+          tcResult <- liftIO $ try $ evaluate $
+            defaultTypeCheckWithHoles $ typecheckModulesWithLocationIncremental
+              (map (fmap cachedModuleDecls) checked) [(path, module_)]
+          case tcResult of
+            Left (ex :: SomeException) ->
+              -- Just a warning to be logged in the "Output" panel and not shown to the user as an error message
+              --  because exceptions are expected when the file has invalid syntax
+              logWarning ("Encountered an exception while typechecking:\n" <> tshow ex)
+            Right (Left err) -> do
+              logError ("An impossible error happened! Please report a bug:\n" <> T.pack (ppTypeErrorInScopedContext' BottomUp err))
+              publishModuleDiagnostics path [err] []    -- sort of impossible
+            Right (Right ((checkedModules, errors), holeInfos)) -> do
+              logDebug (T.pack path <> ": " <> tshow (length errors) <> " errors, "
+                <> tshow (length holeInfos) <> " holes")
+              let decls = fromMaybe [] (lookup path checkedModules)
+                  checked' = checked ++
+                    [(path, RzkCachedModule decls (filter ((== path) . filepathOfTypeError) errors))]
+              cacheTypecheckedModules checked'
+              publishModuleDiagnostics path errors holeInfos
+              -- Stop at the first module with errors, like the batch checker
+              -- ('typecheckModulesWithLocation'') does: later modules depend
+              -- on this one and would report cascading errors.
+              when (null errors) $
+                go (i + 1) checked' rest
+
+    -- Publish the diagnostics of one checked module, grouped by file so all
+    -- diagnostics for a file are published in a single call
+    -- (publishDiagnostics replaces a source's diagnostics per URI, so
+    -- publishing them one at a time would clobber all but the last). The
+    -- module's own file is always published, possibly with an empty list,
+    -- replacing stale diagnostics from the previous run.
+    publishModuleDiagnostics :: FilePath -> [TypeErrorInScopedContext VarIdent] -> [HoleInfo] -> LSP ()
+    publishModuleDiagnostics path typeErrors holeInfos = do
+      let errDiagnostics  = [ (filepathOfTypeError err, [diagnosticOfTypeError err])
+                            | err <- typeErrors ]
+          holeDiagnostics = [ (path', [diagnosticOfHole hole])
+                            | hole <- holeInfos
+                            , Just path' <- [holeLocation hole >>= locationFilePath] ]
+          diagnosticsByFile = Map.insertWith (flip (<>)) path [] $
+            Map.fromListWith (flip (<>)) (errDiagnostics <> holeDiagnostics)
+      forM_ (Map.toList diagnosticsByFile) $ \(path', diags) ->
+        publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path') Nothing (partitionBySource diags)
+
     filepathOfTypeError :: TypeErrorInScopedContext var -> FilePath
     filepathOfTypeError (PlainTypeError err) =
       case location (typeErrorContext err) >>= locationFilePath of

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -231,6 +231,11 @@ typecheckFromConfigFile = do
     -- publishing them one at a time would clobber all but the last). The
     -- module's own file is always published, possibly with an empty list,
     -- replacing stale diagnostics from the previous run.
+    --
+    -- An empty list needs care: the lsp diagnostic store unions the new
+    -- per-source map over the old one, and @partitionBySource []@ has no
+    -- "rzk" key, so the old diagnostics would survive and be re-sent. A
+    -- max count of 0 forces an empty publish to the client, clearing it.
     publishModuleDiagnostics :: FilePath -> [TypeErrorInScopedContext VarIdent] -> [HoleInfo] -> LSP ()
     publishModuleDiagnostics path typeErrors holeInfos = do
       let errDiagnostics  = [ (filepathOfTypeError err, [diagnosticOfTypeError err])
@@ -241,7 +246,8 @@ typecheckFromConfigFile = do
           diagnosticsByFile = Map.insertWith (flip (<>)) path [] $
             Map.fromListWith (flip (<>)) (errDiagnostics <> holeDiagnostics)
       forM_ (Map.toList diagnosticsByFile) $ \(path', diags) ->
-        publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path') Nothing (partitionBySource diags)
+        publishDiagnostics (if null diags then 0 else maxDiagnosticCount)
+          (filePathToNormalizedUri path') Nothing (partitionBySource diags)
 
     filepathOfTypeError :: TypeErrorInScopedContext var -> FilePath
     filepathOfTypeError (PlainTypeError err) =

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -174,6 +174,16 @@ typecheckFromConfigFile = do
           forM_ parseErrors $ \(path, err) -> do
             publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing (partitionBySource [diagnosticOfParseError err])
 
+          -- Files after the first parse error are not typechecked at all
+          -- ('collectErrors' stops collecting modules there); mark the ones
+          -- without a parse error of their own as blocked.
+          case parseErrors of
+            [] -> return ()
+            (blockingPath, _) : _ -> do
+              let reported = map fst parsedModules <> map fst parseErrors
+              publishBlockedDiagnostics rootPath blockingPath
+                (filter (`notElem` reported) modifiedFiles)
+
           -- Typecheck the modified modules one at a time on top of the cached
           -- prefix, reporting progress to the client. Each module is cached
           -- and its diagnostics are published as soon as it is checked, so a
@@ -204,13 +214,15 @@ typecheckFromConfigFile = do
             defaultTypeCheckWithHoles $ typecheckModulesWithLocationIncremental
               (map (fmap cachedModuleDecls) checked) [(path, module_)]
           case tcResult of
-            Left (ex :: SomeException) ->
+            Left (ex :: SomeException) -> do
               -- Just a warning to be logged in the "Output" panel and not shown to the user as an error message
               --  because exceptions are expected when the file has invalid syntax
               logWarning ("Encountered an exception while typechecking:\n" <> tshow ex)
+              publishBlockedDiagnostics rootPath path (map fst rest)
             Right (Left err) -> do
               logError ("An impossible error happened! Please report a bug:\n" <> T.pack (ppTypeErrorInScopedContext' BottomUp err))
               publishModuleDiagnostics path [err] []    -- sort of impossible
+              publishBlockedDiagnostics rootPath path (map fst rest)
             Right (Right ((checkedModules, errors), holeInfos)) -> do
               logDebug (T.pack path <> ": " <> tshow (length errors) <> " errors, "
                 <> tshow (length holeInfos) <> " holes")
@@ -221,9 +233,11 @@ typecheckFromConfigFile = do
               publishModuleDiagnostics path errors holeInfos
               -- Stop at the first module with errors, like the batch checker
               -- ('typecheckModulesWithLocation'') does: later modules depend
-              -- on this one and would report cascading errors.
-              when (null errors) $
-                go (i + 1) checked' rest
+              -- on this one and would report cascading errors. Mark the
+              -- modules this run will not reach.
+              if null errors
+                then go (i + 1) checked' rest
+                else publishBlockedDiagnostics rootPath path (map fst rest)
 
     -- Publish the diagnostics of one checked module, grouped by file so all
     -- diagnostics for a file are published in a single call
@@ -248,6 +262,31 @@ typecheckFromConfigFile = do
       forM_ (Map.toList diagnosticsByFile) $ \(path', diags) ->
         publishDiagnostics (if null diags then 0 else maxDiagnosticCount)
           (filePathToNormalizedUri path') Nothing (partitionBySource diags)
+
+    -- Modules that a run never reaches (they come after a module with an
+    -- error, and every rzk module depends on all earlier ones) get a single
+    -- warning diagnostic naming the blocker, instead of keeping whatever
+    -- diagnostics a previous run left behind. Warning severity keeps the
+    -- file visible in the explorer (yellow badge) while staying distinct
+    -- from a real error in the file itself. It is replaced by real
+    -- diagnostics once the blocker is fixed and the module is reached
+    -- again.
+    publishBlockedDiagnostics :: FilePath -> FilePath -> [FilePath] -> LSP ()
+    publishBlockedDiagnostics rootPath blockingPath notReached =
+      forM_ notReached $ \path ->
+        publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing
+          (partitionBySource [blockedDiagnostic])
+      where
+        blockedDiagnostic = Diagnostic
+          (Range (Position 0 0) (Position 0 99))
+          (Just DiagnosticSeverity_Warning)
+          (Just (InR "not-checked"))
+          Nothing                   -- diagnostic description
+          (Just "rzk")              -- A human-readable string describing the source of this diagnostic
+          ("Not checked: blocked by an error in " <> T.pack (makeRelative rootPath blockingPath))
+          Nothing                   -- tags
+          (Just [])                 -- related information
+          Nothing                   -- data that is preserved between different calls
 
     filepathOfTypeError :: TypeErrorInScopedContext var -> FilePath
     filepathOfTypeError (PlainTypeError err) =

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -647,15 +647,21 @@ dropWhileM p (x:xs) = do
     then dropWhileM p xs
     else return (x:xs)
 
+-- | The cache eviction and the re-typecheck run on the typecheck worker
+-- thread, so this handler returns immediately and later requests (e.g. a
+-- formatting request from format-on-save) are answered while the project
+-- re-check is still running. Spawning the worker cancels the previous one,
+-- so a newer change restarts the re-check.
 handleFilesChanged :: Handler LSP 'Method_WorkspaceDidChangeWatchedFiles
 handleFilesChanged msg = do
   let modifiedPaths = msg ^.. params . changes . traverse . uri . to uriToFilePath . _Just
-  if any ("rzk.yaml" `isSuffixOf`) modifiedPaths
-    then do
-      logDebug "rzk.yaml modified. Clearing module cache"
-      resetCacheForAllFiles
-    else do
-      cache <- getCachedTypecheckedModules
-      actualModified <- dropWhileM (hasNotChanged cache) modifiedPaths
-      resetCacheForFiles actualModified
-  typecheckFromConfigFile
+  spawnTypecheckWorker $ do
+    if any ("rzk.yaml" `isSuffixOf`) modifiedPaths
+      then do
+        logDebug "rzk.yaml modified. Clearing module cache"
+        resetCacheForAllFiles
+      else do
+        cache <- getCachedTypecheckedModules
+        actualModified <- dropWhileM (hasNotChanged cache) modifiedPaths
+        resetCacheForFiles actualModified
+    typecheckFromConfigFile

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -22,7 +22,9 @@ module Language.Rzk.VSCode.Handlers (
 ) where
 
 import           Control.Applicative           ((<|>))
-import           Control.Exception             (SomeException, evaluate, try)
+import           Control.Exception             (SomeAsyncException (..),
+                                                SomeException, evaluate,
+                                                fromException, throwIO, try)
 import           Control.Lens
 import           Control.Monad                 (forM, forM_, unless, when)
 import           Control.Monad.Except          (ExceptT (ExceptT),
@@ -74,6 +76,18 @@ import           Rzk.Format                    (format)
 import           Rzk.Project.Config            (ProjectConfig (include))
 import           Rzk.TypeCheck
 import           Text.Read                     (readMaybe)
+
+-- | Like 'try', but re-throws asynchronous exceptions (a worker restart) and
+-- 'ProgressCancelledException' (a client-side progress cancel; delivered by
+-- 'Control.Concurrent.Async.cancelWith', so 'fromException' does not classify
+-- it as asynchronous). Cancellation must abort the whole run instead of being
+-- reported as a typechecker failure of the current module.
+tryTypecheck :: IO a -> IO (Either SomeException a)
+tryTypecheck action = try action >>= \case
+  Left e
+    | Just (SomeAsyncException _) <- fromException e -> throwIO e
+    | Just cancelled <- fromException @ProgressCancelledException e -> throwIO cancelled
+  result -> return result
 
 -- | Given a list of file paths, reads them and parses them as Rzk modules,
 --   returning the same list of file paths but with the parsed module (or parse error)
@@ -186,7 +200,7 @@ typecheckFromConfigFile = do
             (Just (T.pack (makeRelative rootPath path))))
           -- Run in lenient hole mode so holes are collected (and surfaced as
           -- hints) rather than reported as errors while editing.
-          tcResult <- liftIO $ try $ evaluate $
+          tcResult <- liftIO $ tryTypecheck $ evaluate $
             defaultTypeCheckWithHoles $ typecheckModulesWithLocationIncremental
               (map (fmap cachedModuleDecls) checked) [(path, module_)]
           case tcResult of

--- a/rzk/src/Language/Rzk/VSCode/Lsp.hs
+++ b/rzk/src/Language/Rzk/VSCode/Lsp.hs
@@ -38,6 +38,10 @@ handlers =
         return () -- FIXME: typecheck standalone files (if they are not a part of the project)
     -- An empty hadler is needed to silence the error since it is already handled by the LSP package
     , notificationHandler SMethod_WorkspaceDidChangeConfiguration $ const $ pure ()
+    -- Progress cancellation is handled by the lsp library's bookkeeping (it
+    -- cancels the corresponding withProgress action); the empty handler only
+    -- silences the missing-handler warning.
+    , notificationHandler SMethod_WindowWorkDoneProgressCancel $ const $ pure ()
     , requestHandler SMethod_TextDocumentHover provideHover
     , requestHandler SMethod_TextDocumentDocumentSymbol provideSymbols
     , requestHandler SMethod_TextDocumentDefinition findDefinition 

--- a/rzk/src/Language/Rzk/VSCode/Lsp.hs
+++ b/rzk/src/Language/Rzk/VSCode/Lsp.hs
@@ -24,7 +24,8 @@ maxDiagnosticCount = 100
 handlers :: Handlers LSP
 handlers =
   mconcat
-    [ notificationHandler SMethod_Initialized $ const typecheckFromConfigFile
+    [ notificationHandler SMethod_Initialized $ const $
+        spawnTypecheckWorker typecheckFromConfigFile
     -- TODO: add logging
     -- Empty handlers to silence the errors
     , notificationHandler SMethod_TextDocumentDidOpen $ \_msg -> pure ()


### PR DESCRIPTION
Checking a large project (sHoTT takes ~13 s on my machine) used to give no editor feedback at all, and saving a file could hang the editor: the `lsp` library dispatches messages sequentially, so a format-on-save request queued behind the multi-second re-check running inline in the watched-files handler. This PR addresses both issues.

With this PR, VS Code shows a status-bar progress item during checking, e.g.

```
rzk typechecking: src/simplicial-hott/08-covariant.rzk.md
```

with a working **Cancel** button, and saving a file stays instant while the re-check runs in the background.

## Changes

- **Per-module checking with progress.** `typecheckFromConfigFile` drives the typecheck one module at a time through `typecheckModulesWithLocationIncremental` (the checker itself is pure, so a progress callback cannot live inside it) and reports the fraction of modules done via `withProgress` (`$/progress`). Each module is cached and its diagnostics published as soon as it is checked, so an interrupted run keeps the modules it has finished and the next run continues from there. This also implements the old TODO about grouping diagnostics by path: a checked module always gets exactly one publish (possibly empty), and the blanket diagnostics reset is gone.

- **Worker thread.** The project re-check (including the per-file change detection of `handleFilesChanged`) runs on a worker thread tracked in `RzkEnv`. Spawning cancels the previous worker and waits for it to stop before the new one starts, so a stale worker can never write to the caches after eviction, and a newer change simply restarts the re-check.

- **Cancellation.** The progress notification is cancellable from the client. The per-module exception guard re-throws asynchronous exceptions and `ProgressCancelledException`, so cancellation aborts the run instead of being reported as a typechecker failure of the current module.

- **Fixed diagnostics clearly.** A fixed module now actually clears its old error: the lsp diagnostic store unions the new per-source map over the old one, so publishing an empty list (no "rzk" key) silently kept and re-sent the old diagnostics. An empty publish now uses a max count of 0, which forces an empty list to the client.

- **Blocked modules are marked.** Checking stops at the first module with errors (and files after a parse error are not typechecked); each unreached module now gets one informational diagnostic naming the blocker, e.g. `Not checked: blocked by an error in src/hott/01-paths.rzk.md`, instead of keeping stale diagnostics. It is replaced by real diagnostics once the blocker is fixed.


https://github.com/user-attachments/assets/d7f27d75-0a60-4102-90ec-f071f9631100

