### PR TITLE
Hide unused anonymous binders in function types

### DIFF
--- a/rzk/src/Language/Rzk/Free/Syntax.hs
+++ b/rzk/src/Language/Rzk/Free/Syntax.hs
@@ -667,6 +667,13 @@ fromScope' x used xs = fromTermWith' (x : used) xs . (>>= f)
     f Z     = Pure x
     f (S z) = Pure z
 
+-- | Drop the binder of a scope that does not use it. The error is
+-- unreachable when 'Z' is not among the scope's free variables.
+unusedScope :: Scope Term var -> Term var
+unusedScope scope = scope >>= \case
+  Z   -> error "unusedScope: the bound variable is used"
+  S z -> Pure z
+
 -- | Like 'fromScope'', but additionally restores pattern-binder component names
 -- inside the scope: projections of the bound variable @x@ are folded back to
 -- the names recorded in @binder@ (e.g. @π₁ x@ becomes @t@). For a binder that
@@ -755,6 +762,12 @@ fromTermWith' used vars = go
 
       Hole mname -> Rzk.Hole loc (Rzk.HoleIdent loc (Rzk.HoleIdentToken (holeIdentToken mname)))
 
+      -- An anonymous binder that the return type does not use is not shown:
+      -- @(x₁ : A) → B@ reads better as @A → B@. A user-written name is kept
+      -- even when unused.
+      TypeFun (BinderVar Nothing) Id arg Nothing ret
+        | Z `notElem` freeVars ret ->
+            Rzk.TypeFun loc (Rzk.ParamType loc (go arg)) (go (unusedScope ret))
       TypeFun z Id arg Nothing ret -> withFreshBinder z $ \(x, z', xs) ->
         Rzk.TypeFun loc (Rzk.ParamTermType loc (patternToTerm (binderToPattern z')) (go arg)) (fromScopeBinder' z' x used xs ret)
       TypeFun z Id arg (Just tope) ret -> withFreshBinder z $ \(x, z', xs) ->

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -89,6 +89,17 @@ spec = do
           names (holeTermVars h) `shouldNotContain` ["t"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- Rendering: an anonymous binder that the return type does not use is
+    -- not shown ("U → U" rather than "(x₁ : U) → U"), while a user-written
+    -- name is kept even when unused.
+    it "hides unused anonymous binders in rendered types" $ do
+      case holesOf "#lang rzk-1\n#define mp : (A : U) -> (B : U) -> A -> (A -> B) -> B := ?\n" of
+        [h] -> show (holeGoal h) `shouldBe` "(A : U) → (B : U) → A → (A → B) → B"
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+      case holesOf "#lang rzk-1\n#define keep : (x : U) -> U -> U := ?\n" of
+        [h] -> show (holeGoal h) `shouldBe` "(x : U) → U → U"
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     it "records every hole in a module" $ do
       let holes = holesOf "#lang rzk-1\n#define p : (A : U) -> (B : U) -> A -> B -> A\n  := \\ A B a b -> ?\n"
       length holes `shouldBe` 1


### PR DESCRIPTION
An arrow type whose binder was never named and is not used by the return type rendered with a machine-generated name: a goal `U -> U` printed as `(x₁ : U) → U`.

Render such a domain as a plain parameter `(U → U)`, so every hover, hole goal, and error message reads closer to what the user wrote. A user-written name is kept even when unused, and consuming no fresh name also stops the generated indices of later binders from drifting.