### PR TITLE
LSP: highlight postulates and assumptions distinctly

### DIFF
--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -765,6 +765,7 @@ symbolKindOfDecl = \case
   DeclKindData       -> SymbolKind_Class
   DeclKindDataCon _  -> SymbolKind_EnumMember
   DeclKindDataElim _ -> SymbolKind_Function
+  DeclKindPostulate  -> SymbolKind_Function
   DeclKindDefine     -> SymbolKind_Function
 
 -- | The completion kind of a declaration, mirroring 'symbolKindOfDecl'.
@@ -773,12 +774,18 @@ completionKindOfDecl = \case
   DeclKindData       -> CompletionItemKind_Class
   DeclKindDataCon _  -> CompletionItemKind_EnumMember
   DeclKindDataElim _ -> CompletionItemKind_Function
+  DeclKindPostulate  -> CompletionItemKind_Function
   DeclKindDefine     -> CompletionItemKind_Function
 
 -- | The checker-derived token overlay for identifier /uses/: an occurrence
 -- that resolves to a product of a @#data@ declaration is coloured by its
 -- kind wherever it appears — a constructor as an enum member, the type as a
--- class, a generated eliminator as a library function. Occurrences are
+-- class, a generated eliminator as a library function — and an occurrence
+-- of a postulate or an assumption is marked abstract (declared, but not
+-- proven), so a proof that leans on an axiom is visible at a glance.
+-- Postulates, top-level assumptions, and in-section assumptions get
+-- distinct type/modifier combinations, in decreasing order of severity.
+-- Occurrences are
 -- matched to declarations by definition site (file and line) /and/ name, so
 -- a local that shadows a constructor stays plain, and plain definitions are
 -- left to the lexer baseline. Positions are code points, like every other
@@ -800,7 +807,20 @@ useSiteTokens declsByFile refIndex path =
   , Just (tokenType, modifiers) <- [classify binding]
   ]
   where
-    classify binding = do
+    classify binding
+      -- Assumptions do not survive to the typechecked declarations (the
+      -- section mechanism folds them into their users), so they are
+      -- recognised by their syntactic definition site instead. A
+      -- top-level assumption is a file-wide axiom; one inside a section
+      -- is a hypothesis discharged at its #end, so it keeps the
+      -- parameter token type and only gains the abstract modifier.
+      | Just scope <- RefInd.assumeScopeAt refIndex (RefInd.bindingDef binding) =
+          Just $ case scope of
+            RefInd.AssumeTopLevel ->
+              (SemanticTokenTypes_Function, [SemanticTokenModifiers_Abstract])
+            RefInd.AssumeInSection ->
+              (SemanticTokenTypes_Parameter, [SemanticTokenModifiers_Abstract])
+      | otherwise = do
       let RefInd.Location (RefInd.Uri defPath) range = RefInd.bindingDef binding
           defStart = RefInd.rangeStart range
           key = ( defPath
@@ -813,6 +833,15 @@ useSiteTokens declsByFile refIndex path =
         DeclKindDataCon _  -> Just (SemanticTokenTypes_EnumMember, [])
         DeclKindDataElim _ ->
           Just (SemanticTokenTypes_Function, [SemanticTokenModifiers_DefaultLibrary])
+        -- The abstract and static modifiers are in the default legend, so
+        -- no custom legend is needed; clients style function.abstract
+        -- distinctly (the VS Code extension maps it to a bright scope).
+        -- The static modifier only distinguishes a postulate (a permanent
+        -- axiom) from a top-level assumption (discharged at module end),
+        -- so a postulate can be styled louder.
+        DeclKindPostulate  ->
+          Just ( SemanticTokenTypes_Function
+               , [SemanticTokenModifiers_Abstract, SemanticTokenModifiers_Static] )
         DeclKindDefine     -> Nothing
     -- Keyed by the declared name's own position, which is what the index
     -- records as the definition site (a constructor's key is where it is

--- a/rzk/src/Language/Rzk/VSCode/ReferenceIndex.hs
+++ b/rzk/src/Language/Rzk/VSCode/ReferenceIndex.hs
@@ -14,6 +14,8 @@ module Language.Rzk.VSCode.ReferenceIndex (
   bindingSites,
   locationPath,
   fileOccurrences,
+  AssumeScope (..),
+  assumeScopeAt,
 ) where
 
 import           Control.Applicative      ((<|>))
@@ -65,13 +67,34 @@ data Binding = Binding
   }
   deriving (Eq, Show)
 
-newtype ReferenceIndex = ReferenceIndex
+data ReferenceIndex = ReferenceIndex
   { occurrences :: Map.Map (FilePath, Int) [(Int, Int, Binding)]
     -- ^ Every occurrence (definition or reference), keyed by file and line,
     -- as column spans; identifiers never span lines. This is what makes
     -- 'lookupAt' a map lookup rather than a scan over all bindings.
+  , assumeSites :: Map.Map Location AssumeScope
+    -- ^ The definition sites of @#assume@d names, with their scope.
+    -- Assumptions do not survive to the typechecked declarations (the
+    -- section mechanism folds them into the definitions that use them), so
+    -- the semantic token overlay recognises them here, syntactically. The
+    -- scope is kept because the two kinds warrant different styling: a
+    -- top-level assumption is a file-wide axiom (such as function
+    -- extensionality), while one inside a section is a hypothesis the
+    -- section abstracts over at its @#end@.
   }
   deriving (Show)
+
+-- | Where a name was @#assume@d.
+data AssumeScope
+  = AssumeTopLevel   -- ^ outside any section: a file-wide axiom
+  | AssumeInSection  -- ^ inside a section: a hypothesis, discharged at @#end@
+  deriving (Eq, Show)
+
+-- | The assume-scope of a definition site, if it is one of an @#assume@d
+-- name. A local that shadows an assumption resolves to its own binder,
+-- not to a site recorded here.
+assumeScopeAt :: ReferenceIndex -> Location -> Maybe AssumeScope
+assumeScopeAt index loc = Map.lookup loc (assumeSites index)
 
 -- | One resolved occurrence: name, definition site, occurrence site, and
 -- (for the self-link of a binder) its printed type annotation.
@@ -129,6 +152,12 @@ indexModules modules = group $
           | b <- bs
           , Location (Uri path) (Range (Position l s) (Position _ e)) <- bindingSites b
           ]
