### PR TITLE
Warn about unsaturated meta-prefix uses

### DIFF
--- a/docs/docs/en/reference/commands/options.rzk.md
+++ b/docs/docs/en/reference/commands/options.rzk.md
@@ -27,6 +27,16 @@ Controls the rendering backend for diagrams.
 - `"latex"` — enable rendering in LaTeX format
 - `"none"` — disable rendering (default)
 
+### `warn-meta-prefix`
+
+Controls the sensitivity of the meta-parameter layer check. The type theory implemented in rzk separates a _meta-theoretic parameter layer_ from the object theory (see Section 3.2 of the Rzk paper[^1]), where a statement is abstracted over a context of schematic cube, tope, and type parameters. Per declaration, the _meta prefix_ is the parameter prefix up to and including the last parameter whose type lives outside the object theory proper: a universe, `CUBE`, `TOPE`, or a function type quantifying over or landing in one of those. The check warns when a declaration is used with fewer arguments than its meta prefix at an object-level position (for example, storing it in a pair component); unsaturated use at a meta-typed position, such as aliasing a definition or passing it to a parameter with a matching schematic type, stays allowed. Thus a development reads as a family of object-theory definitions, one per meta instantiation.
+
+- `"strict"` — additionally require an unsaturated argument to sit within a top-level receiver's meta prefix (default); the extra warnings carry the distinct code `MetaPrefixWarningStrictOnly`
+- `"structural"` — warn only at structurally object-level positions
+- `"off"` — disable the check
+
+Note that the check is syntactic and has a known blind spot: with type-in-type, instantiating an ordinary object parameter with a large type can make a position look meta-typed (for example, `g ((X : U) → X → X) h` where `g` expects `(X : U) (x : X)`). The strict sensitivity flags such a use when it falls outside the receiver's meta prefix, but a forgery landing within the prefix, or behind a λ-bound receiver, is not detected; recognising genuinely impredicative instantiations requires universe level inference, which rzk does not implement at the moment.
+
 ### `warn-overhang`
 
 Controls the non-fatal hint printed when a restriction face or a `recOR` guard overhangs the local tope context (is not entailed by it, while still overlapping it). Overhang is legitimate — for example, restricting with an already-defined shape whose faces live on the whole cube — so the hint is informational only. Deciding whether a face overhangs costs a solver query per face, so the hint is off by default.
@@ -57,3 +67,7 @@ Controls the non-fatal hint printed when a restriction face or a `recOR` guard o
 - Options are set for the remainder of the file (or until unset)
 - `#unset-option` reverts an option to its default value
 - Unknown option names or invalid values will result in a typechecking error
+
+[^1]:
+    Nikolai Kudasov, Violetta Sim, Benedikt Ahrens.
+    _Rzk: a Proof Assistant for Synthetic ∞-Categories_. 2026. <https://arxiv.org/abs/2607.12207>

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -34,6 +34,8 @@ extra-source-files:
     test/typecheck/cases/happy-lattice-eq-gives-leq.rzk
     test/typecheck/cases/happy-lattice-mixed-cube.rzk
     test/typecheck/cases/happy-lattice.rzk
+    test/typecheck/cases/happy-meta-prefix-option-off.rzk
+    test/typecheck/cases/happy-meta-prefix-plumbing.rzk
     test/typecheck/cases/happy-modal-basics.rzk
     test/typecheck/cases/happy-modal-flat-recOR-under-op.rzk
     test/typecheck/cases/happy-modal-flat-under-op.rzk
@@ -157,6 +159,10 @@ extra-source-files:
     test/typecheck/cases/multimodule-two-ok/user.rzk
     test/typecheck/cases/uses-whnf-discarded.rzk
     test/typecheck/cases/uses-whnf-masked-transitive.rzk
+    test/typecheck/cases/warn-meta-prefix-object-position.rzk
+    test/typecheck/cases/warn-meta-prefix-option-structural.rzk
+    test/typecheck/cases/warn-meta-prefix-section.rzk
+    test/typecheck/cases/warn-meta-prefix-strict-only.rzk
     test/typecheck/cases/happy-check.expect.yaml
     test/typecheck/cases/happy-data-bool.expect.yaml
     test/typecheck/cases/happy-data-coprod.expect.yaml
@@ -171,6 +177,8 @@ extra-source-files:
     test/typecheck/cases/happy-lattice-eq-gives-leq.expect.yaml
     test/typecheck/cases/happy-lattice-mixed-cube.expect.yaml
     test/typecheck/cases/happy-lattice.expect.yaml
+    test/typecheck/cases/happy-meta-prefix-option-off.expect.yaml
+    test/typecheck/cases/happy-meta-prefix-plumbing.expect.yaml
     test/typecheck/cases/happy-modal-basics.expect.yaml
     test/typecheck/cases/happy-modal-flat-recOR-under-op.expect.yaml
     test/typecheck/cases/happy-modal-flat-under-op.expect.yaml
@@ -290,6 +298,10 @@ extra-source-files:
     test/typecheck/cases/ill-unused-assumption.expect.yaml
     test/typecheck/cases/uses-whnf-discarded.expect.yaml
     test/typecheck/cases/uses-whnf-masked-transitive.expect.yaml
+    test/typecheck/cases/warn-meta-prefix-object-position.expect.yaml
+    test/typecheck/cases/warn-meta-prefix-option-structural.expect.yaml
+    test/typecheck/cases/warn-meta-prefix-section.expect.yaml
+    test/typecheck/cases/warn-meta-prefix-strict-only.expect.yaml
     test/typecheck/cases/literate-fence/expect.yaml
     test/typecheck/cases/multimodule-first-error/expect.yaml
     test/typecheck/cases/multimodule-two-ok/expect.yaml
@@ -333,6 +345,7 @@ library
       Rzk.TypeCheck.Error
       Rzk.TypeCheck.Eval
       Rzk.TypeCheck.Judgements
