### PR TITLE
Formatter fixes: quadratic cost, and the deleted final newline

### DIFF
--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -75,7 +75,7 @@ import           Language.Rzk.VSCode.Logging
 import           Language.Rzk.VSCode.Tokenize  (mergeTokens, tokenizeModule,
                                                 tokenizeSyntaxSymbols)
 import qualified Rzk.Diagnostic                as Diag
-import           Rzk.Format                    (format)
+import qualified Rzk.Format                    as Fmt
 import           Rzk.Project.Config            (ProjectConfig (include))
 import           Rzk.TypeCheck
 import           Text.Read                     (readMaybe)
@@ -477,25 +477,13 @@ formatDocument req res = do
     possibleEdits <- case virtualFileText <$> mdoc of
       Nothing         -> return (Left "Failed to get file contents")
       Just sourceCode -> do
+        -- 'fullDocumentRange' spans the trailing newlines too, so the
+        -- replacement carries them: 'formatDocument' keeps as many as the
+        -- source had, and the document is returned with its final newline
+        -- intact.
         let source = T.filter (/= '\r') sourceCode
-            formatted = format source
-            -- Preserve trailing newlines of the source so formatting is idempotent.
-            formatted'
-              | T.null source = formatted
-              | otherwise =
-                  let inputTrailing = T.length (T.takeWhileEnd (== '\n') source)
-                      outTrailing = T.length (T.takeWhileEnd (== '\n') formatted)
-                  in if outTrailing > inputTrailing
-                     then T.dropEnd (outTrailing - inputTrailing) formatted
-                     else if outTrailing < inputTrailing
-                          then formatted <> T.replicate (inputTrailing - outTrailing) (T.singleton '\n')
-                          else formatted
-            -- Never send trailing newlines: some clients add one when applying a
-            -- full-document edit, so we send content ending with no newline to avoid
-            -- an extra blank line on each format.
-            formatted'' = T.dropWhileEnd (== '\n') formatted'
             range = fullDocumentRange source
-        return (Right [TextEdit range formatted''])
+        return (Right [TextEdit range (Fmt.formatDocument source)])
     case possibleEdits of
 #if MIN_VERSION_lsp(2,7,0)
       Left err    -> res $ Left $ TResponseError (InR ErrorCodes_InternalError) err Nothing

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -409,11 +409,24 @@ format contents =
   let normalized = normalizeTabs contents
   in applyTextEdits (formatTextEdits normalized) normalized
 
--- | Same as 'format'. Use this when replacing the entire document (e.g. from
---   the language server), so that tab normalization and all formatting rules
---   are applied correctly instead of applying incremental edits to tabbed source.
+-- | Format a whole document, for a consumer that replaces it wholesale (the
+--   language server does, so that tab normalization and all formatting rules
+--   are applied instead of incremental edits to tabbed source).
+--
+--   The document ends in as many newlines as it began with. Formatting is a
+--   rewriting of the code, and whether a file ends in a newline is not
+--   something it has an opinion on: that is the editor's @insert_final_newline@
+--   and whatever else formats the surrounding Markdown. The language server
+--   used to send the document with every trailing newline stripped, which
+--   silently deleted the final one on each save and left the file failing a
+--   @.editorconfig@ or Prettier check that no further formatting could satisfy.
 formatDocument :: T.Text -> T.Text
-formatDocument = format
+formatDocument contents = matchTrailingNewlines contents (format contents)
+
+-- | Give the second text as many trailing newlines as the first one has.
+matchTrailingNewlines :: T.Text -> T.Text -> T.Text
+matchTrailingNewlines source formatted =
+  T.dropWhileEnd (== '\n') formatted <> T.takeWhileEnd (== '\n') source
 
 -- | Format Rzk code from a file
 formatFile :: FilePath -> IO T.Text

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -18,6 +18,9 @@ module Rzk.Format (
   normalizeTabs,
 ) where
 
+import           Data.Array              (Array, listArray, (!))
+import           Data.IntMap.Strict      (IntMap)
+import qualified Data.IntMap.Strict      as IntMap
 import           Data.List               (sort)
 
 import qualified Data.Text               as T
