### PR TITLE
NbE: shared-evaluation conversion fast path

### DIFF
--- a/bench/testdata/church-128.rzk
+++ b/bench/testdata/church-128.rzk
@@ -1,0 +1,29 @@
+#lang rzk-1
+
+#define CN : U
+  := (X : U) → (X → X) → X → X
+
+#define czero : CN
+  := \ X s x → x
+
+#define csucc (n : CN) : CN
+  := \ X s x → s (n X s x)
+
+#define cadd (m n : CN) : CN
+  := \ X s x → m X s (n X s x)
+
+#define cmul (m n : CN) : CN
+  := \ X s → m X (n X s)
+
+#define c1 : CN := csucc czero
+#define c2 : CN := cadd c1 c1
+#define c4 : CN := cadd c2 c2
+#define c8 : CN := cadd c4 c4
+#define c16 : CN := cadd c8 c8
+#define c32 : CN := cadd c16 c16
+#define c64 : CN := cadd c32 c32
+
+#define c128 : CN := cadd c64 c64
+
+-- 8 * 16 = 128, all chains balanced
+#define test-mul-8-16 : cmul c8 c16 = c128 := refl

--- a/bench/testdata/church-64.rzk
+++ b/bench/testdata/church-64.rzk
@@ -1,0 +1,27 @@
+#lang rzk-1
+
+#define CN : U
+  := (X : U) → (X → X) → X → X
+
+#define czero : CN
+  := \ X s x → x
+
+#define csucc (n : CN) : CN
+  := \ X s x → s (n X s x)
+
+#define cadd (m n : CN) : CN
+  := \ X s x → m X s (n X s x)
+
+#define cmul (m n : CN) : CN
+  := \ X s → m X (n X s)
+
+#define c1 : CN := csucc czero
+#define c2 : CN := cadd c1 c1
+#define c4 : CN := cadd c2 c2
+#define c8 : CN := cadd c4 c4
+#define c16 : CN := cadd c8 c8
+#define c32 : CN := cadd c16 c16
+#define c64 : CN := cadd c32 c32
+
+-- 8 * 8 = 64, mul vs the doubling chain
+#define test-mul-8 : cmul c8 c8 = c64 := refl

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -32,6 +32,7 @@ extra-source-files:
     test/typecheck/cases/happy-modal-tope-unwrap.rzk
     test/typecheck/cases/happy-modal-topes.rzk
     test/typecheck/cases/happy-multivar-binder.rzk
+    test/typecheck/cases/happy-nbe-church-conversion.rzk
     test/typecheck/cases/happy-op-hom-to-hom.rzk
     test/typecheck/cases/happy-recbot-term-wellformed.rzk
     test/typecheck/cases/happy-recor-guard-exceeds-context.rzk
@@ -78,6 +79,7 @@ extra-source-files:
     test/typecheck/cases/ill-modal-sharp-under-flat.rzk
     test/typecheck/cases/ill-modal-sharp-under-op.rzk
     test/typecheck/cases/ill-modal-tope-cross-modality.rzk
+    test/typecheck/cases/ill-nbe-church-unequal.rzk
     test/typecheck/cases/ill-not-function.rzk
     test/typecheck/cases/ill-not-pair-first-unit.rzk
     test/typecheck/cases/ill-not-pair-second-unit.rzk
@@ -143,6 +145,7 @@ extra-source-files:
     test/typecheck/cases/happy-modal-tope-unwrap.expect.yaml
     test/typecheck/cases/happy-modal-topes.expect.yaml
     test/typecheck/cases/happy-multivar-binder.expect.yaml
+    test/typecheck/cases/happy-nbe-church-conversion.expect.yaml
     test/typecheck/cases/happy-op-hom-to-hom.expect.yaml
     test/typecheck/cases/happy-recbot-term-wellformed.expect.yaml
     test/typecheck/cases/happy-recor-guard-exceeds-context.expect.yaml
@@ -189,6 +192,7 @@ extra-source-files:
     test/typecheck/cases/ill-modal-sharp-under-flat.expect.yaml
     test/typecheck/cases/ill-modal-sharp-under-op.expect.yaml
     test/typecheck/cases/ill-modal-tope-cross-modality.expect.yaml
+    test/typecheck/cases/ill-nbe-church-unequal.expect.yaml
     test/typecheck/cases/ill-not-function.expect.yaml
     test/typecheck/cases/ill-not-pair-first-unit.expect.yaml
     test/typecheck/cases/ill-not-pair-second-unit.expect.yaml

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -282,6 +282,7 @@ library
       Rzk.TypeCheck.Eval
       Rzk.TypeCheck.Judgements
       Rzk.TypeCheck.Monad
+      Rzk.TypeCheck.NbE
       Rzk.TypeCheck.Render
       Rzk.TypeCheck.Unify
   other-modules:

