### PR TITLE
The equation convoy (case-vec) with a wildcard binder as a test case

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -41,6 +41,7 @@ extra-source-files:
     test/typecheck/cases/happy-lattice-mixed-cube.rzk
     test/typecheck/cases/happy-lattice.rzk
     test/typecheck/cases/happy-match-basics.rzk
+    test/typecheck/cases/happy-match-case-vec.rzk
     test/typecheck/cases/happy-match-indexed.rzk
     test/typecheck/cases/happy-meta-prefix-option-off.rzk
     test/typecheck/cases/happy-meta-prefix-plumbing.rzk
@@ -201,6 +202,7 @@ extra-source-files:
     test/typecheck/cases/happy-lattice-mixed-cube.expect.yaml
     test/typecheck/cases/happy-lattice.expect.yaml
     test/typecheck/cases/happy-match-basics.expect.yaml
+    test/typecheck/cases/happy-match-case-vec.expect.yaml
     test/typecheck/cases/happy-match-indexed.expect.yaml
     test/typecheck/cases/happy-meta-prefix-option-off.expect.yaml
     test/typecheck/cases/happy-meta-prefix-plumbing.expect.yaml

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -33,7 +33,11 @@ Paired `*.rzk` / `*.rzk.md` + `*.expect.yaml` (or dir `expect.yaml`). `Rzk.TypeC
   matches, definitional computation, an `into` motive, a dependent
   motive built from the goal, a non-variable scrutinee, branch order,
   a nested match), indexed families (`happy-match-indexed`, with an
-  `into` motive over the index telescope); rejections for the branch
+  `into` motive over the index telescope), the equation convoy
+  (`happy-match-case-vec` — Coq's `case_vec`: the motive returns a
+  function out of the index equation, the match is applied to `refl`,
+  and the unused induction hypothesis is bound as `_`); rejections for
+  the branch
   bijection and arity (`ill-match-missing-branch`,
   `ill-match-duplicate-branch`, `ill-match-unknown-branch`,
   `ill-match-branch-arity`), a scrutinee that is not of a `#data` type

--- a/rzk/test/typecheck/cases/happy-match-case-vec.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-match-case-vec.expect.yaml
@@ -1,0 +1,5 @@
+status: ok
+warnings: []
+regression_for:
+  - match-equation-convoy
+  - match-wildcard-branch-binder

--- a/rzk/test/typecheck/cases/happy-match-case-vec.rzk
+++ b/rzk/test/typecheck/cases/happy-match-case-vec.rzk
@@ -1,0 +1,33 @@
+#lang rzk-1
+
+#data nat := zero | suc (n : nat)
+
+#data vec (A : U) : nat → U
+  := nil : vec A zero
+   | cons (n : nat) (x : A) (xs : vec A n) : vec A (suc n)
+
+-- The equation convoy (Coq's case_vec): the motive generalises the index
+-- with a fresh m and returns a function out of the equation x = m, so each
+-- branch receives the index equation as an explicit hypothesis; the whole
+-- match is applied to refl. The unused induction hypothesis is bound as _
+-- (it still counts towards the branch arity).
+#define case-vec
+  ( A : U) (x : nat) (v : vec A x) (P : U)
+  ( hnil : (x =_{nat} zero) → P)
+  ( hcons : (n : nat) → (a : A) → (w : vec A n) → (x =_{nat} suc n) → P)
+  : P
+  := (match v into (\ m w → (x =_{nat} m) → P)
+       ( nil ⇒ \ H → hnil H
+       | cons n a w _ ⇒ \ H → hcons n a w H)) refl
+
+-- it computes: on a concrete vector the cons branch fires with H := refl
+#define use-case-vec
+  ( A : U) (a : A)
+  : nat
+  := case-vec A (suc zero) (cons A zero a (nil A)) nat
+      ( \ _ → zero)
+      ( \ n _ _ _ → suc n)
+
+#define case-vec-computes (A : U) (a : A)
+  : use-case-vec A a =_{nat} suc zero
+  := refl


### PR DESCRIPTION
A follow-up fixture for #319, prompted by a communication with @LIshy2's regarding index refinement. It ports Coq's `case_vec` through the `into` motive: the motive generalises the index with a fresh `m` and returns a function out of the equation `x =_{nat} m`, so each branch receives the index equation as an explicit hypothesis, and the whole match is applied to `refl`.

```rzk
#define case-vec
  ( A : U) (x : nat) (v : vec A x) (P : U)
  ( hnil : (x =_{nat} zero) → P)
  ( hcons : (n : nat) → (a : A) → (w : vec A n) → (x =_{nat} suc n) → P)
  : P
  := (match v into (\ m w → (x =_{nat} m) → P)
       ( nil ⇒ \ H → hnil H
       | cons n a w _ ⇒ \ H → hcons n a w H)) refl
```

The fixture is also the first coverage for `_` as a branch binder: it counts towards the branch arity and binds nothing. Computation runs through the eliminator and the `refl` application, pinned by a `refl`-checked equality on a concrete vector.