+      , assumeSites = Map.fromList
+          [ (loc, scope)
+          | (file, m) <- modules
+          , (v, scope) <- assumesWithScope (moduleCommands m)
+          , Just loc <- [identLoc file v]
+          ]
       }
       where
         -- Binders produce a self-link (definition site linked to itself) so
@@ -147,6 +176,20 @@ indexModules modules = group $
 
 moduleCommands :: Rzk.Module -> [Rzk.Command]
 moduleCommands (Rzk.Module _ _ cmds) = cmds
+
+-- | The assumed names of a module with their scope, walking the flat
+-- command list with a section-depth counter.
+assumesWithScope :: [Rzk.Command] -> [(Rzk.VarIdent, AssumeScope)]
+assumesWithScope = go (0 :: Int)
+  where
+    go _ [] = []
+    go depth (c : cs) = case c of
+      Rzk.CommandSection _ _     -> go (depth + 1) cs
+      Rzk.CommandSectionEnd _ _  -> go (max 0 (depth - 1)) cs
+      Rzk.CommandAssume _ vars _ ->
+        let scope = if depth == 0 then AssumeTopLevel else AssumeInSection
+        in [ (v, scope) | v <- vars ] ++ go depth cs
+      _                          -> go depth cs
 
 -- | The top-level names a module contributes, with their definition sites.
 -- A @#data@ contributes its type name and constructors, plus the /derived/

--- a/rzk/src/Language/Rzk/VSCode/Tokenize.hs
+++ b/rzk/src/Language/Rzk/VSCode/Tokenize.hs
@@ -18,8 +18,26 @@ import qualified Language.Rzk.Syntax.Lex     as Lex
 tokenizeModule :: Module -> [SemanticTokenAbsolute]
 tokenizeModule (Module _loc langDecl commands) = concat
   [ tokenizeLanguageDecl langDecl
-  , foldMap tokenizeCommand commands
+  , tokenizeCommands 0 commands
   ]
+
+-- | Walk the commands tracking the section depth: an assumption outside
+-- any section is a file-wide axiom and is marked as an abstract function
+-- (see 'tokenizeCommand'), while an assumption inside a section is a
+-- hypothesis the section abstracts over at its @#end@, so it keeps the
+-- parameter token type and only gains the abstract modifier.
+tokenizeCommands :: Int -> [Command] -> [SemanticTokenAbsolute]
+tokenizeCommands _ [] = []
+tokenizeCommands depth (command : commands) = case command of
+  CommandSection{} ->
+    tokenizeCommand command ++ tokenizeCommands (depth + 1) commands
+  CommandSectionEnd{} ->
+    tokenizeCommand command ++ tokenizeCommands (max 0 (depth - 1)) commands
+  CommandAssume _loc vars type_ | depth > 0 -> concat
+    [ foldMap (\var -> mkToken var SemanticTokenTypes_Parameter [SemanticTokenModifiers_Declaration, SemanticTokenModifiers_Abstract]) vars
+    , tokenizeTerm type_
+    ] ++ tokenizeCommands depth commands
+  _ -> tokenizeCommand command ++ tokenizeCommands depth commands
 
 tokenizeLanguageDecl :: LanguageDecl -> [SemanticTokenAbsolute]
 tokenizeLanguageDecl _ = []
