### PR TITLE
Sink declarations and name lists by coercion

### DIFF
--- a/rzk/src/Language/Rzk/Foil/Convert.hs
+++ b/rzk/src/Language/Rzk/Foil/Convert.hs
@@ -1,4 +1,9 @@
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+-- The scope-extension evidence on 'sinkBound' (a coercion) is its soundness
+-- contract, not an argument it can consume, so GHC calls it redundant (and
+-- suggests "simplifying" foil's quantified-constraint Ext instance into the
+-- signature, which would be absurd). Both warnings stay off.
+{-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-redundant-constraints
+                -fno-warn-simplifiable-class-constraints #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -33,6 +38,7 @@ import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import qualified Data.Set                 as Set
 import           Debug.Trace              (trace)   -- FIXME: use proper mechanisms for warnings
+import           Unsafe.Coerce            (unsafeCoerce)
 
 import           Language.Rzk.Foil.Syntax
 import           Language.Rzk.Foil.Names (Binder (..), Display, TModality (..),
@@ -311,7 +317,7 @@ withOpenTerm term k = go Foil.emptyScope [] Map.empty idents
     go scope bound names (x : xs) =
       Foil.withFresh scope $ \binder ->
         let scope' = Foil.extendScope binder scope
-            bound' = (x, Foil.nameOf binder) : map (fmap Foil.sink) bound
+            bound' = (x, Foil.nameOf binder) : sinkBound bound
          in go scope' bound' (Map.insert x (x, BinderVar (Just x)) names) xs
 
     envOf bound x = case lookup x bound of
@@ -324,6 +330,14 @@ withOpenTerm term k = go Foil.emptyScope [] Map.empty idents
       | (x, v) <- bound
       , Just display <- [Map.lookup x names]
       ]
+
+-- | Sink an association list of binders by coercion, with no per-entry
+-- rebuild ('withOpenTerm' calls this at every binder it opens).
+-- 'Foil.sinkContainer' cannot see through the pair (its element must be the
+-- sunk type itself), but the sinkability argument is the same: only the
+-- names mention the scope, and a name sinks by coercion.
+sinkBound :: Foil.DExt n l => [(VarIdent, Foil.Name n)] -> [(VarIdent, Foil.Name l)]
+sinkBound = unsafeCoerce
 
 -- | Every identifier occurring in a piece of surface syntax, bound or free.
 collectVarIdents :: Data a => a -> [Rzk.VarIdent]

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -1,4 +1,7 @@
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+-- The scope-extension evidence on 'sinkDeclGroups' (a coercion) is its
+-- soundness contract, not an argument it can consume, so GHC calls it
+-- redundant. It stays.
+{-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-redundant-constraints #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -29,6 +32,7 @@ import           Data.List                 (intercalate)
 import qualified Data.Map                  as Map
 import qualified Data.Text                 as T
 import           Debug.Trace               (trace)
+import           Unsafe.Coerce             (unsafeCoerce)
 
 import           Control.Monad.Foil        (DExt, Distinct, NameBinder)
 import qualified Control.Monad.Foil        as Foil
@@ -63,15 +67,29 @@ data Decl n = Decl
   , declLocation     :: Maybe LocationInfo
   }
 
--- | A declaration sinks along a scope extension, by coercion (see the note in
--- "Rzk.TypeCheck.Context").
+-- | A declaration sinks along a scope extension by coercion, like the
+-- context does (see the note in "Rzk.TypeCheck.Context"); the proof
+-- obligation is discharged field by field.
+instance Foil.Sinkable Decl where
+  sinkabilityProof rename decl = decl
+    { declNameOf = rename (declNameOf decl)
+    , declType = Foil.sinkabilityProof rename (declType decl)
+    , declValue = Foil.sinkabilityProof rename <$> declValue decl
+    , declUsedVars = rename <$> declUsedVars decl
+    }
+
 sinkDecl :: DExt n l => Decl n -> Decl l
-sinkDecl decl = decl
-  { declNameOf = Foil.sink (declNameOf decl)
-  , declType = Foil.sink (declType decl)
-  , declValue = Foil.sink <$> declValue decl
-  , declUsedVars = Foil.sink <$> declUsedVars decl
-  }
+sinkDecl = Foil.sink
+
+-- | Sinking a whole list is a coercion too, with no per-element rebuild.
+sinkDecls :: DExt n l => [Decl n] -> [Decl l]
+sinkDecls = Foil.sinkContainer
+
+-- | The per-file groups also sink by coercion. 'Foil.sinkContainer' cannot
+-- see through the pair (its element must be the sunk type itself), but the
+-- sinkability argument is the same: only the declarations mention the scope.
+sinkDeclGroups :: DExt n l => [(FilePath, [Decl n])] -> [(FilePath, [Decl l])]
+sinkDeclGroups = unsafeCoerce
 
 -- | What a run of the checker produced: the top-level scope, the declarations in
 -- it, and the errors found.
@@ -123,9 +141,9 @@ withTopLevel name ty mval isAssumption usedVars mrole k = do
           { declName = name
           , declNameOf = Foil.nameOf binder
           , declType = Foil.sink ty
-          , declValue = Foil.sink <$> mval
+          , declValue = Foil.sinkContainer mval
           , declIsAssumption = isAssumption
-          , declUsedVars = Foil.sink <$> usedVars
+          , declUsedVars = Foil.sinkContainer usedVars
           , declLocation = ctxLocation ctx
           }
     inContext ctx' (k binder decl)
@@ -633,7 +651,7 @@ withDataDecls path used name paramVars paramDecls consData k = do
   dDeps <- assumptionDepsOf dTy
   withTopLevel (varIdentAt path name) dTy Nothing False
     (nubNames (used <> dDeps)) Nothing $ \dBinder dDecl ->
-      bindCons (Foil.nameOf dBinder) (map Foil.sink used) 0 consData [sinkDecl dDecl] $
+      bindCons (Foil.nameOf dBinder) (Foil.sinkContainer used) 0 consData [sinkDecl dDecl] $
         \dName usedL declsAcc -> bindElims dName usedL declsAcc
   where
     numParams  = length paramDecls
@@ -665,8 +683,8 @@ withDataDecls path used name paramVars paramDecls consData k = do
       let role = DataRole dName numParams (DataConKind index (length (dataConFields con)))
       withTopLevel (varIdentAt path (dataConName con)) conTy Nothing False
         (nubNames (usedHere <> conDeps)) (Just role) $ \_conBinder conDecl ->
-          bindCons (Foil.sink dName) (map Foil.sink usedHere) (index + 1) rest
-            (map sinkDecl acc <> [conDecl]) kk
+          bindCons (Foil.sink dName) (Foil.sinkContainer usedHere) (index + 1) rest
+            (sinkDecls acc <> [conDecl]) kk
 
     bindElims
       :: forall m. DExt n m
@@ -710,9 +728,9 @@ withDataDecls path used name paramVars paramDecls consData k = do
           recTy' <- memoizeWHNF =<< typecheck recTyT universeT
           recDeps <- assumptionDepsOf recTy'
           withTopLevel (varIdentAt path recName) recTy' Nothing False
-            (nubNames (map Foil.sink usedHere <> recDeps))
+            (nubNames (Foil.sinkContainer usedHere <> recDeps))
             (Just (DataRole (Foil.sink dName) numParams (DataElimKind numMethods ElimRec))) $ \_ recDecl ->
-              k (map sinkDecl (map sinkDecl declsAcc <> [indDecl]) <> [recDecl])
+              k (sinkDecls (sinkDecls declsAcc <> [indDecl]) <> [recDecl])
 
 prefixedIdent :: T.Text -> Rzk.VarIdent -> Rzk.VarIdent
 prefixedIdent p (Rzk.VarIdent pos (Rzk.VarIdentToken t)) =
@@ -841,7 +859,7 @@ checkCommands path i total commands k = case commands of
         consData <- mapM (dataConSurface name paramVars paramDecls) cons
         withDataDecls path used name paramVars paramDecls consData $ \decls ->
           checkCommands path (i + 1) total more $ \moreDecls errs ->
-            k (map sinkDecl decls <> moreDecls) errs
+            k (sinkDecls decls <> moreDecls) errs
 
   command@(Rzk.CommandPostulate _loc name (Rzk.DeclUsedVars _ vars) params ty) : more ->
     announce (" Checking #postulate " <> Rzk.printTree name) $
@@ -862,7 +880,7 @@ checkCommands path i total commands k = case commands of
         ty' <- typecheck tyTerm universeT
         assume (map (varIdentAt path) names) ty' $ \assumed ->
           checkCommands path (i + 1) total more $ \decls errs ->
-            k (map sinkDecl assumed <> decls) errs
+            k (sinkDecls assumed <> decls) errs
 
   command@(Rzk.CommandCheck _loc term ty) : more ->
     announce (" Checking " <> Rzk.printTree term <> " : " <> Rzk.printTree ty) $
@@ -898,7 +916,7 @@ checkCommands path i total commands k = case commands of
       withSection (Just name) i sectionCommands path total $ \sectionDecls sectionErrs ->
         if null sectionErrs
           then checkCommands path (i + countCommands sectionCommands) total more' $
-            \decls errs -> k (map sinkDecl sectionDecls <> decls) errs
+            \decls errs -> k (sinkDecls sectionDecls <> decls) errs
           else k sectionDecls sectionErrs
 
   command@(Rzk.CommandSectionEnd _loc endName) : _more ->
@@ -976,7 +994,7 @@ checkModules (m@(path, _) : ms) k =
     case errs of
       _:_ -> k [(path, decls)] errs
       _ -> checkModules ms $ \rest errors ->
-        k ((path, map sinkDecl decls) : rest) errors
+        k ((path, sinkDecls decls) : rest) errors
 
 -- * The public entry points
 
@@ -1088,7 +1106,7 @@ recheckFrom (Checked ctx decls _errs _warnings) modules =
   fmap package $ runExcept $ runWriterT $ flip runReaderT ctx $
     checkModules modules $ \newDecls errs -> do
       ctx' <- ask
-      pure (Checked ctx' (map (fmap (map sinkDecl)) decls <> newDecls) errs [])
+      pure (Checked ctx' (sinkDeclGroups decls <> newDecls) errs [])
   where
     -- Only this run's warnings: like the errors, the prefix's warnings were
     -- already reported when the prefix was checked.

--- a/rzk/src/Rzk/TypeCheck/Render.hs
+++ b/rzk/src/Rzk/TypeCheck/Render.hs
@@ -332,7 +332,7 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
               ret' <- openScoped binder ret
               -- FIXME: breaks for 2 * (2 * 2), but works for 2 * 2 * 2 = (2 * 2) * 2
               Just <$> renderForSubShapeSVG mainColor dim
-                (map Foil.sink xs) (Foil.nameOf binder)
+                (Foil.sinkContainer xs) (Foil.nameOf binder)
                 ret' (Foil.sink f) (Foil.sink x)
       _ -> do
         t' <- whnfT t
@@ -351,8 +351,8 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
             pure (appT ret' (Foil.sink t') z)
         let mp' | extend = join' (fmap (both Foil.sink) mp) arg' z
                 | otherwise = fmap (both Foil.sink) mp
-            xs' | extend = Foil.nameOf binder : map Foil.sink xs
-                | otherwise = map Foil.sink xs
+            xs' | extend = Foil.nameOf binder : Foil.sinkContainer xs
+                | otherwise = Foil.sinkContainer xs
         renderTermSVGFor mainColor accDim' (mp', xs') body
 
     both f (x, y) = (f x, f y)


### PR DESCRIPTION
Sinking is a coercion in free-foil (`sink = unsafeCoerce`, and `sinkContainer` extends it to any `Functor` container), but several places still paid for it per element. This PR removes them:

- `Decl` gets a `Sinkable` instance, so `sinkDecl` is `Foil.sink` instead of a field-by-field record rebuild, and every `map sinkDecl` becomes `sinkDecls = Foil.sinkContainer` (no per-element spine rebuild).
- Every `map Foil.sink` over name lists (the used-variable threading in the `#data` binder chain, the renderer's superseded-name lists) becomes `Foil.sinkContainer`.
- Two shapes `sinkContainer` cannot see through — its element must be the sunk type itself — are coerced directly with the argument stated in a comment, following the `sinkContextUnchecked` precedent: `withOpenTerm`'s binder association list (previously rebuilt per entry at every binder it opens) and `recheckFrom`'s per-file declaration groups.

No behaviour change.