### PR TITLE
Reject a binder repeated within one binder group

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -59,6 +59,7 @@ extra-source-files:
     test/typecheck/cases/happy-refl-path.rzk
     test/typecheck/cases/happy-restrict-face-not-contained.rzk
     test/typecheck/cases/happy-set-option-warn-overhang.rzk
+    test/typecheck/cases/happy-shadowing-across-groups.rzk
     test/typecheck/cases/happy-shott-simplicial-subcomplexes.rzk
     test/typecheck/cases/happy-subtype-variance-pi-shape-domain.rzk
     test/typecheck/cases/happy-subtype-variance-restriction-faces.rzk
@@ -134,6 +135,9 @@ extra-source-files:
     test/typecheck/cases/ill-recor-coverage-required.rzk
     test/typecheck/cases/ill-recor-guard-disjoint.rzk
     test/typecheck/cases/ill-render-latex-define.rzk
+    test/typecheck/cases/ill-repeated-binder-lambda.rzk
+    test/typecheck/cases/ill-repeated-binder-pair.rzk
+    test/typecheck/cases/ill-repeated-binder-params.rzk
     test/typecheck/cases/ill-restrict-face-disjoint.rzk
     test/typecheck/cases/ill-section-end-mismatch.rzk
     test/typecheck/cases/ill-section-not-closed.rzk
@@ -219,6 +223,7 @@ extra-source-files:
     test/typecheck/cases/happy-refl-path.expect.yaml
     test/typecheck/cases/happy-restrict-face-not-contained.expect.yaml
     test/typecheck/cases/happy-set-option-warn-overhang.expect.yaml
+    test/typecheck/cases/happy-shadowing-across-groups.expect.yaml
     test/typecheck/cases/happy-shott-simplicial-subcomplexes.expect.yaml
     test/typecheck/cases/happy-subtype-variance-pi-shape-domain.expect.yaml
     test/typecheck/cases/happy-subtype-variance-restriction-faces.expect.yaml
@@ -294,6 +299,9 @@ extra-source-files:
     test/typecheck/cases/ill-recor-coverage-required.expect.yaml
     test/typecheck/cases/ill-recor-guard-disjoint.expect.yaml
     test/typecheck/cases/ill-render-latex-define.expect.yaml
+    test/typecheck/cases/ill-repeated-binder-lambda.expect.yaml
+    test/typecheck/cases/ill-repeated-binder-pair.expect.yaml
+    test/typecheck/cases/ill-repeated-binder-params.expect.yaml
     test/typecheck/cases/ill-restrict-face-disjoint.expect.yaml
     test/typecheck/cases/ill-section-end-mismatch.expect.yaml
     test/typecheck/cases/ill-section-not-closed.expect.yaml

--- a/rzk/src/Rzk/Diagnostic.hs
+++ b/rzk/src/Rzk/Diagnostic.hs
@@ -150,6 +150,7 @@ typeErrorTag = \case
   TypeErrorUnusedUsedVariables{}   -> "TypeErrorUnusedUsedVariables"
   TypeErrorImplicitAssumption{}    -> "TypeErrorImplicitAssumption"
   TypeErrorNotIntervalCube{}       -> "TypeErrorNotIntervalCube"
+  TypeErrorRepeatedBinder{}        -> "TypeErrorRepeatedBinder"
   TypeErrorMatchScrutineeNotData{} -> "TypeErrorMatchScrutineeNotData"
   TypeErrorMatchCannotInfer{}      -> "TypeErrorMatchCannotInfer"
   TypeErrorMatchMissingBranch{}    -> "TypeErrorMatchMissingBranch"

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -26,6 +26,7 @@ module Rzk.TypeCheck.Decl where
 
 import           Control.Monad             (forM, when)
 import           Control.Monad.Except      (catchError, runExcept)
+import           Data.Data                 (Data, cast, gmapQ)
 import           Control.Monad.Reader      (ask, asks, local, runReaderT)
 import           Control.Monad.Trans.Writer.CPS (runWriterT)
 import           Data.List                 (intercalate)
@@ -42,7 +43,7 @@ import           Language.Rzk.Foil.Convert (Env, toTerm)
 import           Language.Rzk.Foil.Syntax
 import           Language.Rzk.Foil.Names   (Binder (..), TModality (..),
                                             VarIdent, binderName, markUnresolved,
-                                            patternToTerm, varIdentAt)
+                                            patternToTerm, varIdent, varIdentAt)
 import qualified Language.Rzk.Syntax       as Rzk
 import           Rzk.TypeCheck.Context
 import           Rzk.TypeCheck.Display
@@ -920,18 +921,80 @@ prefixedIdent p (Rzk.VarIdent pos (Rzk.VarIdentToken t)) =
 -- before it stand, the error is reported, and the rest of the module is skipped.
 -- The strict entry points turn the first collected error back into a thrown one.
 withCommand
