### PR TITLE
Holes: introduce a U goal by the type formers

### DIFF
--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -345,7 +345,46 @@ allIntroductionsOf target inScopeNames = do
        in pure [ topeTopT, topeBottomT
                , topeEQT  point point, topeLEQT point point
                , topeAndT tope  tope,  topeOrT  tope  tope ]
+    -- the universe: a type is built by a type former, so each is an
+    -- introduction of a U-goal — a function type, a Σ-type, an identity type,
+    -- the unit type, and every user-declared datatype in scope (applied to
+    -- holes through its parameter telescope). The Σ binder is named, so it is
+    -- freshened like a λ-introduction's binder; the identity type's endpoints
+    -- are terms of an as-yet-unknown type, like the tope universe's points.
+    UniverseT{} -> do
+      ctx <- ask
+      let arrow = typeFunT (BinderVar Nothing) Id (mkHole universeT) Nothing
+                    (closedScope scope (mkHole universeT))
+          sigma = typeSigmaT (BinderVar (Just (refreshVar inScopeNames "x"))) Id
+                    (mkHole universeT) (closedScope scope (mkHole universeT))
+          endpointTy = mkHole universeT
+          identity = typeIdT (mkHole endpointTy) (Just endpointTy) (mkHole endpointTy)
+          formerIds =
+            [ Foil.nameId (dataRoleDataType role)
+            | (_, info) <- varsInScope ctx
+            , Just role <- [varDataRole info]
+            ]
+          formers =
+            [ v
+            | (v, info) <- varsInScope ctx
+            , varIsTopLevel info
+            , Foil.nameId v `elem` formerIds
+            ]
+      datatypes <- mapM (saturateWithHoles . Var) formers
+      pure ([arrow, sigma, identity, typeUnitT] <> datatypes)
     _ -> pure []
+
+-- | Apply a term to holes through its whole Π-telescope: a datatype former
+-- applied through its parameters, so a @U@-goal offers @coprod ? ?@.
+saturateWithHoles :: Distinct n => TermT n -> TypeCheck n (TermT n)
+saturateWithHoles term = do
+  ty <- typeOf term
+  case stripTypeRestrictions ty of
+    TypeFunT _ _ _ param _ ret -> do
+      let h = mkHole param
+      retAt <- instantiate ret h
+      saturateWithHoles (appT retAt term h)
+    _ -> pure term
 
 -- | Whether the two endpoints of an identity type are definitionally equal, so that
 -- @refl@ inhabits it. Like 'fitsInto', any holes or constraints recorded while

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -527,6 +527,23 @@ spec = do
         [h] -> intros h `shouldBe` ["(?, ?)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A U-goal is introduced by the type formers: a function type, a Σ-type,
+    -- an identity type, the unit type, and every user-declared datatype in
+    -- scope, applied to holes through its parameter telescope.
+    it "introduces a U goal by the type formers, including datatypes" $ do
+      case holesOf ("#lang rzk-1\n#data bool := false | true\n"
+                 <> "#data coprod (A B : U) := inl (a : A) | inr (b : B)\n"
+                 <> "#def T : U := ?\n") of
+        [h] -> intros h `shouldBe`
+                 ["? → ?", "Σ (x : ?), ?", "? =_{ ? } ?", "Unit", "bool", "coprod ? ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- The Σ introduction's binder is freshened like a λ's.
+    it "freshens the Σ introduction's binder against the context" $ do
+      case holesOf "#lang rzk-1\n#def T (x : Unit) : U := ?\n" of
+        [h] -> intros h `shouldContain` ["Σ (x₁ : ?), ?"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- An identity type whose endpoints already agree is introduced by refl.
     it "introduces an identity type with agreeing endpoints by refl" $ do
       case holesOf "#lang rzk-1\n#define f : (A : U) -> (a : A) -> (a =_{A} a)\n  := \\ A a -> ?\n" of


### PR DESCRIPTION
A hole of type `U` had no introductions. A type is built by a type former, so each is an introduction of a `U`-goal. In

```rzk
#data bool := false | true

#data coprod (A B : U) := inl (a : A) | inr (b : B)

#def T : U := ?
```

the hole now offers `? → ?`, `Σ (x : ?), ?`, `? =_{ ? } ?`, `Unit`, `bool`, and `coprod ? ?`: the built-in type formers, and every user-declared datatype in scope applied to holes through its parameter telescope.

The Σ binder is named, so it is freshened like a λ-introduction's binder (`Σ (x₁ : ?), ?` when `x` is in scope); the identity type's endpoints are terms of an as-yet-unknown type, mirroring the tope universe's points. Datatype formers are recognised through the data roles that point at them.