### PR TITLE
LSP: convert positions to UTF-16

### DIFF
--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -108,6 +108,7 @@ library:
         - Language.Rzk.VSCode.Handlers
         - Language.Rzk.VSCode.Logging
         - Language.Rzk.VSCode.Lsp
+        - Language.Rzk.VSCode.PositionEncoding
         - Language.Rzk.VSCode.Tokenize
         - Language.Rzk.VSCode.ReferenceIndex
       dependencies:

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -347,6 +347,7 @@ library
         Language.Rzk.VSCode.Handlers
         Language.Rzk.VSCode.Logging
         Language.Rzk.VSCode.Lsp
+        Language.Rzk.VSCode.PositionEncoding
         Language.Rzk.VSCode.Tokenize
         Language.Rzk.VSCode.ReferenceIndex
     build-depends:
@@ -440,6 +441,7 @@ test-suite rzk-test
       Rzk.FormatSpec
       Rzk.HolesSpec
       Rzk.ParserSpec
+      Rzk.PositionEncodingSpec
       Rzk.RefIndexSpec
       Rzk.SemanticTokensSpec
       Rzk.TypeCheckSpec

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -67,6 +67,7 @@ import           Language.Rzk.Syntax           (Module, Term,
                                                 parseModuleSafe, printTree)
 import qualified Language.Rzk.VSCode.Config    as RzkConfig
 import           Language.Rzk.VSCode.Env