-  :: Rzk.Command
+  :: Distinct n
+  => Rzk.Command
   -> ([Decl n] -> [TypeErrorInScopedContext] -> TypeCheck n r)
   -> TypeCheck n r
   -> TypeCheck n r
 withCommand command k action =
-  local atCommand (action `catchError` \err -> k [] [err])
+  local atCommand (checked `catchError` \err -> k [] [err])
   where
+    checked = case duplicateBinders command of
+      (dup, previous) : _ -> issueTypeError (TypeErrorRepeatedBinder dup previous)
+      []                  -> action
     atCommand ctx = ctx
       { ctxCurrentCommand = Just command
       , ctxLocation = updatePosition (Rzk.hasPosition command) <$> ctxLocation ctx
       }
     updatePosition pos loc = loc { locationLine = fst <$> pos }
+
+-- | The binder leaves repeated within one binder /group/ of a surface
+-- command: the parameter list of a λ, of a declaration, or of a constructor
+-- (a single pattern's leaves are part of their group). Each hit pairs the
+-- repeated occurrence with the earlier ones it clashes with.
+--
+-- Shadowing an outer binder stays a warning ('checkNameShadowing'); a
+-- duplicate inside one group can only be a mistake, and the silent
+-- freshening it used to get showed names the user never wrote (issue #321).
+duplicateBinders :: Data a => a -> [(VarIdent, [VarIdent])]
+duplicateBinders x = concat
+  [ maybe [] termGroup (cast x)
+  , maybe [] commandGroup (cast x)
+  , maybe [] constructorGroup (cast x)
+  , concat (gmapQ duplicateBinders x)
+  ]
+  where
+    termGroup :: Rzk.Term -> [(VarIdent, [VarIdent])]
+    termGroup = \case
+      Rzk.Lambda _ params _       -> groupDuplicates (concatMap paramLeaves params)
+      Rzk.ASCII_Lambda _ params _ -> groupDuplicates (concatMap paramLeaves params)
+      _                           -> []
+
+    commandGroup :: Rzk.Command -> [(VarIdent, [VarIdent])]
+    commandGroup = \case
+      Rzk.CommandDefine _ _ _ params _ _  -> groupDuplicates (concatMap paramLeaves params)
+      Rzk.CommandPostulate _ _ _ params _ -> groupDuplicates (concatMap paramLeaves params)
+      Rzk.CommandData _ _ _ params _ _    -> groupDuplicates (concatMap paramLeaves params)
+      _                                   -> []
+
+    constructorGroup :: Rzk.Constructor -> [(VarIdent, [VarIdent])]
+    constructorGroup (Rzk.Constructor _ _ params _) =
+      groupDuplicates (concatMap paramLeaves params)
+
+    paramLeaves :: Rzk.Param -> [Rzk.VarIdent]
+    paramLeaves = \case
+      Rzk.ParamPattern _ pat                  -> patternLeaves pat
+      Rzk.ParamPatternType _ pats _           -> concatMap patternLeaves pats
+      Rzk.ParamPatternShape _ pats _ _        -> concatMap patternLeaves pats
+      Rzk.ParamPatternModalType _ pats _ _    -> concatMap patternLeaves pats
+      Rzk.ParamPatternModalShape _ pats _ _ _ -> concatMap patternLeaves pats
+
+    patternLeaves :: Rzk.Pattern -> [Rzk.VarIdent]
+    patternLeaves = \case
+      Rzk.PatternUnit _ -> []
+      Rzk.PatternVar _ v@(Rzk.VarIdent _ (Rzk.VarIdentToken t)) -> [ v | t /= "_" ]
+      Rzk.PatternPair _ l r -> patternLeaves l <> patternLeaves r
+      Rzk.PatternTuple _ a b cs -> concatMap patternLeaves (a : b : cs)
+
+    -- positions differ between occurrences, so compare by spelling
+    groupDuplicates = go []
+      where
+        go _ [] = []
+        go seen (v : vs) =
+          case [ e | e <- seen, sameSpelling e v ] of
+            []      -> go (v : seen) vs
+            earlier -> (varIdent v, map varIdent (reverse earlier)) : go (v : seen) vs
+    sameSpelling (Rzk.VarIdent _ a) (Rzk.VarIdent _ b) = a == b
 
 -- | Elaborate a surface term in the current top-level scope: a free identifier
 -- resolves to the top-level entry it names.

--- a/rzk/src/Rzk/TypeCheck/Error.hs
+++ b/rzk/src/Rzk/TypeCheck/Error.hs
@@ -56,6 +56,7 @@ data TypeError n
   | TypeErrorUnusedUsedVariables [Foil.Name n] (Foil.Name n)
   | TypeErrorImplicitAssumption (Foil.Name n, TermT n) (Foil.Name n)
   | TypeErrorNotIntervalCube String (TermT n) (TermT n)
+  | TypeErrorRepeatedBinder VarIdent [VarIdent]
   | TypeErrorMatchScrutineeNotData (TermT n) (TermT n)
   | TypeErrorMatchCannotInfer (Term n)
   | TypeErrorMatchMissingBranch VarIdent
@@ -253,6 +254,14 @@ ppTypeError naming = \case
     , "  " <> ppU (untyped lType)
     , "and a point of type"
     , "  " <> ppU (untyped rType)
+    ]
+
+  TypeErrorRepeatedBinder name previous -> block TopDown
+    [ show name <> " is bound multiple times in one binder group"
+    , "  " <> ppVarIdentWithLocation name
+    , "already bound at"
+    , intercalate "\n"
+      [ "  " <> ppVarIdentWithLocation prev | prev <- previous ]
     ]
 
   TypeErrorMatchScrutineeNotData scrut ty -> block TopDown

--- a/rzk/test/typecheck/cases/happy-shadowing-across-groups.expect.yaml
+++ b/rzk/test/typecheck/cases/happy-shadowing-across-groups.expect.yaml
@@ -1,0 +1,3 @@
+status: ok
+regression_for:
+  - https://github.com/rzk-lang/rzk/issues/321

--- a/rzk/test/typecheck/cases/happy-shadowing-across-groups.rzk
+++ b/rzk/test/typecheck/cases/happy-shadowing-across-groups.rzk
@@ -1,0 +1,6 @@
+#lang rzk-1
+
+-- shadowing across separate binder groups stays legal (a warning at most):
+-- only a duplicate within one group is an error
+#define ok : (A : U) → A → A → A
+  := \ A a → \ a → a

--- a/rzk/test/typecheck/cases/ill-repeated-binder-lambda.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-lambda.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorRepeatedBinder
+message_contains:
+  - "x is bound multiple times in one binder group"
+line: 3
+regression_for:
+  - https://github.com/rzk-lang/rzk/issues/321

--- a/rzk/test/typecheck/cases/ill-repeated-binder-lambda.rzk
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-lambda.rzk
@@ -1,0 +1,4 @@
+#lang rzk-1
+
+#define bad : (x y : Unit) → Unit
+  := \ x x → unit

--- a/rzk/test/typecheck/cases/ill-repeated-binder-pair.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-pair.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorRepeatedBinder
+message_contains:
+  - "x is bound multiple times in one binder group"
+line: 3
+regression_for:
+  - https://github.com/rzk-lang/rzk/issues/321

--- a/rzk/test/typecheck/cases/ill-repeated-binder-pair.rzk
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-pair.rzk
@@ -1,0 +1,4 @@
+#lang rzk-1
+
+#define bad (A : U) (p : A) : A
+  := (\ (x , x) → x) p

--- a/rzk/test/typecheck/cases/ill-repeated-binder-params.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-params.expect.yaml
@@ -1,0 +1,7 @@
+status: error
+error_tag: TypeErrorRepeatedBinder
+message_contains:
+  - "A is bound multiple times in one binder group"
+line: 3
+regression_for:
+  - https://github.com/rzk-lang/rzk/issues/321

--- a/rzk/test/typecheck/cases/ill-repeated-binder-params.rzk
+++ b/rzk/test/typecheck/cases/ill-repeated-binder-params.rzk
@@ -1,0 +1,3 @@
+#lang rzk-1
+
+#define bad (A : U) (A : U) : U := A


### PR DESCRIPTION
Closes #321.

Repeating a binder name within one group, `\ x x → e`, was silently accepted: the later occurrence was freshened for display, so hole contexts and messages showed `x₁`, a name the user never wrote and cannot refer to, while the earlier `x` was shadowed. Such a duplicate can only be a mistake, so it is now a structured error:

```
x is bound multiple times in one binder group
  x (file.rzk:3:10)
already bound at
  x (file.rzk:3:8)
```

A group is the parameter list of a λ, of a declaration (`#define f (A : U) (A : U)`), or of a `#data` constructor, and the leaves of a single pattern (`\ (x , x) → x`). The check is a surface-level scan per command, before elaboration gets a chance to freshen, and the error carries both positions.

Shadowing across separate groups is untouched: an inner λ reusing an outer parameter's name stays legal and keeps its warning, which the corpus relies on (sHoTT shadows this way routinely and still checks clean). Fixtures cover the three group kinds and pin the legal cross-group shadowing.

When the proper-pattern representation lands, this check is a natural candidate for the generic pattern layer (a pattern that binds the same name twice), so it may eventually move upstream.