@@ -33,8 +51,13 @@ tokenizeCommand command = case command of
   CommandComputeNF    _loc term -> tokenizeTerm term
   CommandComputeWHNF  _loc term -> tokenizeTerm term
 
+  -- A postulate is declared, but not proven: the abstract modifier lets
+  -- clients render its name (here and at every use site, see
+  -- 'Language.Rzk.VSCode.Handlers.useSiteTokens') distinctly. The static
+  -- modifier distinguishes it from a top-level assumption: a postulate is
+  -- a permanent axiom, so clients can style it louder.
   CommandPostulate _loc name declUsedVars params type_ -> concat
-    [ mkToken name SemanticTokenTypes_Function [SemanticTokenModifiers_Declaration]
+    [ mkToken name SemanticTokenTypes_Function [SemanticTokenModifiers_Declaration, SemanticTokenModifiers_Abstract, SemanticTokenModifiers_Static]
     , tokenizeDeclUsedVars declUsedVars
     , foldMap tokenizeParam params
     , tokenizeTerm type_
@@ -46,8 +69,11 @@ tokenizeCommand command = case command of
     , foldMap tokenizeTerm [type_, term]
     ]
 
+  -- A name assumed at the top level is a file-wide axiom like a postulate
+  -- (see 'CommandPostulate' above), so it gets the same abstract marking;
+  -- 'tokenizeCommands' intercepts the in-section case.
   CommandAssume _loc vars type_ -> concat
-    [ foldMap (\var -> mkToken var SemanticTokenTypes_Parameter [SemanticTokenModifiers_Declaration]) vars
+    [ foldMap (\var -> mkToken var SemanticTokenTypes_Function [SemanticTokenModifiers_Declaration, SemanticTokenModifiers_Abstract]) vars
     , tokenizeTerm type_
     ]
   CommandSection    _loc name -> tokenizeSectionName name

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -1060,11 +1060,13 @@ data DeclView = DeclView
   , declViewKind         :: DeclKind
   } deriving (Eq, Show)
 
--- | What kind of declaration a 'DeclView' renders: a plain definition, or
--- one of the products of a @#data@ (the symbol providers group constructors
--- under their type and keep the generated eliminators out of the outline).
+-- | What kind of declaration a 'DeclView' renders: a plain definition, a
+-- postulate, or one of the products of a @#data@ (the symbol providers group
+-- constructors under their type and keep the generated eliminators out of
+-- the outline; the semantic tokens highlight postulates distinctly).
 data DeclKind
   = DeclKindDefine
+  | DeclKindPostulate          -- ^ a @#postulate@ or @#assume@: declared, but not proven
   | DeclKindData
   | DeclKindDataCon VarIdent   -- ^ a constructor of the named type
   | DeclKindDataElim VarIdent  -- ^ a generated eliminator of the named type
@@ -1090,6 +1092,10 @@ declViews (Checked ctx decls _errs _warnings) = map (fmap (map view)) decls
       Just (DataRole parent _ DataElimKind{}) -> DeclKindDataElim (parentNameOf parent)
       Nothing
         | Foil.nameId (declNameOf d) `elem` formerIds -> DeclKindData
+        -- A declaration with no value is an axiom, whether written as a
+        -- @#postulate@ or an @#assume@ (in practice both are used for
+        -- axioms such as function extensionality).
+        | Nothing <- declValue d -> DeclKindPostulate
         | otherwise -> DeclKindDefine
     view decl = DeclView
       { declViewName = declName decl

--- a/rzk/test/Rzk/SemanticTokensSpec.hs
+++ b/rzk/test/Rzk/SemanticTokensSpec.hs
@@ -75,6 +75,19 @@ dataModule = T.unlines
   , "#define shadow (false : bool) : bool := false"  -- 4
   ]
 
+postulateModule :: T.Text
+postulateModule = T.unlines
+  [ "#lang rzk-1"                                     -- 0
+  , "#postulate ax (A : U) (a : A) : A"               -- 1
+  , "#define use-ax (A : U) (a : A) : A := ax A a"    -- 2
+  , "#assume hyp : U"                                 -- 3
+  , "#define use-hyp : U := hyp"                      -- 4
+  , "#section local"                                  -- 5
+  , "#assume sec : U"                                 -- 6
+  , "#define use-sec : U := sec"                      -- 7
+  , "#end local"                                      -- 8
+  ]
+
 spec :: Spec
 spec = do
   describe "use-site tokens" $ do
