### PR TITLE
LSP: use-site semantic highlighting for #data products

### DIFF
--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -19,6 +19,7 @@ module Language.Rzk.VSCode.Handlers (
   formatSignature,
   formatDocument,
   provideSemanticTokens,
+  useSiteTokens,
   handleFilesChanged,
 ) where
 
@@ -43,6 +44,7 @@ import           Language.LSP.Diagnostics      (partitionBySource)
 import           Language.LSP.Protocol.Lens    (HasContext (context),
                                                 HasDetail (detail),
                                                 HasDocumentation (documentation),
+                                                HasKind (kind),
                                                 HasLabel (label),
                                                 HasParams (params),
                                                 HasPosition (position),
@@ -433,9 +435,10 @@ provideCompletions req res = do
     declsToItems :: FilePath -> (FilePath, [DeclView]) -> [CompletionItem]
     declsToItems root (path, decls) = map (declToItem root path) decls
     declToItem :: FilePath -> FilePath -> DeclView -> CompletionItem
-    declToItem rootDir path (DeclView name type' _ _loc _kind) = def
+    declToItem rootDir path (DeclView name type' _ _loc declKind) = def
 
       & label .~ T.pack (printTree $ getVarIdent name)
+      & kind ?~ completionKindOfDecl declKind
       & detail ?~ T.pack (show type')
       & documentation ?~ InR (MarkupContent MarkupKind_Markdown $ T.pack $
           "---\nDefined" ++
@@ -508,7 +511,16 @@ formatDocument req res = do
 provideSemanticTokens :: Handler LSP 'Method_TextDocumentSemanticTokensFull
 provideSemanticTokens req responder = do
   let doc = req ^. params . textDocument . uri . to toNormalizedUri
+      currentFile = fromMaybe "" (uriToFilePath (req ^. params . textDocument . uri))
   mdoc <- getVirtualFile doc
+  -- Use-site classification needs name resolution (an occurrence of a
+  -- constructor is a plain variable to the AST walk): the reference index
+  -- resolves the occurrences, and the typecheck cache knows each
+  -- declaration's kind.
+  referenceIndex <- indexProject currentFile
+  cachedModules <- getCachedTypecheckedModules
+  let declsByFile = [ (path, cachedModuleDecls m) | (path, m) <- cachedModules ]
+      overlay = useSiteTokens declsByFile referenceIndex currentFile
   possibleTokens <- case virtualFileText <$> mdoc of
     Nothing         -> return (Left "Failed to get file content")
     Just sourceCode -> do
@@ -521,8 +533,10 @@ provideSemanticTokens req responder = do
           logWarning ("Failed to parse file for semantic tokens: " <> err)
           return []
         Right rzkModule -> return (tokenizeModule rzkModule)
+      -- On overlapping positions: the AST walk wins (it has the declaration
+      -- modifiers), then the use-site overlay, then the lexer baseline.
       return (Right (Enc.tokensToUtf16 (Enc.astralLines src)
-        (mergeTokens astTokens (tokenizeSyntaxSymbols src))))
+        (mergeTokens (mergeTokens astTokens overlay) (tokenizeSyntaxSymbols src))))
   case possibleTokens of
     Left err -> do
       -- Exception occurred when parsing the module
@@ -730,10 +744,10 @@ provideSymbols req res = do
       _ -> declToSymbol als Nothing d : outline als ds
 
     declToSymbol :: Enc.AstralLines -> Maybe [DocumentSymbol] -> DeclView -> DocumentSymbol
-    declToSymbol als mchildren decl@(DeclView _ type' _ _loc kind) = DocumentSymbol
+    declToSymbol als mchildren decl@(DeclView _ type' _ _loc declKind) = DocumentSymbol
       { _name           = symbolName
       , _detail         = Just (T.pack (show type'))
-      , _kind           = symbolKindOfDecl kind
+      , _kind           = symbolKindOfDecl declKind
       , _tags           = Nothing
       , _deprecated     = Nothing
       , _range          = range
@@ -752,6 +766,69 @@ symbolKindOfDecl = \case
   DeclKindDataCon _  -> SymbolKind_EnumMember
   DeclKindDataElim _ -> SymbolKind_Function
   DeclKindDefine     -> SymbolKind_Function
+
+-- | The completion kind of a declaration, mirroring 'symbolKindOfDecl'.
+completionKindOfDecl :: DeclKind -> CompletionItemKind
+completionKindOfDecl = \case
+  DeclKindData       -> CompletionItemKind_Class
+  DeclKindDataCon _  -> CompletionItemKind_EnumMember
+  DeclKindDataElim _ -> CompletionItemKind_Function
+  DeclKindDefine     -> CompletionItemKind_Function
+
+-- | The checker-derived token overlay for identifier /uses/: an occurrence
+-- that resolves to a product of a @#data@ declaration is coloured by its
+-- kind wherever it appears — a constructor as an enum member, the type as a
+-- class, a generated eliminator as a library function. Occurrences are
+-- matched to declarations by definition site (file and line) /and/ name, so
+-- a local that shadows a constructor stays plain, and plain definitions are
+-- left to the lexer baseline. Positions are code points, like every other
+-- token source; the UTF-16 conversion happens after merging.
+useSiteTokens
+  :: [(FilePath, [DeclView])]  -- ^ the typechecked declarations, per file
+  -> RefInd.ReferenceIndex
+  -> FilePath                  -- ^ the file to produce tokens for
+  -> [SemanticTokenAbsolute]
+useSiteTokens declsByFile refIndex path =
+  [ SemanticTokenAbsolute
+      { _line = fromIntegral l
+      , _startChar = fromIntegral s
+      , _length = fromIntegral (e - s)
+      , _tokenType = tokenType
+      , _tokenModifiers = modifiers
+      }
+  | (binding, l, s, e) <- RefInd.fileOccurrences refIndex path
+  , Just (tokenType, modifiers) <- [classify binding]
+  ]
+  where
+    classify binding = do
+      let RefInd.Location (RefInd.Uri defPath) range = RefInd.bindingDef binding
+          defStart = RefInd.rangeStart range
+          key = ( defPath
+                , RefInd.positionLine defStart
+                , RefInd.positionCharacter defStart
+                , RefInd.bindingName binding )
+      declKind <- Map.lookup key kindTable
+      case declKind of
+        DeclKindData       -> Just (SemanticTokenTypes_Class, [])
+        DeclKindDataCon _  -> Just (SemanticTokenTypes_EnumMember, [])
+        DeclKindDataElim _ ->
+          Just (SemanticTokenTypes_Function, [SemanticTokenModifiers_DefaultLibrary])
+        DeclKindDefine     -> Nothing
+    -- Keyed by the declared name's own position, which is what the index
+    -- records as the definition site (a constructor's key is where it is
+    -- written, also in a multi-line declaration). The generated eliminators
+    -- share the type name's position — its derived zero-width entries — so
+    -- the name is part of the key.
+    kindTable = Map.fromList
+      [ ((file, line - 1, col - 1, name), declViewKind d)
+      | (_, decls) <- declsByFile
+      , d <- decls
+      , let ident = getVarIdent (declViewName d)
+      , let name = T.pack (printTree ident)
+      , VarIdent (RzkPosition mpath mpos) _ <- [ident]
+      , Just file <- [mpath]
+      , Just (line, col) <- [mpos]
+      ]
 
 -- | Workspace-wide symbol search over every typechecked module in the cache.
 -- The query is matched case-insensitively as an infix of the definition name;

--- a/rzk/src/Language/Rzk/VSCode/ReferenceIndex.hs
+++ b/rzk/src/Language/Rzk/VSCode/ReferenceIndex.hs
@@ -13,6 +13,7 @@ module Language.Rzk.VSCode.ReferenceIndex (
   lookupAt,
   bindingSites,
   locationPath,
+  fileOccurrences,
 ) where
 
 import           Control.Applicative      ((<|>))
@@ -102,6 +103,18 @@ lookupAt index (Uri path) (Position l c) =
   case Map.lookup (path, l) (occurrences index) of
     Nothing    -> Nothing
     Just spans -> listToMaybe [ b | (s, e, b) <- spans, s <= c, c < e ]
+
+-- | Every occurrence recorded for a file, with the binding it resolves to:
+-- 0-based line and column span. Zero-width spans (the derived def entries of
+-- generated eliminators) are skipped; they occupy no characters.
+fileOccurrences :: ReferenceIndex -> FilePath -> [(Binding, Int, Int, Int)]
+fileOccurrences index path =
+  [ (b, l, s, e)
+  | ((p, l), spans) <- Map.toList (occurrences index)
+  , p == path
+  , (s, e, b) <- spans
+  , e > s
+  ]
 
 indexModules :: [(FilePath, Rzk.Module)] -> ReferenceIndex
 indexModules modules = group $

--- a/rzk/src/Language/Rzk/VSCode/Tokenize.hs
+++ b/rzk/src/Language/Rzk/VSCode/Tokenize.hs
@@ -374,7 +374,10 @@ classifySymbol s
   | otherwise            = Just SemanticTokenTypes_Operator
   where
     -- Plain brackets are left to the editor (e.g. bracket pair colorization).
-    ignored = ["(", ")", "[", "]", "{", "}", ";", "<", ">"]
+    -- @}@ is not among them: since the brace shape-parameters were removed,
+    -- it occurs only as the closer of @=_{@ and @refl_{@, which classify as
+    -- operators, so it takes the same colour as its opener.
+    ignored = ["(", ")", "[", "]", "{", ";", "<", ">"]
 
 -- | Combine tokens from the parsed module with tokens from the raw symbol
 -- stream. On overlap (same start position) the AST-based token wins, since

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -214,6 +214,9 @@ endSection errs = do
   where
     sameName a b = Foil.nameId a == Foil.nameId b
 
+    -- The entry records where it was declared; the section-close location is
+    -- only the fallback (previously every declaration of a section carried
+    -- the #end-time location, i.e. the last command's line).
     toDecl loc (name, info) = Decl
       { declName = case varOrig info of
           BinderVar (Just x) -> x
@@ -223,7 +226,9 @@ endSection errs = do
       , declValue = varValue info
       , declIsAssumption = varIsAssumption info
       , declUsedVars = varDeclaredAssumptions info
-      , declLocation = loc
+      , declLocation = case varLocation info of
+          Just declaredAt -> Just declaredAt
+          Nothing         -> loc
       }
 
 -- | An error, captured in the current context (rather than thrown).

--- a/rzk/test/Rzk/SemanticTokensSpec.hs
+++ b/rzk/test/Rzk/SemanticTokensSpec.hs
@@ -9,11 +9,16 @@ import           Test.Hspec
 #ifdef LSP_ENABLED
 import qualified Data.Text                    as T
 import           Language.LSP.Protocol.Types  (SemanticTokenAbsolute (..),
+                                               SemanticTokenModifiers (..),
                                                SemanticTokenTypes (..))
 import           Language.Rzk.Syntax          (parseModule, parseTerm)
-import           Language.Rzk.VSCode.Handlers (formatSignature)
+import           Language.Rzk.VSCode.Handlers (formatSignature, useSiteTokens)
+import qualified Language.Rzk.VSCode.ReferenceIndex as RI
 import           Language.Rzk.VSCode.Tokenize (mergeTokens, tokenizeModule,
                                                tokenizeSyntaxSymbols)
+import           Rzk.TypeCheck                (Context (..), Verbosity (..),
+                                               checkedModules, declViews,
+                                               emptyContext)
 
 -- | Merged tokens of a module, as 'provideSemanticTokens' produces them.
 tokensOf :: T.Text -> [SemanticTokenAbsolute]
@@ -38,8 +43,61 @@ exampleModule = T.unlines
   , "#check TOP : TOPE"                           -- 2
   ]
 
+-- | The use-site overlay of a one-file project: typechecked declarations
+-- plus the reference index, as 'provideSemanticTokens' combines them.
+useSiteTokensOf :: T.Text -> [SemanticTokenAbsolute]
+useSiteTokensOf src = case parseModule src of
+  Left err -> error ("parse error: " <> T.unpack err)
+  Right m  -> case checkedModules [(path, m)] silentContext of
+    Left _err -> error "unexpected type error in use-site fixture"
+    Right (checked, _holes) ->
+      useSiteTokens (declViews checked) (RI.indexModules [(path, m)]) path
+  where
+    path = "use-site.rzk"
+    silentContext = emptyContext { ctxVerbosity = Silent }
+
+-- | The token type and modifiers starting at a (0-based) position, if any.
+useTokenAt :: [SemanticTokenAbsolute] -> (Int, Int) -> Maybe (SemanticTokenTypes, [SemanticTokenModifiers])
+useTokenAt toks (l, c) = case
+  [ (_tokenType t, _tokenModifiers t)
+  | t <- toks
+  , _line t == fromIntegral l, _startChar t == fromIntegral c
+  ] of
+    (tt : _) -> Just tt
+    []       -> Nothing
+
+dataModule :: T.Text
+dataModule = T.unlines
+  [ "#lang rzk-1"                                    -- 0
+  , "#data bool := false | true"                     -- 1
+  , "#define not (b : bool) : bool"                  -- 2
+  , "  := rec-bool bool true false b"                -- 3
+  , "#define shadow (false : bool) : bool := false"  -- 4
+  ]
+
 spec :: Spec
 spec = do
+  describe "use-site tokens" $ do
+    let toks = useSiteTokensOf dataModule
+
+    it "colour a constructor occurrence as an enum member" $
+      useTokenAt toks (3, 19) `shouldBe` Just (SemanticTokenTypes_EnumMember, [])
+
+    it "colour a data type occurrence as a class" $ do
+      useTokenAt toks (3, 14) `shouldBe` Just (SemanticTokenTypes_Class, [])
+      useTokenAt toks (2, 17) `shouldBe` Just (SemanticTokenTypes_Class, [])
+
+    it "colour a generated eliminator occurrence as a library function" $
+      useTokenAt toks (3, 5)
+        `shouldBe` Just (SemanticTokenTypes_Function, [SemanticTokenModifiers_DefaultLibrary])
+
+    it "leave a local that shadows a constructor plain" $
+      -- the body of shadow uses its parameter, not the constructor
+      useTokenAt toks (4, 40) `shouldBe` Nothing
+
+    it "leave plain definitions to the other token sources" $
+      useTokenAt toks (3, 30) `shouldBe` Nothing                -- b, a binder use
+
   describe "semantic tokens" $ do
     let toks = tokensOf exampleModule
         positions = [ (_line t, _startChar t) | t <- toks ]


### PR DESCRIPTION
With #306, the products of a `#data` are highlighted at their declaration, but an occurrence of `inl` in a term was still a plain variable to the AST tokenizer. This PR classifies the uses: a constructor colours as an enum member wherever it appears, the type as a class, and a generated eliminator as a default-library function.

<img width="550" height="350" alt="Снимок экрана — 2026-07-19 в 02 02 04" src="https://github.com/user-attachments/assets/6f19e2ff-5cc5-4089-8fbb-44f82b216ce7" />

The mechanism is a checker-derived overlay. The reference index resolves every identifier occurrence to its definition site, and the typecheck cache knows each declaration's kind, so an occurrence is classified by looking its definition up in a table keyed by the declared name's own position plus the name (the generated eliminators share the type name's position through their derived entries, so the name disambiguates). A local that shadows a constructor resolves to its own binder and stays plain. The overlay merges below the AST walk, so declaration sites keep their modifiers, and above the lexer baseline, which remains the fallback while a file fails to parse or check. Completion items carry the same kinds (enum member, class, function).

In passing this fixes a declaration-location bug: closing a section stamped every declaration with the location at `#end` time (the last command's line), because `toDecl` ignored the entry's recorded location. Declaration views now point at the declaring command, which is also what the new classification relies on.