### PR TITLE
Holes: keep hidden scrutinee names out of the user namespace

### DIFF
--- a/rzk/src/Rzk/TypeCheck/Display.hs
+++ b/rzk/src/Rzk/TypeCheck/Display.hs
@@ -25,7 +25,7 @@ import           Language.Rzk.Foil.Syntax
 import           Language.Rzk.Foil.Names    (Binder (..), Display,
                                               TypeInfo (..), VarIdent,
                                               binderIsCompound, binderLeaves,
-                                              binderToPattern, defaultVarIdents,
+                                              binderDisplayName, binderToPattern, defaultVarIdents,
                                               freshenBinderLeaves, fromVarIdent,
                                               refreshVarIn)
 import qualified Language.Rzk.Syntax         as Rzk
@@ -74,14 +74,15 @@ namingOfContext ctx = Naming
             x : supply' -> name (x, BinderVar (Just x)) [x] supply'
             []          -> panicImpossible "not enough fresh variables"
         binder ->
-          -- A pattern binder: the variable itself needs a placeholder name (it is
-          -- only shown when the whole point is used, and then it prints as the
-          -- pattern), and its leaves are freshened together.
-          case supply of
-            x : supply' ->
-              let binder' = freshenBinderLeaves (Set.toList taken) binder
-               in name (x, binder') (x : binderLeaves binder') supply'
-            [] -> panicImpossible "not enough fresh variables"
+          -- A pattern binder: the variable itself needs a placeholder name only
+          -- when the whole point is used, and then it prints as the pattern —
+          -- so the placeholder is the pattern's own display name ("(na, nb)"),
+          -- which the identifier lexer can never produce. It must not draw
+          -- from the default supply: claiming x₁ here would displace a later
+          -- user-written x₁ in the display (and its hole moves) while the
+          -- source keeps the name. Only the leaves are freshened and claimed.
+          let binder' = freshenBinderLeaves (Set.toList taken) binder
+           in name (binderDisplayName binder', binder') (binderLeaves binder') supply
       where
         name display claimed supply' =
           let (acc, taken') = go (foldr Set.insert taken claimed) supply' rest

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -466,6 +466,32 @@ spec = do
         [h] -> cands h `shouldBe` ["idJ (A, x, \\ b₁ → \\ q → ?, ?, y, p)"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A destructuring pattern's hidden scrutinee must not claim a
+    -- user-facing name: it used to take x₁ from the default supply, so a
+    -- user-written x₁ bound later displayed as x₂ (a context/source
+    -- mismatch) and its moves were dropped as unreferable. The scrutinee's
+    -- placeholder is now the pattern itself, which cannot collide, so the
+    -- context shows x₁ and its candidate survives.
+    it "keeps a user x₁ intact beside a destructuring pattern" $ do
+      case holesOf ("#lang rzk-1\n#data Void\n"
+                 <> "#data coprod (A B : U) := inl (a : A) | inr (b : B)\n"
+                 <> "#def prod (A B : U) : U := Σ (a : A) , B\n"
+                 <> "#def neg (A : U) : U := A → Void\n"
+                 <> "#def t (A B : U) : prod (neg A) (neg B) → coprod A B → coprod A B\n"
+                 <> "  := \\ (na , nb) → \\ x₁ → ?\n") of
+        [h] -> do
+          names (holeTermVars h) `shouldContain` ["x₁"]
+          names (holeTermVars h) `shouldNotContain` ["x₂"]
+          cands h `shouldContain` ["x₁"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
+    -- A whole-point use of a pattern-bound variable renders as the pattern
+    -- itself, which is also the pair expression a move may insert.
+    it "renders a whole-point pattern use as the pattern" $ do
+      case holesOf "#lang rzk-1\n#def t (A B : U) : (Σ (a : A) , B) → Σ (a : A) , B\n  := \\ (x , y) → ?\n" of
+        [h] -> cands h `shouldContain` ["(x, y)"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
   describe "holeIntroductions (type-directed introduction forms)" $ do
     let intros = map show . holeIntroductions
 


### PR DESCRIPTION
A destructuring λ binds one hidden scrutinee variable, and the context naming drew its placeholder from the default supply, claiming `x₁`. In

```rzk
#def t (A B : U) : prod (neg A) (neg B) → coprod A B → Void
  := \ (na , nb) → \ x₁ → ?
```

the user's `x₁` is therefore displayed as `x₂`, so the reported hole context disagrees with the source. Moreover, the display-renamed binder loses its move candidates to the referability guard from #313 (on the data-stage2 branch this hides the `rec-coprod` moves), and the previous hole offers the colliding move `\ x₁ → ?`.

The placeholder only matters when the whole point is used, and then it prints as the pattern. Thus the placeholder is now the pattern's own display name (`(na, nb)`), a spelling the identifier lexer can never produce, and only the pattern's leaves are claimed. A whole-point candidate renders as the pattern `(x, y)`, which is also the pair expression a move may insert.

Note that this is intended as the **last local fix of its kind**. The printed-name bugs (#242, #313, this one) share a root cause: display names are decided too early, in several independent places, and an offered move is never checked to parse back to the intended term. We plan a redesign with source-exact rendering of moves, one naming pass per hole, no placeholder names for hidden binders, and a round-trip check for every offered move. The placeholder introduced here is a stopgap that the redesign retires.