@@ -55,7 +58,10 @@ data FormatState = FormatState
   , lambdaArrow      :: Bool -- ^ After a lambda '\', in the parameters (to leave its -> on the same line)
   , eqBraceDepth     :: Int  -- ^ Depth inside =_{ ... }; 0 = not inside, 1 = at top level after =_{
   , eqBraceOnOwnLine :: Bool -- ^ True if the current =_{ started at the beginning of its line (after spaces)
-  , allTokens        :: [Token] -- ^ The full array of tokens after resolving the layout
+  , tokensOnLine     :: IntMap [Token]
+    -- ^ All the tokens after resolving the layout, grouped by the line they
+    -- start on. Only one rule needs them, and only those on a single line, so
+    -- they are indexed rather than scanned (see 'lineTokensBefore').
   }
 
 -- | Replace every tab character with a single space.
@@ -68,16 +74,41 @@ formatTextEdits :: T.Text -> [FormattingEdit]
 formatTextEdits contents =
   case resolveLayout True (tokens rzkBlocks) of
     Left _err     -> [] -- TODO: log error (in a CLI and LSP friendly way)
-    Right allToks -> go (initialState {allTokens = allToks}) allToks
+    Right allToks -> go (initialState {tokensOnLine = groupByLine allToks}) allToks
   where
-    initialState = FormatState { parensDepth = 0, letDepth  = 0, inDataCommand = False, definingName = False, lambdaArrow = False, eqBraceDepth = 0, eqBraceOnOwnLine = False, allTokens = [] }
+    initialState = FormatState { parensDepth = 0, letDepth  = 0, inDataCommand = False, definingName = False, lambdaArrow = False, eqBraceDepth = 0, eqBraceOnOwnLine = False, tokensOnLine = IntMap.empty }
     incParensDepth s = s { parensDepth = parensDepth s + 1 }
     decParensDepth s = s { parensDepth = 0 `max` (parensDepth s - 1) }
     rzkBlocks = tryExtractMarkdownCodeBlocks "rzk" contents
-    contentLines line = T.lines rzkBlocks !! (line - 1) -- Sorry
-    lineTokensBefore toks line col = filter isBefore toks
+
+    -- Almost every rule reads the line its token sits on, and some read the
+    -- neighbouring ones, so the lines are split once and indexed. Splitting the
+    -- whole document afresh on each lookup made formatting quadratic in the
+    -- file size: sHoTT's largest module took 0.8 s, past the editor's
+    -- format-on-save budget, so saving it looked like it had been refused.
+    sourceLines :: [T.Text]
+    sourceLines = T.lines rzkBlocks
+    lineCount = length sourceLines
+    lineArray :: Array Int T.Text
+    lineArray = listArray (1, lineCount) sourceLines
+
+    -- | The content of a line, by its 1-based number. A line outside the
+    -- document is empty, which is what the rules looking at a neighbour want at
+    -- the first and last line.
+    contentLines line
+      | line >= 1 && line <= lineCount = lineArray ! line
+      | otherwise                      = ""
+
+    groupByLine :: [Token] -> IntMap [Token]
+    groupByLine toks =
+      IntMap.fromListWith (<>) [ (l, [t]) | t@(PT (Pn _ l _) _) <- toks ]
+
+    -- | The tokens preceding a position on its own line. The order within a
+    -- line is not preserved: the one rule that asks only tests them all.
+    lineTokensBefore s line col =
+      filter isBefore (IntMap.findWithDefault [] line (tokensOnLine s))
       where
-        isBefore (PT (Pn _ l c) _) = l == line && c < col
+        isBefore (PT (Pn _ _ c) _) = c < col
         isBefore _                 = False
     unicodeTokens :: [(T.Text, T.Text)]
     unicodeTokens =
@@ -162,7 +193,7 @@ formatTextEdits contents =
       where
         spaceCol = col + 1
         lineContent = contentLines line
-        precededBySingleCharOnly = all isPunctuation (lineTokensBefore (allTokens s) line col)
+        precededBySingleCharOnly = all isPunctuation (lineTokensBefore s line col)
         singleCharUnicodeTokens = filter (\(_, unicode) -> T.length unicode == 1) unicodeTokens
         punctuations :: [T.Text]
         punctuations = concat
@@ -216,7 +247,7 @@ formatTextEdits contents =
           | closingEqBrace && onOwnLine && not isLastOnLine
           = [ FormattingEdit line braceEndCol line (braceEndCol + spacesAfter) "\n  " ]
           | closingEqBrace && onOwnLine && isLastOnLine
-          = let nextLine = if line < length (T.lines rzkBlocks) then contentLines (line + 1) else ""
+          = let nextLine = contentLines (line + 1)
                 spacesNextLine = T.length $ T.takeWhile (== ' ') nextLine
             in if spacesNextLine /= 2 then [ FormattingEdit (line + 1) 1 (line + 1) (1 + spacesNextLine) "  " ] else []
           | otherwise
@@ -316,12 +347,8 @@ formatTextEdits contents =
         spacesAfter = T.length $ T.takeWhile (== ' ') (T.drop (col + T.length tk - 1) lineContent)
         isFirstNonSpaceChar = T.all (== ' ') (T.take (col - 1) lineContent)
         isLastNonSpaceChar = T.all (== ' ') (T.drop (col + T.length tk - 1) lineContent)
-        prevLine
-          | line > 0 = contentLines (line - 1)
-          | otherwise = ""
-        nextLine
-          | line + 1 < length (T.lines rzkBlocks) = contentLines (line + 1)
-          | otherwise = ""
+        prevLine = contentLines (line - 1)
+        nextLine = contentLines (line + 1)
         spacesNextLine = T.length $ T.takeWhile (== ' ') nextLine
         edits = spaceEdits ++ unicodeEdits
         spaceEdits

--- a/rzk/test/Rzk/FormatSpec.hs
+++ b/rzk/test/Rzk/FormatSpec.hs
@@ -2,12 +2,13 @@
 Module      : FormatterSpec
 Description : Tests related to the formatter module
 -}
