### PR TITLE
Playground deploys: mike-safe targets, no force-push, relative base

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -77,40 +77,52 @@ jobs:
       - name: 🔨 Build the playground frontend
         # base must match the deploy target below: main is published to the root
         # `playground/`, every other ref to `<ref>/playground/`. Vite reads
-        # ASSET_URL as its base, and the loader fetches the wasm relative to it.
+        # A relative base: the same build works at every target folder
+        # (playground/, playground/<ref>/, playground/latest/), and the
+        # loader fetches the wasm relative to the page.
         env:
-          ASSET_URL: ${{ github.ref_name == 'main' && format('/{0}/playground/', github.event.repository.name) || format('/{0}/{1}/playground/', github.event.repository.name, github.ref_name) }}
+          ASSET_URL: './'
         run: |
           cd rzk-playground
           npm ci
           npm run build
 
+      # Deploy notes, learned the hard way at v0.11.0:
+      #
+      # - Target folders live under playground/, NEVER at <ref>/playground or
+      #   latest/playground: mike owns the root directories named after doc
+      #   versions and aliases (v0.11.0/, latest/, develop/) and deletes them
+      #   on every docs deploy, taking the playground with them.
+      # - No single-commit: it force-pushes a squash of the whole branch built
+      #   from a possibly stale base, so a concurrent deploy (another ref's
+      #   playground, or mike) gets silently discarded. With force: false the
+      #   action rebases and retries instead.
       - name: '🚀 Publish playground (${{ github.ref_name }})'
-        if: ${{ github.ref_name != 'main' && github.event_name == 'push' }}
+        if: ${{ github.ref_name != 'main' && github.event_name != 'pull_request' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: rzk-playground/dist
-          target-folder: ${{ github.ref_name }}/playground
+          target-folder: playground/${{ github.ref_name }}
           clean: false
-          single-commit: true
+          force: false
 
       - name: '🚀 Publish playground (latest)'
-        if: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'v') && github.event_name == 'push' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'v') && github.event_name != 'pull_request' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: rzk-playground/dist
-          target-folder: latest/playground
+          target-folder: playground/latest
           clean: false
-          single-commit: true
+          force: false
 
       - name: '🚀 Publish playground'
-        if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+        if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: rzk-playground/dist
           target-folder: playground
           clean: false
-          single-commit: true
+          force: false

--- a/docs/config/en/mkdocs.yml
+++ b/docs/config/en/mkdocs.yml
@@ -46,7 +46,10 @@ nav:
           - Rendering Diagrams: reference/render.rzk.md
       - Examples:
           - Weak tope disjunction elimination: examples/recId.rzk.md
-  - Playground: playground/index.html
+  # An absolute URL: the site is deployed under en/<version>/, where a
+  # relative playground/ link would point into the mike version directory,
+  # which carries no playground.
+  - Playground: https://rzk-lang.github.io/rzk/playground/
   - Blog: blog/index.html
 
 theme:

--- a/docs/config/ru/mkdocs.yml
+++ b/docs/config/ru/mkdocs.yml
@@ -46,7 +46,10 @@ nav:
           - Отрисовка диаграм: reference/render.rzk.md
       - Примеры:
           - Слабое устранение объединений форм: examples/recId.rzk.md
-  - Песочница: playground/index.html
+  # Абсолютная ссылка: сайт разворачивается под ru/<версия>/, где
+  # относительная ссылка playground/ вела бы внутрь каталога версии mike,
+  # в котором песочницы нет.
+  - Песочница: https://rzk-lang.github.io/rzk/playground/
   - Блог (англ.): blog/index.html
 
 theme:


### PR DESCRIPTION
After the v0.11.0 release the playground at <https://rzk-lang.github.io/rzk/playground/> served the pre-wasm v0.9.2 build, and the versioned copies disappeared within the hour. Three deploy bugs surfaced together, each hiding the others.

First, the per-ref targets `<ref>/playground` and `latest/playground` sit in root directories that mike owns: every docs deploy of a version deletes the root directories named after that version and its aliases (`v0.11.0/`, `latest/`, `develop/`), taking the playground with them. The targets now live under `playground/` (`playground/<ref>`, `playground/latest`), which mike never touches. The root `playground/` for `main` is unchanged; it has survived years of docs deploys.

Second, `single-commit: true` made every deploy force-push a squash of the whole `gh-pages` branch built from whatever base that run had fetched, so concurrent deploys were silently discarded. This is how the develop run erased the main run's freshly deployed playground and resurfaced the v0.9.2 build (together with Next.js-era leftovers that `clean: false` had preserved underneath since before the Vite playground). The deploys now commit normally with `force: false`, which rebases and retries on a concurrent push.

Third, the Vite base was baked in as an absolute `/rzk/<ref>/playground/` path, so the single tag build was valid at only one of its two targets: the copy at `latest/playground` referenced its assets under `v0.11.0/`. The base is now relative (`ASSET_URL: './'`), making one build valid at every target folder.

Two related fixes ride along: the docs nav playground links become absolute URLs (a relative `playground/` resolves into the mike version directory, which carries no playground), and the publish steps also run on `workflow_dispatch`, so a lost deploy can be re-run by hand.

The live root `playground/` was restored out-of-band on `gh-pages` (commits `e20a0e36`, `06e1d023`): the wasm build recovered from the squash commit, its baked base rewritten to `/rzk/playground/`, and the Next.js and GHCJS leftovers removed.