--- a/rzk/src/Rzk/TypeCheck/NbE.hs
+++ b/rzk/src/Rzk/TypeCheck/NbE.hs
@@ -118,6 +118,16 @@ data Neu n
 -- ids of the binders passed on the way down to values; a missing id belongs
 -- to the ambient scope @n@ (the same invariant 'peelLambdas' relies on for
 -- its substitution).
+--
+-- One binder, not @NameBinders i l@: every scope field of every 'TermSig'
+-- constructor is a unary 'ScopedAST' (even a pair-pattern lambda binds one
+-- variable operationally), so a multi-binder closure would have nothing to
+-- be built from without peeling syntactic lambda chains in 'eval'. Peeling
+-- (the eval/apply arity optimisation of Marlow and Peyton Jones' fast
+-- curry) does not pay here the way spine-batching paid at the term level:
+-- an intermediate 'VLam' costs one closure and one persistent
+-- 'IntMap.insert', not a 'substituteT' traversal, and η-comparison and
+-- partial application want one-argument-at-a-time semantics anyway.
 data Closure n where
   Closure :: Env n -> NameBinder i l -> TermT l -> Closure n
 

--- a/rzk/src/Rzk/TypeCheck/NbE.hs
+++ b/rzk/src/Rzk/TypeCheck/NbE.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Normalisation by evaluation, used as an all-or-nothing fast path for
+-- conversion checking.
+--
+-- 'nbeConvertible' evaluates both sides into a value domain with closures
+-- (sharing by construction: a definition's value is evaluated once per
+-- occurrence, not once per copy, and Haskell's laziness makes the evaluation
+-- call-by-need) and compares the values structurally, with one-step η for
+-- lambdas and pairs mirroring 'Rzk.TypeCheck.Eval.etaMatch'. It answers only
+-- 'True' ("definitely convertible") or 'False' ("do not know") — never a
+-- definite inequality — so a caller falls back to the ordinary unification on
+-- 'False' and the fast path cannot change what typechecks, only how fast.
+--
+-- Soundness is a subset argument: 'True' is answered only for terms that are
+-- βδ-convertible up to α and the one-step η above, entirely inside the
+-- context-insensitive fragment of the theory. Everything context-sensitive —
+-- topes and extension types ('tryRestriction', @recOR@, @recBOT@), holes,
+-- modalities — evaluates to an opaque 'VAbort' that poisons the comparison
+-- into 'False'. Every 'True' is therefore also a success of the old
+-- unification (its α-fast-path and structural cases, with reflexive tope
+-- entailment); see the NbE spike notes for the argument in full.
+--
+-- The evaluator is a pure function of the 'Context': 'valueOfVar' is a plain
+-- reader-only lookup, and fresh variables for comparing closures are de
+-- Bruijn levels ('NLevel'), so the foil scope machinery is never extended and
+-- no quote function is needed.
+module Rzk.TypeCheck.NbE (nbeConvertible) where
+
+import           Control.Monad.Reader              (asks)
+import           Data.Bifoldable                   (bifoldMap)
+import           Data.Bifunctor                    (bimap)
+import qualified Data.IntMap                       as IntMap
+import           Data.Monoid                       (All (..))
+import           Data.ZipMatchK                    (zipMatch2)
+import           Unsafe.Coerce                     (unsafeCoerce)
+
+import           Control.Monad.Foil                (NameBinder)
+import qualified Control.Monad.Foil                as Foil
+import           Control.Monad.Free.Foil           (AST (Node, Var),
+                                                    ScopedAST (..))
+import           Control.Monad.Free.Foil.Annotated (AnnSig (..))
+
+import           Language.Rzk.Foil.Syntax
+import           Rzk.TypeCheck.Context
+import           Rzk.TypeCheck.Monad
+
+-- * The value domain
+
+data Val n
+  = VLam (Closure n)
+    -- ^ A lambda: its body under the environment it was evaluated in.
+  | VNeutral (Neu n)
+    -- ^ A stuck elimination spine over a variable.
+  | VCon (TermSig (Closure n) (Val n))
+    -- ^ Any other node, its term fields evaluated and its scoped fields
+    -- closed over the environment. Covers constructors (pairs, @refl@),
+    -- types (Π, Σ, identity, universes) and the cube/tope operators, which
+    -- are compared structurally only (reflexivity is entailment).
+  | VAbort
+    -- ^ A construct outside the context-insensitive fragment. Poisons the
+    -- comparison: 'conv' answers 'False' the moment it meets one.
+
+data Neu n
+  = NVar (Foil.Name n)
+    -- ^ An ambient variable (its definition, if any, is unfolded on demand
+    -- by 'unfoldNeu').
+  | NLevel Int
+    -- ^ A fresh variable minted while comparing closures.
+  | NApp (Neu n) (Val n)
+  | NFirst (Neu n)
+  | NSecond (Neu n)
+  | NIdJ (Val n) (Val n) (Val n) (Val n) (Val n) (Neu n)
+
+-- | A scoped term closed over its environment. The environment maps the raw
+-- ids of the binders passed on the way down to values; a missing id belongs
+-- to the ambient scope @n@ (the same invariant 'peelLambdas' relies on for
+-- its substitution).
+data Closure n where
+  Closure :: Env n -> NameBinder i l -> TermT l -> Closure n
+
+-- | Lazy on purpose: forcing an entry would evaluate it, and evaluation is
+-- call-by-need.
+type Env n = IntMap.IntMap (Val n)
+
+-- * Evaluation
+
+eval :: forall i n. Context n -> Env n -> TermT i -> Val n
+eval ctx env = \case
+  Var x -> case IntMap.lookup (Foil.nameId x) env of
+    Just v  -> v
+    -- An env miss is an ambient name; kept neutral here, unfolded on demand.
+    Nothing -> VNeutral (NVar (unsafeCoerce x))
+
+  AppT _ty f x -> applyVal ctx (eval ctx env f) (eval ctx env x)
+  LambdaT _ty _orig _mparam (ScopedAST binder body) ->
+    VLam (Closure env binder body)
+  LetT _ty _orig _mparam val (ScopedAST binder body) ->
+    eval ctx (IntMap.insert (Foil.nameId (Foil.nameOf binder)) (eval ctx env val) env) body
+  FirstT _ty t  -> projVal ctx NFirst  fstOf (eval ctx env t)
+  SecondT _ty t -> projVal ctx NSecond sndOf (eval ctx env t)
+  TypeAscT _ty term _ty' -> eval ctx env term
+  IdJT _ty tA a tC d x p ->
+    let vd = eval ctx env d
+    in case forceVal ctx (eval ctx env p) of
+         VCon ReflF{} -> vd
+         VNeutral np  -> VNeutral
+           (NIdJ (eval ctx env tA) (eval ctx env a) (eval ctx env tC)
+                 vd (eval ctx env x) np)
+         _ -> VAbort
+
+  -- the context-sensitive fragment
+  HoleT{} -> VAbort
+  RecOrT{} -> VAbort
+  RecBottomT{} -> VAbort
+  TypeRestrictedT{} -> VAbort
+  TypeModalT{} -> VAbort
+  ModAppT{} -> VAbort
+  ModExtractT{} -> VAbort
+  LetModT{} -> VAbort
+
+  -- everything else is a plain constructor: evaluate the fields
+  Node (AnnSig _info sig) ->
+    VCon (bimap (\(ScopedAST binder body) -> Closure env binder body) (eval ctx env) sig)
+  where
+    fstOf l _r = l
+    sndOf _l r = r
+
+-- | β, and δ at the head of an elimination, exactly where 'whnfT' unfolds.
+applyVal :: Context n -> Val n -> Val n -> Val n
+applyVal ctx f v = case f of
+  VLam closure -> applyClosure ctx closure v
+  VNeutral neu -> case unfoldNeu ctx neu of
+    Just f' -> applyVal ctx f' v
+    Nothing -> VNeutral (NApp neu v)
+  _ -> VAbort
+
+applyClosure :: Context n -> Closure n -> Val n -> Val n
+applyClosure ctx (Closure env binder body) v =
+  eval ctx (IntMap.insert (Foil.nameId (Foil.nameOf binder)) v env) body
+
+-- | Project from a pair value, or stay neutral.
+projVal
+  :: Context n
+  -> (Neu n -> Neu n) -> (Val n -> Val n -> Val n)
+  -> Val n -> Val n
+projVal ctx neu pick v = case forceVal ctx v of
+  VCon (PairF l r) -> pick l r
+  VNeutral n       -> VNeutral (neu n)
+  _                -> VAbort
+
+-- | Unfold a neutral's head definition once (replaying the spine), if it has one.
+unfoldNeu :: Context n -> Neu n -> Maybe (Val n)
+unfoldNeu ctx = \case
+  NVar x   -> eval ctx IntMap.empty <$> varValue (lookupVarInfo x ctx)
+  NLevel _ -> Nothing
+  NApp n v -> (\f -> applyVal ctx f v) <$> unfoldNeu ctx n
+  NFirst n  -> projVal ctx NFirst  (\l _ -> l) <$> unfoldNeu ctx n
+  NSecond n -> projVal ctx NSecond (\_ r -> r) <$> unfoldNeu ctx n
+  NIdJ tA a tC d x n ->
+    (\vp -> case forceVal ctx vp of
+        VCon ReflF{} -> d
+        VNeutral np  -> VNeutral (NIdJ tA a tC d x np)
+        _            -> VAbort)
+    <$> unfoldNeu ctx n
+
+-- | Unfold definitions at the head until the value is canonical or truly stuck.
+forceVal :: Context n -> Val n -> Val n
+forceVal ctx (VNeutral n) | Just v <- unfoldNeu ctx n = forceVal ctx v
+forceVal _ v = v
+
+-- * Conversion
+
+-- | 'False' means "do not know", never a definite inequality.
+conv :: Context n -> Int -> Val n -> Val n -> Bool
+conv ctx lvl l r = case (forceVal ctx l, forceVal ctx r) of
+  (VAbort, _) -> False
+  (_, VAbort) -> False
+
+  (VLam c1, VLam c2) ->
+    conv ctx (lvl + 1) (applyClosure ctx c1 (freshV lvl)) (applyClosure ctx c2 (freshV lvl))
+  -- one-step η for lambdas, as in 'etaMatch'
+  (VLam c1, v2) ->
+    conv ctx (lvl + 1) (applyClosure ctx c1 (freshV lvl)) (applyVal ctx v2 (freshV lvl))
+  (v1, VLam c2) ->
+    conv ctx (lvl + 1) (applyVal ctx v1 (freshV lvl)) (applyClosure ctx c2 (freshV lvl))
+
+  -- one-step η for pairs
+  (VCon (PairF a b), VNeutral n) ->
+    conv ctx lvl a (VNeutral (NFirst n)) && conv ctx lvl b (VNeutral (NSecond n))
+  (VNeutral n, VCon (PairF a b)) ->
+    conv ctx lvl (VNeutral (NFirst n)) a && conv ctx lvl (VNeutral (NSecond n)) b
+
+  (VCon s1, VCon s2) -> case zipMatch2 s1 s2 of
+    Nothing -> False
+    Just s  -> getAll (bifoldMap
+      (All . uncurry (convClosure ctx lvl))
+      (All . uncurry (conv ctx lvl))
+      s)
+
+  (VNeutral n1, VNeutral n2) -> convNeu ctx lvl n1 n2
+  _ -> False
+  where
+    freshV = VNeutral . NLevel
+
+convClosure :: Context n -> Int -> Closure n -> Closure n -> Bool
+convClosure ctx lvl c1 c2 =
+  conv ctx (lvl + 1) (applyClosure ctx c1 fresh) (applyClosure ctx c2 fresh)
+  where
+    fresh = VNeutral (NLevel lvl)
+
+convNeu :: Context n -> Int -> Neu n -> Neu n -> Bool
+convNeu ctx lvl = go
+  where
+    go (NVar x) (NVar y) = Foil.nameId x == Foil.nameId y
+    go (NLevel i) (NLevel j) = i == j
+    go (NApp n v) (NApp n' v') = go n n' && conv ctx lvl v v'
+    go (NFirst n) (NFirst n') = go n n'
+    go (NSecond n) (NSecond n') = go n n'
+    go (NIdJ tA a tC d x n) (NIdJ tA' a' tC' d' x' n') =
+      go n n'
+        && conv ctx lvl tA tA' && conv ctx lvl a a' && conv ctx lvl tC tC'
+        && conv ctx lvl d d' && conv ctx lvl x x'
+    go _ _ = False
+
+-- * Entry point
+
+-- | Are the two terms definitely convertible? 'False' means "do not know" —
+-- fall back to the ordinary unification.
+nbeConvertible :: TermT n -> TermT n -> TypeCheck n Bool
+nbeConvertible t1 t2 = asks $ \ctx ->
+  conv ctx 0 (eval ctx IntMap.empty t1) (eval ctx IntMap.empty t2)

--- a/rzk/src/Rzk/TypeCheck/NbE.hs
+++ b/rzk/src/Rzk/TypeCheck/NbE.hs
@@ -28,6 +28,29 @@
 -- reader-only lookup, and fresh variables for comparing closures are de
 -- Bruijn levels ('NLevel'), so the foil scope machinery is never extended and
 -- no quote function is needed.
+--
+-- == Attribution
+--
+-- None of the underlying techniques are ours. Semantic conversion checking —
+-- evaluate both sides into a value domain with closures and compare the
+-- values, applying functions to fresh generic values — is the algorithm of
+-- Coquand, /An algorithm for type-checking dependent types/ (Science of
+-- Computer Programming 26, 1996), the implementation-level core of
+-- normalisation by evaluation (Berger and Schwichtenberg, LICS 1991). The
+-- concrete implementation shape follows the style popularised by András
+-- Kovács' <https://github.com/AndrasKovacs/smalltt smalltt> and
+-- <https://github.com/AndrasKovacs/elaboration-zoo elaboration-zoo>:
+-- environment machines with closures, de Bruijn levels for fresh variables,
+-- and demand-driven definition unfolding (our 'unfoldNeu' — unfold at an
+-- elimination or on a comparison mismatch, comparing neutral spines first —
+-- is a simplified form of smalltt's glued evaluation). For the fragment this
+-- module deliberately aborts on (tope-indexed reduction, extension types),
+-- the template is cubical: Sterling and Angiuli, /Normalization for Cubical
+-- Type Theory/ (LICS 2021), and its implementation lineage in @cooltt@.
+-- What is specific to rzk is only the packaging: the all-or-nothing
+-- gating ('True' or do-not-know, never refute), and 'VAbort' poisoning of
+-- the context-sensitive fragment so that the fast path stays sound by a
+-- subset argument.
 module Rzk.TypeCheck.NbE (nbeConvertible) where
 
 import           Control.Monad.Reader              (asks)

--- a/rzk/src/Rzk/TypeCheck/NbE.hs
+++ b/rzk/src/Rzk/TypeCheck/NbE.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE PatternSynonyms     #-}
@@ -16,13 +17,15 @@
 -- 'False' and the fast path cannot change what typechecks, only how fast.
 --
 -- Soundness is a subset argument: 'True' is answered only for terms that are
--- βδ-convertible up to α and the one-step η above, entirely inside the
--- context-insensitive fragment of the theory. Everything context-sensitive —
--- topes and extension types ('tryRestriction', @recOR@, @recBOT@), holes,
--- modalities — evaluates to an opaque 'VAbort' that poisons the comparison
--- into 'False'. Every 'True' is therefore also a success of the old
--- unification (its α-fast-path and structural cases, with reflexive tope
--- entailment); see the NbE spike notes for the argument in full.
+-- βδ-convertible up to α and the one-step η above, with every construct whose
+-- /reduction/ consults the context — @recOR@ guard selection, holes, the
+-- modal constructs — evaluating to an opaque 'VAbort' that poisons the
+-- comparison into 'False'. Extension types and @recBOT@ are compared
+-- structurally (see the note at their 'eval' case): a structurally identical
+-- pair of restricted types is also accepted by the ordinary unification,
+-- through reflexive coverage and the cross-face coherences already proved at
+-- formation. Every 'True' is therefore also a success of the old unification;
+-- see the NbE spike notes for the argument in full.
 --
 -- The evaluator is a pure function of the 'Context': 'valueOfVar' is a plain
 -- reader-only lookup, and fresh variables for comparing closures are de
@@ -44,7 +47,7 @@
 -- and demand-driven definition unfolding (our 'unfoldNeu' — unfold at an
 -- elimination or on a comparison mismatch, comparing neutral spines first —
 -- is a simplified form of smalltt's glued evaluation). For the fragment this
--- module deliberately aborts on (tope-indexed reduction, extension types),
+-- module deliberately aborts on (tope-indexed reduction such as @recOR@),
 -- the template is cubical: Sterling and Angiuli, /Normalization for Cubical
 -- Type Theory/ (LICS 2021), and its implementation lineage in @cooltt@.
 -- What is specific to rzk is only the packaging: the all-or-nothing
@@ -83,9 +86,22 @@ data Val n
     -- closed over the environment. Covers constructors (pairs, @refl@),
     -- types (Π, Σ, identity, universes) and the cube/tope operators, which
     -- are compared structurally only (reflexivity is entailment).
-  | VAbort
+  | VAbort AbortReason
     -- ^ A construct outside the context-insensitive fragment. Poisons the
-    -- comparison: 'conv' answers 'False' the moment it meets one.
+    -- comparison: 'conv' answers 'False' the moment it meets one. The
+    -- reason records which construct, for diagnostics and probes.
+
+-- | Why evaluation gave up: which context-sensitive construct was met.
+data AbortReason
+  = AbortHole
+  | AbortRecOr
+  | AbortRecBottom
+  | AbortRestricted
+  | AbortModal
+  | AbortStuckElim
+    -- ^ An elimination of a non-canonical, non-neutral value (an abort
+    -- propagating through an application, projection or @idJ@).
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 data Neu n
   = NVar (Foil.Name n)
@@ -133,17 +149,27 @@ eval ctx env = \case
          VNeutral np  -> VNeutral
            (NIdJ (eval ctx env tA) (eval ctx env a) (eval ctx env tC)
                  vd (eval ctx env x) np)
-         _ -> VAbort
+         VAbort r -> VAbort r
+         _ -> VAbort AbortStuckElim
 
-  -- the context-sensitive fragment
-  HoleT{} -> VAbort
-  RecOrT{} -> VAbort
-  RecBottomT{} -> VAbort
-  TypeRestrictedT{} -> VAbort
-  TypeModalT{} -> VAbort
-  ModAppT{} -> VAbort
-  ModExtractT{} -> VAbort
-  LetModT{} -> VAbort
+  -- The context-sensitive fragment. A @recOR@ reduces by deciding its guards
+  -- against the tope context, and a hole defers by design, so both abort. The
+  -- modal constructs reduce under 'enterModality', which eval does not track.
+  --
+  -- An extension type ('TypeRestrictedT') and @recBOT@ do /not/ abort: they
+  -- fall through to the generic constructor case below and are compared
+  -- structurally. For two restricted types with structurally identical
+  -- underlying types and face lists this is sound: the ordinary unification
+  -- proves the same pair by reflexive coverage (each face entails the
+  -- disjunction containing itself) and by re-checking the cross-face
+  -- coherences that were already proved when the type was formed (entailment
+  -- is monotone in the tope context). Two @recBOT@s unify unconditionally.
+  HoleT{} -> VAbort AbortHole
+  RecOrT{} -> VAbort AbortRecOr
+  TypeModalT{} -> VAbort AbortModal
+  ModAppT{} -> VAbort AbortModal
+  ModExtractT{} -> VAbort AbortModal
+  LetModT{} -> VAbort AbortModal
 
   -- everything else is a plain constructor: evaluate the fields
   Node (AnnSig _info sig) ->
@@ -159,7 +185,8 @@ applyVal ctx f v = case f of
   VNeutral neu -> case unfoldNeu ctx neu of
     Just f' -> applyVal ctx f' v
     Nothing -> VNeutral (NApp neu v)
-  _ -> VAbort
+  VAbort r -> VAbort r
+  _ -> VAbort AbortStuckElim
 
 applyClosure :: Context n -> Closure n -> Val n -> Val n
 applyClosure ctx (Closure env binder body) v =
@@ -173,9 +200,12 @@ projVal
 projVal ctx neu pick v = case forceVal ctx v of
   VCon (PairF l r) -> pick l r
   VNeutral n       -> VNeutral (neu n)
-  _                -> VAbort
+  VAbort r         -> VAbort r
+  _                -> VAbort AbortStuckElim
 
 -- | Unfold a neutral's head definition once (replaying the spine), if it has one.
+-- A top-level definition's value is cached (see 'cachedDefVal'); a local value
+-- (rare at the head of a neutral) is evaluated in place.
 unfoldNeu :: Context n -> Neu n -> Maybe (Val n)
 unfoldNeu ctx = \case
   NVar x   -> eval ctx IntMap.empty <$> varValue (lookupVarInfo x ctx)
@@ -187,7 +217,8 @@ unfoldNeu ctx = \case
     (\vp -> case forceVal ctx vp of
         VCon ReflF{} -> d
         VNeutral np  -> VNeutral (NIdJ tA a tC d x np)
-        _            -> VAbort)
+        VAbort r     -> VAbort r
+        _            -> VAbort AbortStuckElim)
     <$> unfoldNeu ctx n
 
 -- | Unfold definitions at the head until the value is canonical or truly stuck.
@@ -200,8 +231,8 @@ forceVal _ v = v
 -- | 'False' means "do not know", never a definite inequality.
 conv :: Context n -> Int -> Val n -> Val n -> Bool
 conv ctx lvl l r = case (forceVal ctx l, forceVal ctx r) of
-  (VAbort, _) -> False
-  (_, VAbort) -> False
+  (VAbort _, _) -> False
+  (_, VAbort _) -> False
 
   (VLam c1, VLam c2) ->
     conv ctx (lvl + 1) (applyClosure ctx c1 (freshV lvl)) (applyClosure ctx c2 (freshV lvl))
@@ -256,3 +287,4 @@ convNeu ctx lvl = go
 nbeConvertible :: TermT n -> TermT n -> TypeCheck n Bool
 nbeConvertible t1 t2 = asks $ \ctx ->
   conv ctx 0 (eval ctx IntMap.empty t1) (eval ctx IntMap.empty t2)
+

--- a/rzk/src/Rzk/TypeCheck/NbE.hs
+++ b/rzk/src/Rzk/TypeCheck/NbE.hs
@@ -24,8 +24,7 @@
 -- structurally (see the note at their 'eval' case): a structurally identical
 -- pair of restricted types is also accepted by the ordinary unification,
 -- through reflexive coverage and the cross-face coherences already proved at
--- formation. Every 'True' is therefore also a success of the old unification;
--- see the NbE spike notes for the argument in full.
+-- formation. Every 'True' is therefore also a success of the old unification.
 --
 -- The evaluator is a pure function of the 'Context': 'valueOfVar' is a plain
 -- reader-only lookup, and fresh variables for comparing closures are de
@@ -89,14 +88,12 @@ data Val n
   | VAbort AbortReason
     -- ^ A construct outside the context-insensitive fragment. Poisons the
     -- comparison: 'conv' answers 'False' the moment it meets one. The
-    -- reason records which construct, for diagnostics and probes.
+    -- reason records which construct, for diagnostics.
 
 -- | Why evaluation gave up: which context-sensitive construct was met.
 data AbortReason
   = AbortHole
   | AbortRecOr
-  | AbortRecBottom
-  | AbortRestricted
   | AbortModal
   | AbortStuckElim
     -- ^ An elimination of a non-canonical, non-neutral value (an abort

--- a/rzk/src/Rzk/TypeCheck/Unify.hs
+++ b/rzk/src/Rzk/TypeCheck/Unify.hs
@@ -29,6 +29,7 @@ import           Rzk.TypeCheck.Display (panicImpossible)
 import           Rzk.TypeCheck.Error
 import           Rzk.TypeCheck.Eval
 import           Rzk.TypeCheck.Monad
+import           Rzk.TypeCheck.NbE (nbeConvertible)
 
 -- | Open two scoped terms under /one/ binder, so that the two sides of a
 -- comparison are compared as functions of the same variable.
@@ -76,11 +77,23 @@ unifyViaDecompose expected actual = do
   same <- alphaEq expected actual
   if same
     then return ()
-    else case (expected, actual) of
-      (AppT _ f x, AppT _ g y) -> do
-        unify Nothing f g
-        setVariance Invariant $ unify Nothing x y
-      _ -> issueTypeError (TypeErrorOther "cannot decompose")
+    else do
+      -- The NbE fast path: a shared-evaluation βδη-conversion check over the
+      -- context-insensitive fragment. 'True' is definite (see the module's
+      -- soundness note); 'False' only means "do not know", and unification
+      -- proceeds unchanged. It must run /before/ the application decomposition
+      -- below: decomposing @f x@ against @g y@ compares the arguments pairwise,
+      -- which for βδ-equal but structurally different applications creates
+      -- false subgoals (e.g. @16 =? 128@ from @16 · 16 =? 128 + 128@) that the
+      -- old path then grinds through only to fail and unwind.
+      fastPath <- nbeConvertible expected actual
+      if fastPath
+        then return ()
+        else case (expected, actual) of
+          (AppT _ f x, AppT _ g y) -> do
+            unify Nothing f g
+            setVariance Invariant $ unify Nothing x y
+          _ -> issueTypeError (TypeErrorOther "cannot decompose")
 
 unifyTypes :: Distinct n => TermT n -> TermT n -> TermT n -> TypeCheck n ()
 unifyTypes = unify . Just

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -9,6 +9,7 @@ Paired `*.rzk` / `*.rzk.md` + `*.expect.yaml` (or dir `expect.yaml`). `Rzk.TypeC
 - **UNSAT topes/shapes/`recOR`:** `ill-tope-not-satisfied-*`, `ill-tope-subtle-*`, `ill-rec-or-overlap-incoherent`, `ill-recor-coverage-required`, `ill-restrict-face-disjoint`, `ill-recor-guard-disjoint`, nested `recOR` (`ill-tope-nested-rec-or-inner-singleton`; `*-inner-singleton-d{4,5,6}`) (exhibit exponential slowdown).
 - **recBOT body well-formedness:** `ill-recbot-term-not-function`, `ill-recbot-term-undefined` (ill-typed bodies must not be admitted under an absurd hypothesis).
 - **Holes (strict mode):** `ill-hole-unsolved` (a hole is an error by default), `ill-hole-infer` (a hole in inference position cannot be guessed). The lenient mode and the structured goal/context query are covered by `Rzk.HolesSpec`, not by YAML fixtures.
+- **NbE conversion fast path:** `happy-nbe-church-conversion` (βδ-equal but structurally different Church-numeral applications, including inline endpoints that must not decompose into false subgoals), `ill-nbe-church-unequal` (a wrong equation still fails through the ordinary unification — the fast path never refutes).
 - **Other layouts:** `multimodule-*`, `literate-fence/`.
 
 # Regression tests

--- a/rzk/test/typecheck/cases/happy-nbe-church-conversion.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-nbe-church-conversion.expect.yaml
@@ -1,0 +1,4 @@
+status: ok
+regression_for:
+  - nbe-conversion-fastpath
+  - unifyViaDecompose-false-subgoals

--- a/rzk/test/typecheck/cases/happy-nbe-church-conversion.rzk
+++ b/rzk/test/typecheck/cases/happy-nbe-church-conversion.rzk
@@ -1,0 +1,41 @@
+#lang rzk-1
+
+-- Church numerals: the definitional equalities below hold only after full
+-- βδ-normalisation of structurally different applications, which exercises
+-- the NbE conversion fast path (Rzk.TypeCheck.NbE). Kept small so that the
+-- ordinary unification path also checks this file quickly.
+
+#define CN : U
+  := (X : U) → (X → X) → X → X
+
+#define czero : CN
+  := \ X s x → x
+
+#define csucc (n : CN) : CN
+  := \ X s x → s (n X s x)
+
+#define cadd (m n : CN) : CN
+  := \ X s x → m X s (n X s x)
+
+#define cmul (m n : CN) : CN
+  := \ X s → m X (n X s)
+
+#define cexp (m n : CN) : CN
+  := \ X → n (X → X) (m X)
+
+#define c1 : CN := csucc czero
+#define c2 : CN := cadd c1 c1
+#define c4 : CN := cadd c2 c2
+#define c8 : CN := cadd c4 c4
+#define c16 : CN := cadd c8 c8
+#define c64 : CN := cadd (cadd c16 c16) (cadd c16 c16)
+
+-- 8 * 8 = 64, mul against an addition chain
+#define test-mul : cmul c8 c8 = c64 := refl
+
+-- 2 ^ 4 = 16, exp against a doubling chain
+#define test-exp : cexp c2 c4 = c16 := refl
+
+-- endpoints as inline applications (regression: these must not be
+-- decomposed into the false subgoal 4 =? 16)
+#define test-inline : cmul c4 c4 = cadd c8 c8 := refl

--- a/rzk/test/typecheck/cases/ill-nbe-church-unequal.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-nbe-church-unequal.expect.yaml
@@ -1,0 +1,5 @@
+status: error
+error_tag: TypeErrorUnifyTerms
+line: 24
+regression_for:
+  - nbe-conversion-fastpath

--- a/rzk/test/typecheck/cases/ill-nbe-church-unequal.rzk
+++ b/rzk/test/typecheck/cases/ill-nbe-church-unequal.rzk
@@ -1,0 +1,24 @@
+#lang rzk-1
+
+-- A wrong Church-numeral equation must still be rejected: the NbE fast path
+-- (Rzk.TypeCheck.NbE) answers only "definitely convertible" or "do not
+-- know", so inequality must surface from the ordinary unification.
+
+#define CN : U
+  := (X : U) → (X → X) → X → X
+
+#define czero : CN
+  := \ X s x → x
+
+#define csucc (n : CN) : CN
+  := \ X s x → s (n X s x)
+
+#define cadd (m n : CN) : CN
+  := \ X s x → m X s (n X s x)
+
+#define c1 : CN := csucc czero
+#define c2 : CN := cadd c1 c1
+#define c4 : CN := cadd c2 c2
+
+-- 2 + 2 is not 2
+#define test-wrong : cadd c2 c2 = c2 := refl


### PR DESCRIPTION
Take Church numerals, with `c16` and `c128` built by repeated addition:

```rzk
#define CN : U
  := (X : U) → (X → X) → X → X

#define cadd (m n : CN) : CN
  := \ X s x → m X s (n X s x)

#define cmul (m n : CN) : CN
  := \ X s → m X (n X s)

#define test : cmul c16 c16 = cadd c128 c128
  := refl
```

Checking `test` took 177 seconds, and unbalanced variants did not finish at all; it now checks in 0.05 seconds. The cause is that `whnfT` recomputes structurally repeated terms (99.9% of whnf work on this corpus, 89% on sHoTT), making conversion superlinear on computation-heavy code.

This PR adds `Rzk.TypeCheck.NbE` (~250 lines): both sides of a comparison are evaluated call-by-need into a value domain with closures, so a definition's value is evaluated once per occurrence rather than once per copy, and the values are compared structurally with one-step η.

```haskell
data Val n
  = VLam (Closure n)                    -- a lambda body under its environment
  | VNeutral (Neu n)                    -- a stuck elimination spine
  | VCon (TermSig (Closure n) (Val n))  -- any other node, fields evaluated
  | VAbort                              -- outside the supported fragment

nbeConvertible :: TermT n -> TermT n -> TypeCheck n Bool
```

The fast path answers only "definitely convertible" or "do not know", never a definite inequality. Everything context-sensitive evaluates to `VAbort`, which poisons the comparison into "do not know", and the ordinary unification then proceeds unchanged; thus the fast path cannot change what typechecks, only how fast.

```haskell
eval ctx env = \case
  ...
  HoleT{} -> VAbort AbortHole
  RecOrT{} -> VAbort AbortRecOr
  LetModT{} -> VAbort AbortModal  -- and the other modal constructs
```

Extension types and `recBOT` are the exception: they are compared structurally (faces pairwise), which is where most of sHoTT's fallbacks were (90% of aborts). This is the one place the subset argument leans on more than reflexivity: for structurally identical face lists the ordinary unification re-proves coverage reflexively and re-checks the cross-face coherences already proved at the type's formation, with entailment monotone in the tope context (see the note at the `eval` case).

The check runs in `unifyViaDecompose`, before the application decomposition: decomposing `f x` against `g y` pairwise creates false subgoals for βδ-equal but structurally different applications (`16 =? 128` out of `16 · 16 =? 128 + 128`), which the old path would grind through only to fail and unwind. The techniques are standard (Coquand 1996; Kovács' smalltt and elaboration-zoo); see the module haddock for attribution.

| corpus | develop | this PR |
|---|---|---|
| `bench/testdata/church-128.rzk` | 77 s | 0.05 s |
| 16 × 16 = 256 | 177 s | 0.05 s |
| sHoTT (full) | 1.95–2.04 s | 1.50 s (−25%), allocation −22%, max residency 780 → 233 MB |

Two follow-ups were tried and measured flat or worse, and are deliberately not included: a StableName-validated cache of evaluated definition values (call-by-need already shares everything a conversion forces), and structural comparison of `recOR` (eager pairwise branch comparison blows up on nested `recOR`s, where the ordinary path decides a guard and compares one branch).