+{-# LANGUAGE OverloadedStrings #-}
 module Rzk.FormatSpec where
 
 import qualified Data.Text.IO as T
 import           Test.Hspec
 
-import           Rzk.Format   (format, isWellFormatted)
+import           Rzk.Format   (format, formatDocument, isWellFormatted)
 
 formatsTo :: FilePath -> FilePath -> Expectation
 formatsTo beforePath afterPath = do
@@ -66,3 +67,21 @@ spec = do
     it "Fixes indentation" pending
 
     it "Wraps long lines" pending
+
+  -- The language server replaces the whole document, and used to send it with
+  -- every trailing newline stripped: saving deleted the file's final newline,
+  -- which then failed the .editorconfig and Prettier checks that sHoTT's CI
+  -- runs, with no formatting able to satisfy both.
+  describe "formatDocument" $ do
+    it "Keeps the final newline" $ do
+      formatDocument "#lang rzk-1\n" `shouldBe` "#lang rzk-1\n"
+
+    it "Keeps a document that ends without a newline as it was" $ do
+      formatDocument "#lang rzk-1" `shouldBe` "#lang rzk-1"
+
+    it "Keeps the trailing blank lines the source had" $ do
+      formatDocument "#lang rzk-1\n\n\n" `shouldBe` "#lang rzk-1\n\n\n"
+
+    it "Is idempotent on the final newline" $ do
+      let src = "#lang rzk-1\n\n#define id (A : U)\n  : A → A\n  := \\ x → x\n"
+      formatDocument src `shouldBe` src


### PR DESCRIPTION
Two independent fixes to the formatter, both reported by Fredrik Bakke as making sHoTT uncomfortable to edit.

1. **Formatting is linear in the file size.** The lines are split once into an array and the tokens grouped once by the line they start on, both indexed. Until now `contentLines` split the whole document afresh on every lookup, and the rule that inspects the tokens preceding a position filtered the entire token list, which made `formatTextEdits` quadratic.

2. **The document keeps its final newline.** It now ends in as many newlines as it began with, and the rule lives in `Rzk.Format.formatDocument`, which existed for this consumer and was until now a synonym for `format`. The language server replaces the whole document, and sent it with all trailing newlines stripped while the range it replaces already spans them, so the final newline was deleted on each format. A file so formatted then fails `.editorconfig`'s `insert_final_newline` and Prettier, and no further formatting can satisfy both.

What matters for editing is how long the server takes to answer a `textDocument/formatting` request, since VS Code abandons a format-on-save that has not answered within 750 ms. Measured over the stdio protocol against a running server (median of 8 round trips per point):

| lines | v0.11.1 | this branch |
| ----: | ------: | ----------: |
|   300 |  6.9 ms |      4.7 ms |
|   600 | 23.0 ms |      7.0 ms |
|  1200 | 160.2 ms |     13.7 ms |
|  2367 | **787.8 ms** |  20.2 ms |

The last row is `simplicial-hott/08-covariant.rzk.md`, sHoTT's largest module: on my machine it sat right at the cutoff, so saving it looked as if the editor were refusing. Anyone on a slower machine lost the save outright.

Of the 13 ms the library now spends on that module, 8.3 ms is BNFC's layout resolver and 2.3 ms the lexer, both shared with the rest of rzk. The formatter's own rules are 2.4 ms. So there is no further large win to be had inside the formatter, and at 20 ms against a 750 ms budget there is no need to look for one, I think.