+      Rzk.TypeCheck.MetaPrefix
       Rzk.TypeCheck.Monad
       Rzk.TypeCheck.NbE
       Rzk.TypeCheck.Render

--- a/rzk/src/Rzk/Diagnostic.hs
+++ b/rzk/src/Rzk/Diagnostic.hs
@@ -187,6 +187,22 @@ diagnoseCheckWarning (LargeInductiveTypeWarning dataName conName loc) = Diagnost
         <> " lives above U"
   , diagnosticHole     = Nothing
   }
+diagnoseCheckWarning (MetaPrefixWarning defName usedName supplied required rule loc) = Diagnostic
+  { diagnosticSeverity = SeverityWarning
+  , diagnosticCode     = case rule of
+      MetaPrefixBoth       -> "MetaPrefixWarning"
+      MetaPrefixStrictOnly -> "MetaPrefixWarningStrictOnly"
+  , diagnosticLocation = loc
+  , diagnosticMessage  =
+      "meta-parameter layer: " <> show usedName <> " is used with "
+        <> show supplied <> " of its " <> show required
+        <> " meta-prefix arguments"
+        <> (case rule of
+              MetaPrefixBoth       -> " at an object-level position"
+              MetaPrefixStrictOnly -> " outside another declaration's meta prefix")
+        <> " (in " <> show defName <> ")"
+  , diagnosticHole     = Nothing
+  }
 
 -- | A checker warning as a human-readable line (the CLI).
 ppCheckWarning :: CheckWarning -> String

--- a/rzk/src/Rzk/TypeCheck/Context.hs
+++ b/rzk/src/Rzk/TypeCheck/Context.hs
@@ -89,6 +89,11 @@ data VarInfo n = VarInfo
   , varLocation            :: Maybe LocationInfo
   , varDataRole            :: Maybe (DataRole n)
     -- ^ the role the entry plays for a @#data@ declaration, if any
+  , varMetaPrefix          :: Int
+    -- ^ the length of the entry's meta-parameter prefix (0 for locals and
+    -- for declarations with no meta parameters); see
+    -- "Rzk.TypeCheck.MetaPrefix". Recomputed when a section close rewrites
+    -- the entry's type.
   }
 
 -- | The role a top-level entry plays for a @#data@ declaration. The ι-rule
@@ -238,7 +243,22 @@ data Context n = Context
     -- is legitimate (see @happy-restrict-face-not-contained@). Enabled with
     -- @#set-option "warn-overhang" "yes"@. The /disjointness/ error next to
     -- it is unaffected: a vacuous face is always rejected.
+  , ctxMetaPrefixSensitivity :: MetaPrefixSensitivity
+    -- ^ How sensitively the meta-parameter layer check classifies use
+    -- positions (see "Rzk.TypeCheck.MetaPrefix"). Strict by default; set
+    -- with @#set-option "warn-meta-prefix" = "off" | "structural" | "strict"@.
   }
+
+-- | The sensitivity levels of the meta-parameter layer check.
+data MetaPrefixSensitivity
+  = MetaPrefixOff
+    -- ^ no meta-prefix warnings
+  | MetaPrefixStructural
+    -- ^ warn only at structurally object-level positions
+  | MetaPrefixStrict
+    -- ^ additionally require an unsaturated schema argument to sit within
+    -- a top-level receiver's meta prefix (the default)
+  deriving (Eq, Show)
 
 -- | An open section: the entries declared in it, newest first.
 data SectionInfo n = SectionInfo
@@ -272,6 +292,7 @@ emptyContext = Context
   , ctxDeferHoleMismatches = True
   , ctxHintLemmas = []
   , ctxWarnOverhang = False
+  , ctxMetaPrefixSensitivity = MetaPrefixStrict
   }
 
 -- | The tope context of an empty context: @⊤@ holds under every modality.

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -49,6 +49,7 @@ import           Rzk.TypeCheck.Display
 import           Rzk.TypeCheck.Error
 import           Rzk.TypeCheck.Eval
 import           Rzk.TypeCheck.Judgements
+import           Rzk.TypeCheck.MetaPrefix
 import           Rzk.TypeCheck.Monad
 import           Rzk.TypeCheck.Render
 
@@ -122,6 +123,8 @@ withTopLevel
   -> TypeCheck n r
 withTopLevel name ty mval isAssumption usedVars mrole k = do
   checkTopLevelDuplicate name
+  metaPrefix <- metaPrefixOf ty
+  recordMetaPrefixUses name ty mval
   ctx <- ask
   Foil.withFresh (ctxScope ctx) $ \binder -> do
     let info = VarInfo
@@ -135,6 +138,7 @@ withTopLevel name ty mval isAssumption usedVars mrole k = do
           , varDeclaredAssumptions = usedVars
           , varLocation = ctxLocation ctx
           , varDataRole = mrole
+          , varMetaPrefix = metaPrefix
           }
         ctx' = recordInSection (Foil.nameOf binder) (enterBinder binder info [] ctx)
         decl = Decl
@@ -193,7 +197,14 @@ endSection errs = do
   let sectionHasHole = any (maybe False containsHole . varValue . snd) infos
       tolerateUnused = lenient && sectionHasHole
 