+import qualified Language.Rzk.VSCode.PositionEncoding as Enc
 import qualified Language.Rzk.VSCode.ReferenceIndex as RefInd
 import           Language.Rzk.VSCode.Logging
 import           Language.Rzk.VSCode.Tokenize  (mergeTokens, tokenizeModule,
@@ -126,20 +127,50 @@ fromLspUri u = RefInd.Uri { uriPath = fromMaybe "" (uriToFilePath u) }
 toLspUri :: RefInd.Uri -> LSP.Uri
 toLspUri (RefInd.Uri { uriPath = p }) = filePathToUri p
 
-fromLspPosition :: LSP.Position -> RefInd.Position
-fromLspPosition (LSP.Position l c) =
-  RefInd.Position (fromIntegral l) (fromIntegral c)
+-- | The astral-line map of a file, for position conversion at the LSP
+-- boundary (see "Language.Rzk.VSCode.PositionEncoding"): from the editor
+-- buffer when the file is open, from disk otherwise. A file that cannot be
+-- read converts as all-BMP, i.e. the conversion is the identity.
+astralLinesOfFile :: FilePath -> LSP Enc.AstralLines
+astralLinesOfFile path = do
+  mdoc <- getVirtualFile (filePathToNormalizedUri path)
+  case virtualFileText <$> mdoc of
+    Just text -> return (Enc.astralLines (T.filter (/= '\r') text))
+    Nothing -> liftIO $ do
+      result <- try @SomeException (readFile path)
+      return $ case result of
+        Left _    -> Enc.astralLines ""
+        Right src -> Enc.astralLines (T.filter (/= '\r') (T.pack src))
 
-toLspPosition :: RefInd.Position -> LSP.Position
-toLspPosition (RefInd.Position l c) =
-  LSP.Position (fromIntegral l) (fromIntegral c)
+fromLspPosition :: Enc.AstralLines -> LSP.Position -> RefInd.Position
+fromLspPosition als (LSP.Position l c) =
+  RefInd.Position (fromIntegral l)
+    (Enc.colFromUtf16 als (fromIntegral l) (fromIntegral c))
 
-toLspRange :: RefInd.Range -> Range
-toLspRange (RefInd.Range s e) = Range (toLspPosition s) (toLspPosition e)
+toLspPosition :: Enc.AstralLines -> RefInd.Position -> LSP.Position
+toLspPosition als (RefInd.Position l c) =
+  LSP.Position (fromIntegral l)
+    (fromIntegral (Enc.colToUtf16 als l c))
 
-toLspLocation :: RefInd.Location -> LSP.Location
-toLspLocation (RefInd.Location u r) =
-  LSP.Location (toLspUri u) (toLspRange r)
+toLspRange :: Enc.AstralLines -> RefInd.Range -> Range
+toLspRange als (RefInd.Range s e) =
+  Range (toLspPosition als s) (toLspPosition als e)
+
+-- | Convert locations to LSP, fetching the astral-line map once per file.
+toLspLocations :: [RefInd.Location] -> LSP [LSP.Location]
+toLspLocations locations = do
+  let files = nub (map RefInd.locationPath locations)
+  alss <- Map.fromList <$> forM files (\f -> (,) f <$> astralLinesOfFile f)
+  return
+    [ LSP.Location (toLspUri u) (toLspRange als r)
+    | RefInd.Location u r <- locations
+    , Just als <- [Map.lookup (RefInd.uriPath u) alss]
+    ]
+
+toLspLocation :: RefInd.Location -> LSP LSP.Location
+toLspLocation (RefInd.Location u r) = do
+  als <- astralLinesOfFile (RefInd.uriPath u)
+  return (LSP.Location (toLspUri u) (toLspRange als r))
 
 typecheckFromConfigFile :: LSP ()
 typecheckFromConfigFile = do
@@ -172,7 +203,8 @@ typecheckFromConfigFile = do
 
           -- Report parse errors to the client
           forM_ parseErrors $ \(path, err) -> do
-            publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing (partitionBySource [diagnosticOfParseError err])
+            als <- astralLinesOfFile path
+            publishDiagnostics maxDiagnosticCount (filePathToNormalizedUri path) Nothing (partitionBySource [diagnosticOfParseError als err])
 
           -- Files after the first parse error are not typechecked at all
           -- ('collectErrors' stops collecting modules there); mark the ones
@@ -332,8 +364,8 @@ typecheckFromConfigFile = do
     diagnosticOfHole :: HoleInfo -> Diagnostic
     diagnosticOfHole = lspDiagnosticOf . Diag.diagnoseHole
 
-    diagnosticOfParseError :: T.Text -> Diagnostic
-    diagnosticOfParseError err = Diagnostic (Range (Position errLine errColumnStart) (Position errLine errColumnEnd))
+    diagnosticOfParseError :: Enc.AstralLines -> T.Text -> Diagnostic
+    diagnosticOfParseError als err = Diagnostic (Enc.rangeToUtf16 als (Range (Position errLine errColumnStart) (Position errLine errColumnEnd)))
                       (Just DiagnosticSeverity_Error)
                       (Just $ InR "parse-error")
                       Nothing
@@ -418,11 +450,11 @@ fullDocumentRange source
   | otherwise =
       let newlineCount = T.count (T.singleton '\n') source
           endLine = newlineCount
-          -- Length of last line (after last newline); if no newline, whole text is one line
+          -- Length of the last line (after the last newline; if no newline,
+          -- the whole text is one line), in UTF-16 units as LSP counts them.
           endCharacter
             | T.last source == '\n' = 0
-            | Just i <- T.findIndex (== '\n') (T.reverse source) = fromIntegral i
-            | otherwise = fromIntegral (T.length source)
+            | otherwise = fromIntegral (Enc.utf16Length (T.takeWhileEnd (/= '\n') source))
       in Range (Position 0 0) (Position (fromIntegral endLine) endCharacter)
 
 formatDocument :: Handler LSP 'Method_TextDocumentFormatting
@@ -482,7 +514,8 @@ provideSemanticTokens req responder = do
           logWarning ("Failed to parse file for semantic tokens: " <> err)
           return []
         Right rzkModule -> return (tokenizeModule rzkModule)
-      return (Right (mergeTokens astTokens (tokenizeSyntaxSymbols src)))
+      return (Right (Enc.tokensToUtf16 (Enc.astralLines src)
+        (mergeTokens astTokens (tokenizeSyntaxSymbols src))))
   case possibleTokens of
     Left err -> do
       -- Exception occurred when parsing the module
@@ -501,8 +534,11 @@ findDefinition req res = do
   let uri' = req ^. params . textDocument . uri
       currentFile = fromMaybe "" (uriToFilePath uri')
   referenceIndex <- indexProject currentFile
-  case RefInd.lookupAt referenceIndex (fromLspUri uri') (fromLspPosition (req ^. params . position)) of
-    Just binding -> res $ Right $ InL $ Definition $ InL (toLspLocation (RefInd.bindingDef binding))
+  als <- astralLinesOfFile currentFile
+  case RefInd.lookupAt referenceIndex (fromLspUri uri') (fromLspPosition als (req ^. params . position)) of
+    Just binding -> do
+      location <- toLspLocation (RefInd.bindingDef binding)
+      res $ Right $ InL $ Definition $ InL location
     Nothing      -> res $ Right $ InR $ InR Null
 
 findReferences :: Handler LSP 'Method_TextDocumentReferences
@@ -511,12 +547,14 @@ findReferences req res = do
       currentFile = fromMaybe "" (uriToFilePath uri')
       includeDeclaration = req ^. params . context . to (\(ReferenceContext incl) -> incl)
   referenceIndex <- indexProject currentFile
-  case RefInd.lookupAt referenceIndex (fromLspUri uri') (fromLspPosition (req ^. params . position)) of
-    Just binding ->
+  als <- astralLinesOfFile currentFile
+  case RefInd.lookupAt referenceIndex (fromLspUri uri') (fromLspPosition als (req ^. params . position)) of
+    Just binding -> do
       let sites
             | includeDeclaration = RefInd.bindingSites binding
             | otherwise          = RefInd.bindingRefs binding
-      in res $ Right $ InL (map toLspLocation sites)
+      locations <- toLspLocations sites
+      res $ Right $ InL locations
     Nothing -> res $ Right $ InL []
 
 indexProject :: FilePath -> LSP RefInd.ReferenceIndex
@@ -590,17 +628,19 @@ formatSignature name ty
 provideHover :: Handler LSP 'Method_TextDocumentHover
 provideHover req res = do
   let uri' = req ^. params . textDocument . uri
-      pos  = fromLspPosition (req ^. params . position)
       currentFile = fromMaybe "" $ uriToFilePath uri'
   referenceIndex <- indexProject currentFile
+  als <- astralLinesOfFile currentFile
+  let pos = fromLspPosition als (req ^. params . position)
   case RefInd.lookupAt referenceIndex (fromLspUri uri') pos of
     Nothing -> res $ Right $ InR Null
     Just binding -> do
       cached <- getCachedTypecheckedModules
       let body = hoverContent binding cached
+      LSP.Location _ defRange <- toLspLocation (RefInd.bindingDef binding)
       res $ Right $ InL $ Hover
         (InL (MarkupContent MarkupKind_Markdown body))
-        (Just (toLspRange (RefInd.locationRange (RefInd.bindingDef binding))))
+        (Just defRange)
   where
     hoverContent binding cached =
       T.pack (file ++ "\n\n```rzk\n" ++ signature ++ "\n```")
@@ -644,27 +684,30 @@ provideHover req res = do
 
 -- | The printed name of a declaration and the range of its defining
 -- occurrence, shared by the document and workspace symbol providers.
-declNameRange :: DeclView -> (T.Text, Range)
-declNameRange (DeclView name _ _ _) = (T.pack (printTree ident), range)
+declNameRange :: Enc.AstralLines -> DeclView -> (T.Text, Range)
+declNameRange als (DeclView name _ _ _) = (T.pack (printTree ident), range)
   where
     ident = getVarIdent name
     VarIdent pos _ = ident
     RzkPosition _path pos' = pos
     (line, col) = fromMaybe (0, 0) pos'
     len = length (printTree ident)
-    pos0 = Position (fromIntegral (max 0 (line - 1))) (fromIntegral (max 0 (col - 1)))
-    end  = Position (fromIntegral (max 0 (line - 1))) (fromIntegral (max 0 (col - 1) + len))
+    line0 = max 0 (line - 1)
+    col0 = max 0 (col - 1)
+    pos0 = Position (fromIntegral line0) (fromIntegral (Enc.colToUtf16 als line0 col0))
+    end  = Position (fromIntegral line0) (fromIntegral (Enc.colToUtf16 als line0 (col0 + len)))
     range = Range pos0 end
 
 provideSymbols :: Handler LSP 'Method_TextDocumentDocumentSymbol
 provideSymbols req res = do
   let currentFile = fromMaybe "" $ uriToFilePath $ req ^. params . textDocument . uri
   cachedModules <- getCachedTypecheckedModules
+  als <- astralLinesOfFile currentFile
   let decls = maybe [] cachedModuleDecls (lookup currentFile cachedModules)
-  res $ Right $ InR $ InL $ map declToSymbol decls
+  res $ Right $ InR $ InL $ map (declToSymbol als) decls
   where
-    declToSymbol :: DeclView -> DocumentSymbol
-    declToSymbol decl@(DeclView _ type' _ _loc) = DocumentSymbol
+    declToSymbol :: Enc.AstralLines -> DeclView -> DocumentSymbol
+    declToSymbol als decl@(DeclView _ type' _ _loc) = DocumentSymbol
       { _name           = symbolName
       , _detail         = Just (T.pack (show type'))
       , _kind           = SymbolKind_Function
@@ -675,7 +718,7 @@ provideSymbols req res = do
       , _children       = Nothing
       }
       where
-        (symbolName, range) = declNameRange decl
+        (symbolName, range) = declNameRange als decl
 
 -- | Workspace-wide symbol search over every typechecked module in the cache.
 -- The query is matched case-insensitively as an infix of the definition name;
@@ -685,20 +728,21 @@ provideWorkspaceSymbols :: Handler LSP 'Method_WorkspaceSymbol
 provideWorkspaceSymbols req res = do
   let symbolQuery = T.toLower (req ^. params . query)
   cachedModules <- getCachedTypecheckedModules
-  let symbols =
-        [ WorkspaceSymbol
-            { _name          = symbolName
-            , _kind          = SymbolKind_Function
-            , _tags          = Nothing
-            , _containerName = Nothing
-            , _location      = InL (Location (filePathToUri path) range)
-            , _data_         = Nothing
-            }
-        | (path, cachedModule) <- cachedModules
-        , decl <- cachedModuleDecls cachedModule
-        , let (symbolName, range) = declNameRange decl
-        , symbolQuery `T.isInfixOf` T.toLower symbolName
-        ]
+  symbols <- fmap concat $ forM cachedModules $ \(path, cachedModule) -> do
+    als <- astralLinesOfFile path
+    return
+      [ WorkspaceSymbol
+          { _name          = symbolName
+          , _kind          = SymbolKind_Function
+          , _tags          = Nothing
+          , _containerName = Nothing
+          , _location      = InL (Location (filePathToUri path) range)
+          , _data_         = Nothing
+          }
+      | decl <- cachedModuleDecls cachedModule
+      , let (symbolName, range) = declNameRange als decl
+      , symbolQuery `T.isInfixOf` T.toLower symbolName
+      ]
   res $ Right $ InR $ InL symbols
 
 

--- a/rzk/src/Language/Rzk/VSCode/PositionEncoding.hs
+++ b/rzk/src/Language/Rzk/VSCode/PositionEncoding.hs
@@ -1,0 +1,104 @@
+-- | Conversion between code-point and UTF-16 positions at the LSP boundary.
+--
+-- LSP positions count UTF-16 code units (the default position encoding, and
+-- the only one VS Code supports), while alex positions and everything derived
+-- from them (the surface AST, the reference index, the typechecker) count
+-- Unicode code points. The two agree except on lines containing astral-plane
+-- characters (code points above U+FFFF, such as @𝕀@), each of which takes two
+-- UTF-16 units. Emitting a code-point column for such a line shifts every
+-- position to the right of the character, and a range boundary can land in
+-- the middle of a surrogate pair, which is what shatters the glyph in the
+-- editor (see issue #303).
+--
+-- Everything internal stays in code points; the handlers convert with this
+-- module when crossing the wire, in both directions. 'AstralLines' records
+-- only the lines where the two encodings differ, so for the common all-BMP
+-- document every conversion is an identity after one map lookup.
+module Language.Rzk.VSCode.PositionEncoding (
+  AstralLines,
+  astralLines,
+  utf16Length,
+  colToUtf16,
+  colFromUtf16,
+  positionFromUtf16,
+  rangeToUtf16,
+  tokensToUtf16,
+) where
+
+import qualified Data.IntMap.Strict          as IntMap
+import qualified Data.Text                   as T
+import           Language.LSP.Protocol.Types (Position (Position),
+                                              Range (Range),
+                                              SemanticTokenAbsolute (..))
+
+-- | The lines of a document on which code-point and UTF-16 columns differ,
+-- keyed by 0-based line number.
+newtype AstralLines = AstralLines (IntMap.IntMap T.Text)
+
+astralLines :: T.Text -> AstralLines
+astralLines src = AstralLines $ IntMap.fromDistinctAscList
+  [ (i, line) | (i, line) <- zip [0 ..] (T.lines src), T.any isAstral line ]
+
+isAstral :: Char -> Bool
+isAstral c = c > '\xFFFF'
+
+utf16Width :: Char -> Int
+utf16Width c = if isAstral c then 2 else 1
+
+-- | The length of a text in UTF-16 code units.
+utf16Length :: T.Text -> Int
+utf16Length = T.foldl' (\n c -> n + utf16Width c) 0
+
+-- | Convert a 0-based code-point column on the given 0-based line to UTF-16
+-- units. A column beyond the end of the line keeps its distance past the end
+-- (the diagnostics code uses column 99 to mean "to the end of the line").
+colToUtf16 :: AstralLines -> Int -> Int -> Int
+colToUtf16 (AstralLines ls) line col =
+  case IntMap.lookup line ls of
+    Nothing   -> col
+    Just text -> utf16Length (T.take col text) + max 0 (col - T.length text)
+
+-- | Convert a 0-based UTF-16 column on the given 0-based line to code
+-- points. A column inside a surrogate pair maps to the start of its
+-- character.
+colFromUtf16 :: AstralLines -> Int -> Int -> Int
+colFromUtf16 (AstralLines ls) line col =
+  case IntMap.lookup line ls of
+    Nothing   -> col
+    Just text -> go 0 0 (T.unpack text)
+      where
+        go cp units (c : cs)
+          | units >= col                = cp
+          | units + utf16Width c > col  = cp
+          | otherwise                   = go (cp + 1) (units + utf16Width c) cs
+        go cp units []                  = cp + max 0 (col - units)
+
+-- | Convert an incoming LSP position (UTF-16) to code points.
+positionFromUtf16 :: AstralLines -> Position -> Position
+positionFromUtf16 als (Position l c) =
+  Position l (fromIntegral (colFromUtf16 als (fromIntegral l) (fromIntegral c)))
+
+-- | Convert an outgoing range (code points) to UTF-16.
+rangeToUtf16 :: AstralLines -> Range -> Range
+rangeToUtf16 als (Range s e) = Range (posToUtf16 s) (posToUtf16 e)
+  where
+    posToUtf16 (Position l c) =
+      Position l (fromIntegral (colToUtf16 als (fromIntegral l) (fromIntegral c)))
+
+-- | Convert semantic tokens (code points) to UTF-16. The length is converted
+-- through the token's end column, so a token that itself contains astral
+-- characters (e.g. the @𝕀@ keyword) gets its UTF-16 width.
+tokensToUtf16 :: AstralLines -> [SemanticTokenAbsolute] -> [SemanticTokenAbsolute]
+tokensToUtf16 als@(AstralLines ls) tokens
+  | IntMap.null ls = tokens
+  | otherwise      = map adjust tokens
+  where
+    adjust token = token
+      { _startChar = fromIntegral start'
+      , _length    = fromIntegral (end' - start')
+      }
+      where
+        line   = fromIntegral (_line token)
+        start  = fromIntegral (_startChar token)
+        start' = colToUtf16 als line start
+        end'   = colToUtf16 als line (start + fromIntegral (_length token))

--- a/rzk/test/Rzk/PositionEncodingSpec.hs
+++ b/rzk/test/Rzk/PositionEncodingSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Position conversion at the LSP boundary: code points vs UTF-16 units
+-- (see issue #303). An astral-plane character such as @𝕀@ counts as one code
+-- point but two UTF-16 units, so every position to its right on the same
+-- line differs between the two encodings.
+module Rzk.PositionEncodingSpec (spec) where
+
+import           Test.Hspec
+
+#ifdef LSP_ENABLED
+import qualified Data.Text                             as T
+import           Language.LSP.Protocol.Types           (SemanticTokenAbsolute (..))
+import           Language.Rzk.VSCode.PositionEncoding
+import           Language.Rzk.VSCode.Tokenize          (tokenizeSyntaxSymbols)
+
+-- | @ab𝕀cd@: code points a0 b1 𝕀2 c3 d4; UTF-16 a0 b1 𝕀2 c4 d5.
+astralLine :: T.Text
+astralLine = "ab\120128cd"
+
+spec :: Spec
+spec = do
+  describe "column conversion" $ do
+    let als = astralLines astralLine
+
+    it "is the identity before an astral character" $ do
+      colToUtf16 als 0 2 `shouldBe` 2
+      colFromUtf16 als 0 2 `shouldBe` 2
+
+    it "shifts by one per astral character to the left" $ do
+      colToUtf16 als 0 3 `shouldBe` 4
+      colToUtf16 als 0 5 `shouldBe` 6
+      colFromUtf16 als 0 4 `shouldBe` 3
+      colFromUtf16 als 0 6 `shouldBe` 5
+
+    it "maps a column inside a surrogate pair to the character start" $
+      colFromUtf16 als 0 3 `shouldBe` 2
+
+    it "keeps the distance past the end of the line" $
+      -- The diagnostics code uses column 99 for "to the end of the line".
+      colToUtf16 als 0 99 `shouldBe` 100
+
+    it "is the identity on lines without astral characters" $ do
+      let alsAscii = astralLines "abcd\nefgh"
+      colToUtf16 alsAscii 1 3 `shouldBe` 3
+      colFromUtf16 alsAscii 1 3 `shouldBe` 3
+
+    it "round-trips on character boundaries" $ do
+      let cols = [0 .. 6]
+      [ colFromUtf16 als 0 (colToUtf16 als 0 c) | c <- cols ] `shouldBe` cols
+
+  describe "utf16Length" $
+    it "counts an astral character as two units" $
+      utf16Length astralLine `shouldBe` 6
+
+  describe "semantic tokens" $ do
+    -- @#define f (x : 𝕀) : 𝕀 := x@ — 𝕀 at code points 15 and 20, @:=@ at 22.
+    let src = "#lang rzk-1\n#define f (x : \120128) : \120128 := x\n"
+        als = astralLines src
+        toks = tokensToUtf16 als (tokenizeSyntaxSymbols src)
+        spansAt line = [ (_startChar t, _length t) | t <- toks, _line t == line ]
+
+    it "reports the UTF-16 width of an astral token" $
+      -- The first 𝕀: same start (nothing astral before it), doubled width.
+      spansAt 1 `shouldSatisfy` elem (15, 2)
+
+    it "shifts tokens to the right of an astral character" $ do
+      -- The second 𝕀 (code point 20) has one astral character before it,
+      -- and @:=@ (code point 22) has two.
+      spansAt 1 `shouldSatisfy` elem (21, 2)
+      spansAt 1 `shouldSatisfy` elem (24, 2)
+
+    it "does not move tokens on other lines" $
+      spansAt 0 `shouldSatisfy` elem (0, 5)   -- #lang
+#else
+spec :: Spec
+spec = describe "position encoding" (pure ())
+#endif


### PR DESCRIPTION
This PR fixes #303. Typing `𝕀` used to break highlighting: the glyph rendered as two broken symbols and everything to its right on the same line was shifted; hover and go-to-definition to the right of it resolved to the wrong identifier or to nothing.

The cause is a position-encoding mismatch. LSP positions count UTF-16 code units (the default encoding, and the only one VS Code supports), while alex positions and everything derived from them count Unicode code points. The two differ exactly on lines containing astral-plane characters (code points above U+FFFF, such as `𝕀`), each of which takes two UTF-16 units. A token boundary landing inside a surrogate pair is what shatters the glyph in the editor.

Everything internal stays in code points; the new `Language.Rzk.VSCode.PositionEncoding` module converts at the wire boundary, in both directions. Its `AstralLines` map records only the lines where the two encodings differ, so for the common all-BMP document every conversion is an identity after one map lookup. The handlers now convert:

- semantic token positions and lengths (a `𝕀` token also gets its UTF-16 width of 2);
- parse-error diagnostic ranges and the full-document formatting range;
- document and workspace symbol ranges, hover, definition and reference locations (fetching the line map once per target file);
- incoming cursor positions for hover, definition, and references, converted back to code points before the reference index lookup.

Type-error and hole diagnostics are line-level and unaffected.

<img width="154" height="64" alt="Снимок экрана — 2026-07-18 в 21 32 02" src="https://github.com/user-attachments/assets/6d7565ac-70a6-4b9b-9487-9a7c98f8deeb" />