@@ -97,6 +110,22 @@ spec = do
 
     it "leave plain definitions to the other token sources" $
       useTokenAt toks (3, 30) `shouldBe` Nothing                -- b, a binder use
+
+    it "colour a postulate occurrence as an abstract static function" $ do
+      let ptoks = useSiteTokensOf postulateModule
+      useTokenAt ptoks (2, 38)                                  -- ax, in use-ax
+        `shouldBe` Just ( SemanticTokenTypes_Function
+                        , [SemanticTokenModifiers_Abstract, SemanticTokenModifiers_Static] )
+
+    it "colour a top-level-assumption occurrence as an abstract function" $ do
+      let ptoks = useSiteTokensOf postulateModule
+      useTokenAt ptoks (4, 23)                                  -- hyp, in use-hyp
+        `shouldBe` Just (SemanticTokenTypes_Function, [SemanticTokenModifiers_Abstract])
+
+    it "colour an in-section-assumption occurrence as an abstract parameter" $ do
+      let ptoks = useSiteTokensOf postulateModule
+      useTokenAt ptoks (7, 23)                                  -- sec, in use-sec
+        `shouldBe` Just (SemanticTokenTypes_Parameter, [SemanticTokenModifiers_Abstract])
 
   describe "semantic tokens" $ do
     let toks = tokensOf exampleModule
@@ -132,6 +161,20 @@ spec = do
             ]
       tokenAt toks' (1, 27) `shouldBe` Just SemanticTokenTypes_Regexp  -- ?
       tokenAt toks' (2, 29) `shouldBe` Just SemanticTokenTypes_Regexp  -- ?goal
+
+    it "mark postulate and assume declarations as abstract, by severity" $ do
+      let ptoks = tokensOf postulateModule
+      useTokenAt ptoks (1, 11)                                  -- ax, declared
+        `shouldBe` Just ( SemanticTokenTypes_Function
+                        , [ SemanticTokenModifiers_Declaration
+                          , SemanticTokenModifiers_Abstract
+                          , SemanticTokenModifiers_Static ] )
+      useTokenAt ptoks (3, 8)                                   -- hyp, assumed
+        `shouldBe` Just ( SemanticTokenTypes_Function
+                        , [SemanticTokenModifiers_Declaration, SemanticTokenModifiers_Abstract] )
+      useTokenAt ptoks (6, 8)                                   -- sec, assumed in a section
+        `shouldBe` Just ( SemanticTokenTypes_Parameter
+                        , [SemanticTokenModifiers_Declaration, SemanticTokenModifiers_Abstract] )
 
     it "mark holes even in files that do not parse" $
       tokenizeSyntaxSymbols "#lang rzk-1\n#define broken (x : A) := ?\n"


### PR DESCRIPTION
This PR makes depending on an axiom visible in the editor. For example, in

```rzk
#assume funext : FunExt

#define weakfunext : WeakFunExt
  := ... (funext A C f g) ...
```

the name `funext` is now highlighted distinctly, both at its declaration and at every use site. The `uses` clause already documents such dependencies, but it is not required when an axiom appears explicitly in the body, so a proof that leans on an axiom could look no different from a self-contained one.

There are three tiers, in decreasing order of severity:

- a `#postulate` is a permanent axiom: `function` with the `abstract` and `static` modifiers (error red in VS Code with the companion extension PR);
- a top-level `#assume` is a file-wide axiom, discharged at module end: `function` with the `abstract` modifier (the same reddish colour as holes);
- an `#assume` inside a `#section` is a hypothesis the section abstracts over at its `#end`: `parameter` with the `abstract` modifier (italics).

All modifiers are standard and part of the default semantic tokens legend, so no custom legend is needed; clients without specific styling render the names as plain functions and parameters, as before.

<img width="558" height="341" alt="Снимок экрана — 2026-07-19 в 10 35 52" src="https://github.com/user-attachments/assets/f0b58979-618e-43ec-bcda-f44b80c9e4ab" />
<img width="555" height="573" alt="Снимок экрана — 2026-07-19 в 10 35 34" src="https://github.com/user-attachments/assets/0998149e-60a7-4af3-9ca1-8761426ed5f7" />

Implementation notes:

- Postulates are identified by a new `DeclKindPostulate` in `DeclView`: a top-level declaration with no value that is not a product of a `#data` declaration.
- Assumptions do not survive to the typechecked declarations (the section mechanism folds them into the definitions that use them), so the reference index records the definition sites of `#assume` commands together with their section scope (`AssumeScope`), and the use-site overlay recognises them there, syntactically.
- A local binder that shadows an assumption resolves to its own definition site and stays plain. Names inside a `uses (...)` clause keep their parameter colour; the clause is already an explicit dependence declaration.