-  (kept, errs') <- collectSectionDecls tolerateUnused errs [] infos
+  (kept0, errs') <- collectSectionDecls tolerateUnused errs [] infos
+
+  -- Abstracting over the section's assumptions rewrote the entries' types,
+  -- which can change their meta-parameter prefix (an assumption such as
+  -- funext becomes a leading meta parameter), so recompute it.
+  kept <- forM kept0 $ \(name, info) -> do
+    metaPrefix <- metaPrefixOf (varType info)
+    pure (name, info { varMetaPrefix = metaPrefix })
 
   loc <- asks ctxLocation
   let decls = map (toDecl loc) kept
@@ -427,6 +438,14 @@ setOption "warn-overhang" = \case
   "no"  -> localWarnOverhang False
   _ -> const $
     issueTypeError $ TypeErrorOther "unknown value for \"warn-overhang\" (use \"yes\" or \"no\")"
+-- The sensitivity of the meta-parameter layer check (see
+-- "Rzk.TypeCheck.MetaPrefix"); strict by default.
+setOption "warn-meta-prefix" = \case
+  "off"        -> localMetaPrefixSensitivity MetaPrefixOff
+  "structural" -> localMetaPrefixSensitivity MetaPrefixStructural
+  "strict"     -> localMetaPrefixSensitivity MetaPrefixStrict
+  _ -> const $
+    issueTypeError $ TypeErrorOther "unknown value for \"warn-meta-prefix\" (use \"off\", \"structural\", or \"strict\")"
 setOption optionName = const $ const $
   issueTypeError $ TypeErrorOther ("unknown option " <> show optionName)
 
@@ -435,6 +454,8 @@ unsetOption "verbosity" = localVerbosity (ctxVerbosity emptyContext)
 unsetOption "render" = localRenderBackend (ctxRenderBackend emptyContext)
 unsetOption "render-hide-term" = localHideTerm (ctxRenderHideTerm emptyContext)
 unsetOption "warn-overhang" = localWarnOverhang (ctxWarnOverhang emptyContext)
+unsetOption "warn-meta-prefix" =
+  localMetaPrefixSensitivity (ctxMetaPrefixSensitivity emptyContext)
 unsetOption optionName = const $
   issueTypeError $ TypeErrorOther ("unknown option " <> show optionName)
 
@@ -678,10 +699,9 @@ withDataDecls path used name paramVars paramDecls consData k = do
       when (containsUniverse probeT) $ do
         loc <- asks ctxLocation
         recordCheckWarning $ LargeInductiveTypeWarning
-          { warningDataName = varIdentAt path name
-          , warningConName = varIdentAt path (dataConName con)
-          , warningLocation = loc
-          }
+          (varIdentAt path name)
+          (varIdentAt path (dataConName con))
+          loc
       conTyTerm <- elaborate (dataConType con)
       conTy <- memoizeWHNF =<< typecheck conTyTerm universeT
       conDeps <- assumptionDepsOf conTy
@@ -1036,8 +1056,10 @@ typecheckModulesWithHoles = typecheckModulesWithHolesAndLemmas []
 
 -- | Like 'typecheckModulesWithHoles', but additionally offers the given named
 -- top-level definitions as hole candidates (each applied to holes when its type
--- fits the goal). The game passes a level's allow-list of relevant lemmas so they
--- surface as moves; an empty list reproduces 'typecheckModulesWithHoles'.
+-- fits the goal, and never below its meta prefix — an unsaturated schema is not
+-- a suggestion, see "Rzk.TypeCheck.MetaPrefix"). The game passes a level's
+-- allow-list of relevant lemmas so they surface as moves; an empty list
+-- reproduces 'typecheckModulesWithHoles'.
 typecheckModulesWithHolesAndLemmas
   :: [VarIdent]
   -> [(FilePath, Rzk.Module)]

--- a/rzk/src/Rzk/TypeCheck/Eval.hs
+++ b/rzk/src/Rzk/TypeCheck/Eval.hs
@@ -154,6 +154,7 @@ binderInfo orig md ty mval loc = VarInfo
   , varDeclaredAssumptions = []
   , varLocation = loc
   , varDataRole = Nothing
+  , varMetaPrefix = 0
   }
 
 -- | Run an action under a binder that has already been chosen.

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -126,18 +126,28 @@ data ElimCost = SpineStep | Branching
 -- does not spend the budget. Only the genuinely branching eliminators count
 -- against 'maxEliminationDepth', so the bound limits real search depth, not
 -- argument count, and a lemma that must be applied to many holes is still reached.
+--
+-- A spine over a top-level hypothesis is emitted only once its meta prefix
+-- (see "Rzk.TypeCheck.MetaPrefix") is fully applied: an unsaturated schema
+-- is not a suggestion, mirroring the warn-meta-prefix discipline. The search
+-- still passes through the unsaturated stages, so the saturated spines
+-- behind them are found; only the emission is gated.
 allEliminationsInto
   :: Distinct n => TermT n -> [VarIdent] -> TermT n -> TypeCheck n [TermT n]
-allEliminationsInto target inScopeNames = go maxEliminationDepth
+allEliminationsInto target inScopeNames hyp = do
+  minApps <- case hyp of
+    Var v -> asks (varMetaPrefix . lookupVarInfo v)
+    _     -> pure 0
+  go minApps maxEliminationDepth hyp
   where
-    go depth term = do
+    go minApps depth term = do
       ty    <- typeOf term
-      fits  <- fitsInto term ty target
+      fits  <- if minApps <= 0 then fitsInto term ty target else pure False
       elims <- eliminatorsOf inScopeNames ty
-      let step (SpineStep, wrap) = go depth =<< wrap term
+      let step (SpineStep, wrap) = go (minApps - 1) depth =<< wrap term
           step (Branching, wrap)
             | depth <= 0 = pure []
-            | otherwise  = go (depth - 1) =<< wrap term
+            | otherwise  = go minApps (depth - 1) =<< wrap term
       deeper <- concat <$> mapM step elims
       pure ([term | fits] <> deeper)
 

--- a/rzk/src/Rzk/TypeCheck/MetaPrefix.hs
+++ b/rzk/src/Rzk/TypeCheck/MetaPrefix.hs
@@ -1,0 +1,282 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | The meta-parameter layer check.
+--
+-- The type theory implemented in rzk separates a /meta-theoretic parameter
+-- layer/ from the object theory (RSTT proper): see §3.2 of the Rzk paper
+-- (Kudasov, Sim, Ahrens, \"Rzk: a Proof Assistant for Synthetic
+-- ∞-Categories\", <https://arxiv.org/abs/2607.12207 arXiv:2607.12207>),
+-- where a statement is abstracted over a context of schematic cube, tope,
+-- and type parameters. The checker did not enforce responsible use of
+-- this layer. Per declaration, the /meta prefix/ is the
+-- parameter prefix up to and including the last parameter whose type lives
+-- outside RSTT proper: a universe, @CUBE@, @TOPE@, or a Π-type quantifying
+-- over or landing in one of those. Interleaved object parameters are swept
+-- in, which only strengthens the check.
+--
+-- The discipline: the meta prefix must be fully supplied wherever the
+-- declaration is used at an object-level position; unsaturated use at a
+-- meta-typed position is legitimate macro-level plumbing and stays allowed.
+-- Then the development reads as a family of object-theory definitions, one
+-- per meta instantiation.
+--
+-- Positions are classified structurally, on the elaborated term:
+--
+-- - the root of a declaration's type and value is meta (a definition may
+--   alias a schema), and a λ-body inherits its λ's position (the value's
+--   leading λs are the declaration's own parameters);
+-- - an application argument is meta when the function's Π-domain at that
+--   position is meta-shaped (the receiver declared a schema parameter);
+-- - the components of type formers are meta (types are the schema layer),
+--   except the endpoints of an identity type, which are terms;
+-- - everything else (pair components, projections, @recOR@ branches, a
+--   @let@-bound value, …) is an object position.
+--
+-- The strict rule (the default, see 'MetaPrefixSensitivity') additionally
+-- requires an unsaturated schema argument to sit within a /top-level/
+-- receiver's meta prefix. This also polices meta-shaped domains that only
+-- arise by instantiating a receiver's object parameters with large types
+-- (as in composing schema-level implications with a generic @comp@); such
+-- uses are emitted with the distinct code 'MetaPrefixStrictOnly', so the
+-- structural sensitivity can silence them without losing the rest.
+--
+-- Known blind spot: under type-in-type, an impredicative instantiation can
+-- forge a meta-shaped argument domain out of an object parameter — with
+-- @g : (X : U) → X → X@, in @g ((X : U) → X → X) my-id@ the second
+-- domain is meta-shaped only because @X@ was instantiated with a large
+-- type. The structural sensitivity reads such a position as meta and stays
+-- silent. The strict default flags it when the argument falls outside the
+-- receiver's meta prefix (as here), but a forgery landing /within/ the
+-- prefix, or behind a λ-bound receiver, still passes: deciding whether an
+-- instantiation is genuinely impredicative is level inference, a separate
+-- (planned) analysis, not this check.
+module Rzk.TypeCheck.MetaPrefix (
+  metaPrefixOf,
+  isMetaType,
+  recordMetaPrefixUses,
+) where
+
+import           Control.Monad            (forM_, when)
+import           Control.Monad.Except     (catchError)
+import           Control.Monad.Reader     (ask, asks)
+import           Data.Bifoldable          (bifoldr)
+import           Data.Maybe               (fromMaybe)
+
+import           Control.Monad.Foil       (Distinct)
+import qualified Control.Monad.Foil       as Foil
+import           Control.Monad.Free.Foil  (AST (Node, Var))
+
+import           Control.Monad.Free.Foil.Annotated (AnnSig (..))
+import           Language.Rzk.Foil.Names  (TModality (..), TypeInfo (..),
+                                           VarIdent, binderName)
+import           Language.Rzk.Foil.Syntax
+import           Rzk.TypeCheck.Context
+import           Rzk.TypeCheck.Eval
+import           Rzk.TypeCheck.Monad
+
+-- * Classifying types
+
+-- | Does this type live outside RSTT proper — is it a universe, @CUBE@,
+-- @TOPE@, or a Π-type that quantifies over or lands in one of those? This
+-- covers a family into a universe (@A → U@, a tope family) and a schematic
+-- type such as @(X : U) → X → X@ (predicatively both are large). A
+-- parameter of such a type is a meta parameter. Never throws; an
+-- unanswerable probe reads as object.
+isMetaType :: Distinct n => TermT n -> TypeCheck n Bool
+isMetaType t = flip catchError (\_ -> pure False) $ do
+  t' <- headView t
+  case t' of
+    UniverseT{}     -> pure True
+    UniverseCubeT{} -> pure True
+    UniverseTopeT{} -> pure True
+    TypeFunT _ orig md param _mtope ret -> do
+      paramMeta <- isMetaType param
+      if paramMeta
+        then pure True
+        else inScope orig md param ret isMetaType
+    _               -> pure False
+
+-- | The length of the meta prefix of a declaration with this type: the
+-- number of leading parameters up to and including the last meta one
+-- (0 when there is none). Never throws.
+metaPrefixOf :: Distinct n => TermT n -> TypeCheck n Int
+metaPrefixOf ty = flip catchError (\_ -> pure 0) $ go 1 0 ty
+  where
+    go :: Distinct l => Int -> Int -> TermT l -> TypeCheck l Int
+    go pos acc t = headView t >>= \case
+      TypeFunT _ orig md param _mtope ret -> do
+        meta <- isMetaType param
+        let acc' = if meta then pos else acc
+        inScope orig md param ret (go (pos + 1) acc')
+      _ -> pure acc
+
+-- | The head of a type, for classification: syntactically if the head is
+-- already informative, through WHNF otherwise (a defined name such as
+-- @FunExt@ must unfold). Restrictions are stripped either way; a boundary
+-- does not change which layer a type lives in.
+headView :: Distinct n => TermT n -> TypeCheck n (TermT n)
+headView t = case stripTypeRestrictions t of
+  t'@UniverseT{}     -> pure t'
+  t'@UniverseCubeT{} -> pure t'
+  t'@UniverseTopeT{} -> pure t'
+  t'@TypeFunT{}      -> pure t'
+  t'@TypeSigmaT{}    -> pure t'
+  t'@TypeIdT{}       -> pure t'
+  t'                 -> stripTypeRestrictions <$> whnfT t'
+
+-- * The use-site walk
+
+-- | How a position is classified under the two candidate rules.
+data PosKind = MetaPos | ObjectPos
+  deriving (Eq)
+
+data Positions = Positions
+  { posStructural :: PosKind
+  , posStrict     :: PosKind
+  }
+
+rootPositions, typePositions, objectPositions :: Positions
+rootPositions   = Positions MetaPos MetaPos
+typePositions   = Positions MetaPos MetaPos
+objectPositions = Positions ObjectPos ObjectPos
+
+-- | Walk a declaration's elaborated type and value, warning about every
+-- use of a top-level name that supplies fewer arguments than its meta
+-- prefix at an object-level position. Advisory: never throws, and runs
+-- silently so WHNF probes do not trace.
+recordMetaPrefixUses
+  :: forall n. Distinct n
+  => VarIdent -> TermT n -> Maybe (TermT n) -> TypeCheck n ()
+recordMetaPrefixUses defName ty mval =
+  asks ctxMetaPrefixSensitivity >>= \case
+    MetaPrefixOff -> pure ()
+    _ -> localVerbosity Silent $ flip catchError (\_ -> pure ()) $ do
+      go rootPositions ty
+      mapM_ (go rootPositions) mval
+  where
+    go :: forall l. Distinct l => Positions -> TermT l -> TypeCheck l ()
+    go pos t = case t of
+      Var v -> checkHead pos v 0
+
+      AppT{} -> do
+        let (h, args) = collectSpine t []
+        mk <- case h of
+          Var v -> do
+            ctx <- ask
+            let info = lookupVarInfo v ctx
+            checkHead pos v (length args)
+            pure (if varIsTopLevel info then Just (varMetaPrefix info) else Nothing)
+          _ -> do
+            go objectPositions h
+            pure Nothing
+        forM_ (zip [1 :: Int ..] args) $ \(i, (fnode, arg)) -> do
+          domMeta <- domainIsMeta fnode
+          let strict = case mk of
+                Just k | domMeta && i <= k -> MetaPos
+                _                          -> ObjectPos
+          go (Positions (if domMeta then MetaPos else ObjectPos) strict) arg
+
+      LambdaT info orig mparam body -> do
+        (mdom, md) <- case mparam of
+          Just (LambdaParam m ty' _mtope) -> do
+            go typePositions ty'
+            pure (Just ty', m)
+          -- A bare λ: the domain of its own Π-type.
+          Nothing -> do
+            dom <- funDomain (infoType info)
+            pure (dom, Id)
+        inScope orig md (fromMaybe universeT mdom) body (go pos)
+
+      TypeFunT _ orig md param _mtope ret -> do
+        go typePositions param
+        inScope orig md param ret (go typePositions)
+
+      TypeSigmaT _ orig md a bscope -> do
+        go typePositions a
+        inScope orig md a bscope (go typePositions)
+
+      -- The endpoints are terms; storing an unsaturated schema in an
+      -- identity type is an object-level use.
+      TypeIdT _ a mtA b -> do
+        go objectPositions a
+        mapM_ (go typePositions) mtA
+        go objectPositions b
+
+      TypeRestrictedT _ ty' rs -> do
+        go typePositions ty'
+        forM_ rs $ \(_tope, term) -> go objectPositions term
+
+      LetT _ orig manno value body -> do
+        mapM_ (go typePositions) manno
+        go objectPositions value
+        let valueType = case typeInfoOf value of
+              Just valueInfo -> Just (infoType valueInfo)
+              Nothing        -> manno
+        inScopeWith orig Id (fromMaybe universeT valueType) (Just value) body (go pos)
+
+      LetModT _ orig _nu mu manno value body -> do
+        mapM_ (go typePositions) manno
+        go objectPositions value
+        unwrapped <- case typeInfoOf value of
+          Nothing        -> pure Nothing
+          Just valueInfo -> modalDomain (infoType valueInfo)
+        inScope orig mu (fromMaybe universeT unwrapped) body (go pos)
+
+      Node (AnnSig _ f) ->
+        mapM_ (go objectPositions) (bifoldr (\_ acc -> acc) (:) [] f)
+
+    -- An unsaturated top-level head at an object position warns; at a
+    -- position only the strict rule rejects, the warning is marked so.
+    checkHead :: forall l. Positions -> Foil.Name l -> Int -> TypeCheck l ()
+    checkHead pos v nargs = do
+      ctx <- ask
+      let info = lookupVarInfo v ctx
+          k = varMetaPrefix info
+      when (varIsTopLevel info && k > nargs) $ do
+        sensitivity <- asks ctxMetaPrefixSensitivity
+        let mrule = case (posStructural pos, posStrict pos) of
+              (ObjectPos, _) -> Just MetaPrefixBoth
+              (MetaPos, ObjectPos)
+                | MetaPrefixStrict <- sensitivity -> Just MetaPrefixStrictOnly
+              _              -> Nothing
+        forM_ mrule $ \rule -> do
+          loc <- asks ctxLocation
+          recordCheckWarning $ MetaPrefixWarning
+            defName
+            (fromMaybe "_" (binderName (varOrig info)))
+            nargs
+            k
+            rule
+            loc
+
+    -- Is the Π-domain of this function node meta-shaped?
+    domainIsMeta :: forall l. Distinct l => TermT l -> TypeCheck l Bool
+    domainIsMeta f = flip catchError (\_ -> pure False) $ do
+      tf <- typeOfUncomputed f
+      headView tf >>= \case
+        TypeFunT _ _ _ dom _ _ -> isMetaType dom
+        _                      -> pure False
+
+    funDomain :: forall l. Distinct l => TermT l -> TypeCheck l (Maybe (TermT l))
+    funDomain tf = flip catchError (\_ -> pure Nothing) $
+      headView tf >>= \case
+        TypeFunT _ _ _ dom _ _ -> pure (Just dom)
+        _                      -> pure Nothing
+
+    modalDomain :: forall l. TermT l -> TypeCheck l (Maybe (TermT l))
+    modalDomain tv = flip catchError (\_ -> pure Nothing) $
+      pure $ case stripTypeRestrictions tv of
+        TypeModalT _ _ a -> Just a
+        _                -> Nothing
+
+collectSpine :: TermT n -> [(TermT n, TermT n)] -> (TermT n, [(TermT n, TermT n)])
+collectSpine (AppT _ f x) acc = collectSpine f ((f, x) : acc)
+collectSpine h acc            = (h, acc)

--- a/rzk/src/Rzk/TypeCheck/Monad.hs
+++ b/rzk/src/Rzk/TypeCheck/Monad.hs
@@ -75,10 +75,30 @@ data HoleInfo = HoleInfo
 -- escalate it.
 data CheckWarning
   = LargeInductiveTypeWarning
-      { warningDataName :: VarIdent
-      , warningConName  :: VarIdent
-      , warningLocation :: Maybe LocationInfo
-      }
+      VarIdent              -- ^ the data type
+      VarIdent              -- ^ the constructor whose field stores a universe
+      (Maybe LocationInfo)
+  | MetaPrefixWarning
+      VarIdent              -- ^ the declaration whose type or body contains the use
+      VarIdent              -- ^ the declaration used with too few meta-prefix arguments
+      Int                   -- ^ the arguments supplied
+      Int                   -- ^ the length of the meta prefix
+      MetaPrefixRule
+      (Maybe LocationInfo)
+  deriving (Eq, Show)
+
+-- | Where a warning points, for per-file attribution.
+warningLocation :: CheckWarning -> Maybe LocationInfo
+warningLocation (LargeInductiveTypeWarning _ _ loc)  = loc
+warningLocation (MetaPrefixWarning _ _ _ _ _ loc)    = loc
+
+-- | Which candidate rule of the meta-parameter layer check flags a
+-- 'MetaPrefixWarning' (see "Rzk.TypeCheck.MetaPrefix"): the structural
+-- rule, or only its stricter variant. Both are emitted so the two
+-- candidate defaults can be measured on a corpus side by side.
+data MetaPrefixRule
+  = MetaPrefixBoth
+  | MetaPrefixStrictOnly
   deriving (Eq, Show)
 
 type TypeCheck n =
@@ -136,6 +156,10 @@ localHideTerm hide = local $ \ctx -> ctx { ctxRenderHideTerm = hide }
 
 localWarnOverhang :: Bool -> TypeCheck n a -> TypeCheck n a
 localWarnOverhang warn = local $ \ctx -> ctx { ctxWarnOverhang = warn }
+
+localMetaPrefixSensitivity :: MetaPrefixSensitivity -> TypeCheck n a -> TypeCheck n a
+localMetaPrefixSensitivity sensitivity =
+  local $ \ctx -> ctx { ctxMetaPrefixSensitivity = sensitivity }
 
 -- | Render the enclosed action with the proof term hidden.
 hidingTerm :: TypeCheck n a -> TypeCheck n a

--- a/rzk/test/Rzk/FoilCoreSpec.hs
+++ b/rzk/test/Rzk/FoilCoreSpec.hs
@@ -64,6 +64,7 @@ hypothesis name ty = VarInfo
   , varDeclaredAssumptions = []
   , varLocation = Nothing
   , varDataRole = Nothing
+  , varMetaPrefix = 0
   }
 
 spec :: Spec

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -432,6 +432,27 @@ spec = do
       in flip oneHole (holesWithLemmas ["deep"] deepSrc) $ \h ->
            cands h `shouldContain` ["deep ? ? ? ? ? ? ? ?"]
 
+    -- A lemma is never offered below its meta prefix (here X and Y, so two
+    -- arguments): an unsaturated schema is not a suggestion, mirroring the
+    -- warn-meta-prefix discipline.
+    it "does not offer a lemma below its meta prefix" $
+      let metaSrc = "#lang rzk-1\n#postulate A : U\n"
+                 <> "#postulate pick : (X : U) -> (Y : U) -> X -> X\n"
+                 <> "#define goal : A -> A := ?\n"
+      in flip oneHole (holesWithLemmas ["pick"] metaSrc) $ \h -> do
+           cands h `shouldContain` ["pick ? ?"]
+           filter (`elem` ["pick", "pick ?"]) (cands h) `shouldBe` []
+
+    -- Also at the schema's own type: the bare alias is not offered (writing
+    -- the alias is the user's call), while the saturated spine still is.
+    it "does not offer a bare schema even at its own type" $
+      let aliasSrc = "#lang rzk-1\n"
+                  <> "#define my-id (X : U) (x : X) : X := x\n"
+                  <> "#define goal : (X : U) -> X -> X := ?\n"
+      in flip oneHole (holesWithLemmas ["my-id"] aliasSrc) $ \h -> do
+           cands h `shouldContain` ["my-id ?"]
+           filter (== "my-id") (cands h) `shouldBe` []
+
   describe "holeCandidates under shadowing" $ do
     let cands = map show . holeCandidates
         -- the motive λ rebinds b, so at the inner hole the telescope's b is

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -18,6 +18,14 @@ Paired `*.rzk` / `*.rzk.md` + `*.expect.yaml` (or dir `expect.yaml`). `Rzk.TypeC
   (`ill-data-recursive`, `ill-data-non-u-sort`, `ill-data-return-type`,
   `ill-data-shape-field`, `ill-data-eliminator-clause`) and name clashes
   (`ill-data-duplicate-constructor`, `ill-data-clash-generated`).
+- **Meta-parameter layer check:** the object-position
+  warning (`warn-meta-prefix-object-position`), the strict-only marking
+  (`warn-meta-prefix-strict-only`), warning-free plumbing — aliasing,
+  saturation, passing a schema to a meta-prefix parameter
+  (`happy-meta-prefix-plumbing`), the recomputation of the prefix at
+  section close (`warn-meta-prefix-section`), and the sensitivity option
+  (`happy-meta-prefix-option-off`, `warn-meta-prefix-option-structural`);
+  all asserted via the `warnings` field.
 - **Other layouts:** `multimodule-*`, `literate-fence/`.
 
 # Regression tests
@@ -44,6 +52,7 @@ Fixture comments and `regression_for` use stable prose (which judgment fails, wh
 | Pattern-binder name restoration | `ill-hole-pattern-binder-names` | A pair-pattern lambda `\ (a , b) -> ?` renders its components by name in the strict-mode error: the goal `B (first p)` folds to `B a` and the binder shows as `(a , b)`, not `π₁ x` of a fresh variable. Lenient-mode goals/context covered by `Rzk.HolesSpec`. |
 | Bare pattern point in tope | `ill-tope-pattern-binder-bare` | A pattern-bound point used bare (not projected) in a shape's membership tope renders as the pattern: a type error's local tope context shows `Δ² (t , s)`, not `Δ² x₁`. Complements the projection-folding restoration above. |
 | `#data` stage 1 (M3, design/inductive-types.md) | `happy-data-*`, `ill-data-*` | The declaration registers the type former before checking constructors (the prototype's ordering bug); the ι-rule fires in WHNF and NF (refl on computed equalities); section closure abstracts the whole family uniformly (`makeAssumptionExplicit` forces the type former). Stage-1 rejections are `TypeErrorOther` with distinguishing `message_contains`. |
+| Meta-parameter layer check | `warn-meta-prefix-*`, `happy-meta-prefix-plumbing` | An unsaturated use of a declaration below its meta prefix warns at object-level positions (`Rzk.TypeCheck.MetaPrefix`); aliasing at a definition root and meta-shaped argument domains stay silent (the sHoTT `weakextext-extext` composition pattern); `endSection` recomputes `varMetaPrefix` after abstracting assumptions. |
 
 # Test schema
 

--- a/rzk/test/typecheck/cases/happy-meta-prefix-option-off.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-meta-prefix-option-off.expect.yaml
@@ -1,0 +1,4 @@
+status: ok
+warnings: []
+regression_for:
+  - meta-parameter-layer-check sensitivity option

--- a/rzk/test/typecheck/cases/happy-meta-prefix-option-off.rzk
+++ b/rzk/test/typecheck/cases/happy-meta-prefix-option-off.rzk
@@ -1,0 +1,9 @@
+#lang rzk-1
+
+#set-option "warn-meta-prefix" = "off"
+
+#define my-id (X : U) (x : X) : X := x
+
+-- Would warn at the default (strict) sensitivity; the option disables
+-- the check for the rest of the module.
+#define stash : Σ (h : (X : U) → X → X), Unit := (my-id, unit)

--- a/rzk/test/typecheck/cases/happy-meta-prefix-plumbing.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-meta-prefix-plumbing.expect.yaml
@@ -1,0 +1,5 @@
+status: ok
+warnings: []
+regression_for:
+  - meta-parameter-layer-check
+  - sHoTT weakextext-extext composition plumbing stays warning-free

--- a/rzk/test/typecheck/cases/happy-meta-prefix-plumbing.rzk
+++ b/rzk/test/typecheck/cases/happy-meta-prefix-plumbing.rzk
@@ -1,0 +1,16 @@
+#lang rzk-1
+
+#define my-id (X : U) (x : X) : X := x
+
+-- Aliasing a schema at the root of a definition is macro-level plumbing.
+#define alias : (X : U) → X → X := my-id
+
+-- A saturated use is always fine.
+#define saturated (A : U) (a : A) : A := my-id A a
+
+-- Passing a schema to another declaration's meta-prefix parameter is
+-- allowed under both rules (the receiving domain is meta-shaped and within
+-- the receiver's meta prefix), as in composing extensionality lemmas.
+#define apply-h (h : (X : U) → X → X) (A : U) (a : A) : A := h A a
+
+#define plumbed (A : U) (a : A) : A := apply-h my-id A a

--- a/rzk/test/typecheck/cases/warn-meta-prefix-object-position.expect.yaml
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-object-position.expect.yaml
@@ -1,0 +1,5 @@
+status: ok
+warnings:
+  - MetaPrefixWarning
+regression_for:
+  - meta-parameter-layer-check

--- a/rzk/test/typecheck/cases/warn-meta-prefix-object-position.rzk
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-object-position.rzk
@@ -1,0 +1,8 @@
+#lang rzk-1
+
+-- my-id has meta prefix X (a universe parameter).
+#define my-id (X : U) (x : X) : X := x
+
+-- Storing the unsaturated schema in a pair component is an object-level
+-- use: the meta prefix must be supplied.
+#define stash : Σ (h : (X : U) → X → X), Unit := (my-id, unit)

--- a/rzk/test/typecheck/cases/warn-meta-prefix-option-structural.expect.yaml
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-option-structural.expect.yaml
@@ -1,0 +1,5 @@
+status: ok
+warnings:
+  - MetaPrefixWarning
+regression_for:
+  - meta-parameter-layer-check sensitivity option

--- a/rzk/test/typecheck/cases/warn-meta-prefix-option-structural.rzk
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-option-structural.rzk
@@ -1,0 +1,12 @@
+#lang rzk-1
+
+#set-option "warn-meta-prefix" = "structural"
+
+#define my-id (X : U) (x : X) : X := x
+
+-- Flagged only by the strict rule, so silenced at this sensitivity.
+#define local-use (A : U) (a : A) : A
+  := (\ (h : (X : U) → X → X) → h A a) my-id
+
+-- An object-level position still warns under the structural rule.
+#define stash : Σ (h : (X : U) → X → X), Unit := (my-id, unit)

--- a/rzk/test/typecheck/cases/warn-meta-prefix-section.expect.yaml
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-section.expect.yaml
@@ -1,0 +1,6 @@
+status: ok
+warnings:
+  - MetaPrefixWarning
+regression_for:
+  - meta-parameter-layer-check
+  - endSection recomputes varMetaPrefix after abstracting assumptions

--- a/rzk/test/typecheck/cases/warn-meta-prefix-section.rzk
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-section.rzk
@@ -1,0 +1,12 @@
+#lang rzk-1
+
+-- Closing the section abstracts T out of use-T, whose type becomes
+-- (T : U) → U: the meta prefix must be recomputed at #end.
+#section sec
+#assume T : U
+#define use-T uses (T) : U := T
+#end sec
+
+-- An object-level use of the generalised definition without its (new)
+-- meta parameter.
+#define stash : Σ (h : U → U), Unit := (use-T, unit)

--- a/rzk/test/typecheck/cases/warn-meta-prefix-strict-only.expect.yaml
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-strict-only.expect.yaml
@@ -1,0 +1,5 @@
+status: ok
+warnings:
+  - MetaPrefixWarningStrictOnly
+regression_for:
+  - meta-parameter-layer-check

--- a/rzk/test/typecheck/cases/warn-meta-prefix-strict-only.rzk
+++ b/rzk/test/typecheck/cases/warn-meta-prefix-strict-only.rzk
@@ -1,0 +1,9 @@
+#lang rzk-1
+
+#define my-id (X : U) (x : X) : X := x
+
+-- Passing the unsaturated schema to a local parameter whose declared type
+-- is meta-shaped is allowed by the structural rule; only the strict rule
+-- (top-level receiver, within its meta prefix) flags it.
+#define local-use (A : U) (a : A) : A
+  := (\ (h : (X : U) → X → X) → h A a) my-id


### PR DESCRIPTION
The type theory implemented in rzk separates a _meta-theoretic parameter layer_ from the object theory,[^rzk] where a statement is abstracted over a context of schematic cube, tope, and type parameters. The checker did not enforce responsible use of this layer. For example, in

```rzk
#define my-id (X : U) (x : X) : X := x

#define stash : Σ (h : (X : U) → X → X), Unit := (my-id, unit)
```

the definition `stash` stores `my-id` without instantiating its meta parameter `X`, and now gets a warning: `my-id` is used with 0 of its 1 meta-prefix arguments at an object-level position.

Per declaration, the _meta prefix_ is the parameter prefix up to and including the last parameter whose type lives outside the object theory proper: a universe, `CUBE`, `TOPE`, or a function type quantifying over or landing in one of those. Interleaved object parameters are swept in. The discipline: the meta prefix must be fully supplied wherever the declaration is used at an object-level position; unsaturated use at a meta-typed position, such as aliasing a definition or passing it to a parameter with a matching schematic type, is macro-level plumbing and stays allowed. Thus a development reads as a family of object-theory definitions, one per meta instantiation. Violations are warnings on the diagnostics channel from #306, so they reach the CLI, `--json`, and the LSP.

Positions are classified structurally on the elaborated term (see the haddock of `Rzk.TypeCheck.MetaPrefix`). A `warn-meta-prefix` option controls the sensitivity, documented in `docs/docs/en/reference/commands/options.rzk.md`:

- `"strict"` (default) additionally requires an unsaturated schema argument to sit within a top-level receiver's meta prefix; the extra warnings carry the distinct code `MetaPrefixWarningStrictOnly`, so the two levels are distinguishable downstream;
- `"structural"` warns only at structurally object-level positions;
- `"off"` disables the check.

On sHoTT, the structural level produces zero warnings and the strict default exactly two, both in `weakextext-extext`, where the two extensionality lemmas are composed point-free with `comp`; writing the composition as an explicit λ (or lowering the sensitivity) resolves them, to be addressed in sHoTT separately. Performance on the full sHoTT corpus: wall time is flat (1.46 s → 1.47 s median), allocations +6.4% (half from the extra traversal, half from the WHNF domain probes; a candidate-gated two-pass would halve it if it ever matters).

Hole suggestions respect the same discipline: a candidate spine over an allow-listed lemma is offered only once the lemma's meta prefix is fully applied, so an unsaturated schema is never suggested. In particular, the bare lemma is not offered even when the goal is the schema's own type (writing an alias is the user's call); the spine saturated through the prefix, such as `my-id ?`, still is. The search still passes through the unsaturated stages, so the saturated spines behind them are found.

Implementation notes:

- The prefix length is stored in `VarInfo` (`varMetaPrefix`), computed once per top-level declaration in `withTopLevel`; closing a section recomputes it, because abstracting the section's assumptions rewrites the entries' types (an assumption such as `funext` becomes a leading meta parameter).
- Known blind spot, documented with the option: with type-in-type, instantiating an object parameter with a large type can make a position look meta-typed. The strict default flags such a use when it falls outside the receiver's meta prefix, but a forgery landing within the prefix, or behind a λ-bound receiver, is not detected; recognising genuinely impredicative instantiations requires universe level inference, which rzk does not implement at the moment.
- Fixtures cover the object-position warning, the strict-only marking, warning-free plumbing, the section recomputation, and both non-default sensitivities; `PR_TYPECHECK_FIXTURES.md` is updated.

[^rzk]: Nikolai Kudasov, Violetta Sim, and Benedikt Ahrens. *Rzk: a Proof Assistant for Synthetic ∞-Categories.* 2026. <https://arxiv.org/abs/2607.12207> — §3.2 for the meta-theoretic parameter layer.