### PR TITLE
Report errors and holes where they are, and report all of them

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -154,6 +154,7 @@ extra-source-files:
     test/typecheck/cases/ill-recor-as-tope.rzk
     test/typecheck/cases/ill-recor-coverage-required.rzk
     test/typecheck/cases/ill-recor-guard-disjoint.rzk
+    test/typecheck/cases/ill-recover-after-body-error.rzk
     test/typecheck/cases/ill-render-latex-define.rzk
     test/typecheck/cases/ill-repeated-binder-lambda.rzk
     test/typecheck/cases/ill-repeated-binder-pair.rzk
@@ -338,6 +339,7 @@ extra-source-files:
     test/typecheck/cases/ill-recor-as-tope.expect.yaml
     test/typecheck/cases/ill-recor-coverage-required.expect.yaml
     test/typecheck/cases/ill-recor-guard-disjoint.expect.yaml
+    test/typecheck/cases/ill-recover-after-body-error.expect.yaml
     test/typecheck/cases/ill-render-latex-define.expect.yaml
     test/typecheck/cases/ill-repeated-binder-lambda.expect.yaml
     test/typecheck/cases/ill-repeated-binder-pair.expect.yaml

--- a/rzk/src/Language/Rzk/Foil/Convert.hs
+++ b/rzk/src/Language/Rzk/Foil/Convert.hs
@@ -41,8 +41,10 @@ import           Debug.Trace              (trace)   -- FIXME: use proper mechani
 import           Unsafe.Coerce            (unsafeCoerce)
 
 import           Language.Rzk.Foil.Syntax
-import           Language.Rzk.Foil.Names (Binder (..), Display, TModality (..),
-                                           VarIdent, holeName, toBinder, varIdent)
+import           Language.Rzk.Foil.Names (Binder (..), Display,
+                                           RzkPosition (RzkPosition),
+                                           TModality (..), VarIdent, holeName,
+                                           toBinder, varIdent)
 import qualified Language.Rzk.Foil.Names as Free
 import qualified Language.Rzk.Syntax      as Rzk
 
@@ -115,8 +117,26 @@ toTerm scope env = go
       , "  " <> Rzk.printTree suggestion
       ]
 
+    -- Every node is tagged with where it was written, so that a diagnostic
+    -- points at the sub-term it is about rather than at the declaration around
+    -- it.
+    --
+    -- A node with no position of its own is left with whatever the conversion
+    -- of its body found. Desugaring builds surface nodes and hands them back to
+    -- 'go', and not all of them carry a position: the λ that @addParams@ wraps
+    -- a definition's body in is spelled nowhere, and overwriting the body's
+    -- position with its absence would put every such error back on the
+    -- declaration line.
+    --
+    -- The file is not recorded here: a term is converted while checking a known
+    -- module, and the diagnostic takes the path from the context around it.
     go :: Rzk.Term -> Term n
-    go = \case
+    go term = case Rzk.hasPosition term of
+      Nothing  -> go' term
+      Just pos -> atSrcPos (RzkPosition Nothing (Just pos)) (go' term)
+
+    go' :: Rzk.Term -> Term n
+    go' = \case
       -- ASCII aliases are desugared exactly as before.
       Rzk.ASCII_CubeUnitStar loc -> go (Rzk.CubeUnitStar loc)
       Rzk.ASCII_Cube2_0 loc -> go (Rzk.Cube2_0 loc)

--- a/rzk/src/Language/Rzk/Foil/Convert.hs
+++ b/rzk/src/Language/Rzk/Foil/Convert.hs
@@ -27,7 +27,7 @@
 -- they can be shown back to the user.
 module Language.Rzk.Foil.Convert where
 
-import           Control.Monad.Foil       (Distinct, NameBinder, NameMap, Scope)
+import           Control.Monad.Foil       (Distinct, NameMap, Scope)
 import qualified Control.Monad.Foil       as Foil
 import           Control.Monad.Foil.Internal (NameMap (..))
 import           Control.Monad.Free.Foil  (AST (..), ScopedAST (..))
@@ -65,7 +65,7 @@ toScopedPatternWith
   :: Distinct n
   => Scope n -> Rzk.Pattern -> Env n
   -> (forall l. Distinct l => Scope l -> Env l -> Term l)
-  -> ScopedAST NameBinder TermSig n
+  -> ScopedTerm n
 toScopedPatternWith scope pat env k =
   Foil.withFresh scope $ \binder ->
     let scope' = Foil.extendScope binder scope
@@ -78,14 +78,14 @@ toScopedPatternWith scope pat env k =
 -- | Enter a pattern binder over a surface body.
 toScopedPattern
   :: Distinct n
-  => Scope n -> Rzk.Pattern -> Env n -> Rzk.Term -> ScopedAST NameBinder TermSig n
+  => Scope n -> Rzk.Pattern -> Env n -> Rzk.Term -> ScopedTerm n
 toScopedPattern scope pat env body =
   toScopedPatternWith scope pat env (\scope' env' -> toTerm scope' env' body)
 
 -- | Enter an anonymous binder (a non-dependent function type binds nothing).
 toScopedAnon
   :: Distinct n
-  => Scope n -> Env n -> Rzk.Term -> ScopedAST NameBinder TermSig n
+  => Scope n -> Env n -> Rzk.Term -> ScopedTerm n
 toScopedAnon scope env body =
   Foil.withFresh scope $ \binder ->
     let scope' = Foil.extendScope binder scope

--- a/rzk/src/Language/Rzk/Foil/Print.hs
+++ b/rzk/src/Language/Rzk/Foil/Print.hs
@@ -269,7 +269,7 @@ freshenBinder used' stream (BinderPair l r) =
 --
 -- (free-foil's own @freeVarsOf@ would do, but it is not in the 0.2.0 release --
 -- it is one of the unreleased helpers on free-foil's @main@.)
-scopeUsesItsBinder :: ScopedAST Foil.NameBinder TermSig n -> Bool
+scopeUsesItsBinder :: ScopedTerm n -> Bool
 scopeUsesItsBinder (ScopedAST binder body) =
   Foil.nameId (Foil.nameOf binder) `elem` nameIdsOf body
 

--- a/rzk/src/Language/Rzk/Foil/Syntax.hs
+++ b/rzk/src/Language/Rzk/Foil/Syntax.hs
@@ -60,8 +60,9 @@ import           Generics.Kind.TH                (deriveGenericK)
 import qualified GHC.Generics                   as GHC
 import           Unsafe.Coerce                  (unsafeCoerce)
 
-import           Language.Rzk.Foil.Names        (Binder (..), TModality (..),
-                                                 TypeInfo (..), VarIdent)
+import           Language.Rzk.Foil.Names        (Binder (..), RzkPosition (..),
+                                                 TModality (..), TypeInfo (..),
+                                                 VarIdent)
 
 -- * The signature
 --
@@ -199,10 +200,30 @@ instance ZipMatchK TypeInfo where
   zipMatchWithK (f :^: M0) (TypeInfo t1 _ _) (TypeInfo t2 _ _) =
     Just (TypeInfo (maybe (error "ZipMatchK TypeInfo: annotation forced") id (f t1 t2)) Nothing Nothing)
 
+-- | Where a term was written.
+--
+-- This is the annotation of an /untyped/ term, so that a diagnostic can point
+-- at the sub-term it is about rather than at the declaration around it (issue
+-- #81). It is a phantom in the node's term parameter: the annotation machinery
+-- wants a functor of the term, and a position holds no terms.
+newtype SrcPos term = SrcPos RzkPosition
+  deriving (Functor, Foldable, Traversable)
+
+-- | Two terms written in different places are the same term, so a position is
+-- ignored in matching, as a node's type is.
+instance ZipMatchK SrcPos where
+  zipMatchWithK _ (SrcPos pos) _ = Just (SrcPos pos)
+
+-- | No position: what a node the checker builds itself carries, and what a node
+-- gets until the conversion from the surface syntax puts the real one on it.
+noSrcPos :: SrcPos term
+noSrcPos = SrcPos (RzkPosition Nothing Nothing)
+
 -- * Terms
 
--- | An untyped term: the surface syntax, elaborated but without annotations.
-type Term = AST NameBinder TermSig
+-- | An untyped term: the surface syntax, elaborated, every node carrying where
+-- it was written.
+type Term = AST NameBinder (AnnSig SrcPos TermSig)
 
 -- | A typed term: every node carries its type. The successor of @TermT@.
 type TermT = AST NameBinder (AnnSig TypeInfo TermSig)
@@ -211,7 +232,23 @@ type TermT = AST NameBinder (AnnSig TypeInfo TermSig)
 type ScopedTermT = ScopedAST NameBinder (AnnSig TypeInfo TermSig)
 
 -- | A scope of an untyped term.
-type ScopedTerm = ScopedAST NameBinder TermSig
+type ScopedTerm = ScopedAST NameBinder (AnnSig SrcPos TermSig)
+
+-- | Record where a term was written.
+--
+-- A variable carries no node of its own, so it is returned unchanged; where a
+-- variable occurrence was written is on its 'VarIdent' instead.
+atSrcPos :: RzkPosition -> Term n -> Term n
+atSrcPos pos (Node (AnnSig _ sig)) = Node (AnnSig (SrcPos pos) sig)
+atSrcPos _ t@(Var _)               = t
+
+-- | Where the term was written, when it came from a file.
+positionOfTerm :: Term n -> Maybe RzkPosition
+positionOfTerm (Var _)                        = Nothing
+positionOfTerm (Node (AnnSig (SrcPos pos) _)) =
+  case rzkLineCol pos of
+    Nothing -> Nothing
+    Just _  -> Just pos
 
 -- | The annotation of a node: its type, and its memoised normal forms. A
 -- variable carries none — its type lives in the context.
@@ -222,7 +259,7 @@ typeInfoOf (Node (AnnSig info _)) = Just info
 -- | Drop every annotation, for printing and for the surface-facing API.
 untyped :: TermT n -> Term n
 untyped (Var name)              = Var name
-untyped (Node (AnnSig _ann sig)) = Node (bimap untypedScoped untyped sig)
+untyped (Node (AnnSig _ann sig)) = UntypedNode (bimap untypedScoped untyped sig)
   where
     untypedScoped (ScopedAST binder body) = ScopedAST binder (untyped body)
 
@@ -275,7 +312,7 @@ nubT (t : ts) = t : nubT (filter (not . eqT t) ts)
 -- makes the coercion back to the outer scope right.
 freeVarsOfTerm :: Term n -> [Foil.Name n]
 freeVarsOfTerm (Var x)    = [x]
-freeVarsOfTerm (Node sig) = bifoldMap freeVarsOfScoped freeVarsOfTerm sig
+freeVarsOfTerm (UntypedNode sig) = bifoldMap freeVarsOfScoped freeVarsOfTerm sig
   where
     freeVarsOfScoped :: ScopedTerm n' -> [Foil.Name n']
     freeVarsOfScoped (ScopedAST binder body) =
@@ -296,7 +333,7 @@ freeVarsOfTermT = freeVarsOfTerm . untyped
 containsUniverse :: Term n -> Bool
 containsUniverse Universe   = True
 containsUniverse (Var _)    = False
-containsUniverse (Node sig) =
+containsUniverse (UntypedNode sig) =
   bifoldr (\scoped acc -> containsUniverseScoped scoped || acc)
           (\t acc -> containsUniverse t || acc) False sig
   where
@@ -312,7 +349,7 @@ isHoleT _       = False
 holeNamesOf :: Term n -> [Maybe VarIdent]
 holeNamesOf (Hole mname) = [mname]
 holeNamesOf (Var _)      = []
-holeNamesOf (Node sig)   = bifoldr (\scoped acc -> holeNamesOfScoped scoped <> acc)
+holeNamesOf (UntypedNode sig) = bifoldr (\scoped acc -> holeNamesOfScoped scoped <> acc)
                                    (\t acc -> holeNamesOf t <> acc) [] sig
   where
     holeNamesOfScoped (ScopedAST _ body) = holeNamesOf body
@@ -520,57 +557,68 @@ pattern HoleT info mname = Node (AnnSig info (HoleF mname))
 
 -- ** Untyped patterns
 --
--- The same constructors on 'Term' (no annotation), for the surface conversions
--- and the printer.
+-- The same constructors on 'Term', for the surface conversions and the printer.
+--
+-- Each goes through 'UntypedNode', which ignores a node's position on the way in
+-- and leaves it unset on the way out. So the checker builds and matches untyped
+-- terms exactly as it did before terms carried a position, and the conversion
+-- from the surface syntax ('atSrcPos') is the only place that puts a real one on.
 
-pattern Universe = Node UniverseF
-pattern UniverseCube = Node UniverseCubeF
-pattern UniverseTope = Node UniverseTopeF
-pattern CubeUnit = Node CubeUnitF
-pattern CubeUnitStar = Node CubeUnitStarF
-pattern Cube2 = Node Cube2F
-pattern Cube2_0 = Node Cube2_0F
-pattern Cube2_1 = Node Cube2_1F
-pattern CubeI = Node CubeIF
-pattern CubeI_0 = Node CubeI_0F
-pattern CubeI_1 = Node CubeI_1F
-pattern CubeProduct l r = Node (CubeProductF l r)
-pattern CubeFlip t = Node (CubeFlipF t)
-pattern CubeUnflip t = Node (CubeUnflipF t)
-pattern CubeSup l r = Node (CubeSupF l r)
-pattern CubeInf l r = Node (CubeInfF l r)
-pattern TopeTop = Node TopeTopF
-pattern TopeBottom = Node TopeBottomF
-pattern TopeEQ l r = Node (TopeEQF l r)
-pattern TopeLEQ l r = Node (TopeLEQF l r)
-pattern TopeAnd l r = Node (TopeAndF l r)
-pattern TopeOr l r = Node (TopeOrF l r)
-pattern TopeInv t = Node (TopeInvF t)
-pattern TopeUninv t = Node (TopeUninvF t)
-pattern RecBottom = Node RecBottomF
-pattern RecOr rs = Node (RecOrF rs)
-pattern TypeFun orig md param mtope ret = Node (TypeFunF orig md param mtope ret)
-pattern TypeSigma orig md a b = Node (TypeSigmaF orig md a b)
-pattern TypeId a mtA b = Node (TypeIdF a mtA b)
-pattern App f x = Node (AppF f x)
-pattern Let orig mparam val body = Node (LetF orig mparam val body)
-pattern Lambda orig mparam body = Node (LambdaF orig mparam body)
-pattern Pair l r = Node (PairF l r)
-pattern First t = Node (FirstF t)
-pattern Second t = Node (SecondF t)
-pattern Refl mx = Node (ReflF mx)
-pattern IdJ a b c d e f = Node (IdJF a b c d e f)
-pattern Match scrut mmotive branches = Node (MatchF scrut mmotive branches)
-pattern MatchArm orig arm = Node (MatchArmF orig arm)
-pattern Unit = Node UnitF
-pattern TypeUnit = Node TypeUnitF
-pattern TypeAsc term ty = Node (TypeAscF term ty)
-pattern TypeRestricted ty rs = Node (TypeRestrictedF ty rs)
-pattern TypeModal md ty = Node (TypeModalF md ty)
-pattern ModApp md t = Node (ModAppF md t)
-pattern ModExtract app inn t = Node (ModExtractF app inn t)
-pattern LetMod orig app inn mparam mmotive val body = Node (LetModF orig app inn mparam mmotive val body)
-pattern Hole mname = Node (HoleF mname)
+-- | An untyped node, taken and made without regard for where it was written.
+pattern UntypedNode :: TermSig (ScopedTerm n) (Term n) -> Term n
+pattern UntypedNode sig <- Node (AnnSig _ sig) where
+  UntypedNode sig = Node (AnnSig noSrcPos sig)
+
+{-# COMPLETE Var, UntypedNode #-}
+
+pattern Universe = UntypedNode UniverseF
+pattern UniverseCube = UntypedNode UniverseCubeF
+pattern UniverseTope = UntypedNode UniverseTopeF
+pattern CubeUnit = UntypedNode CubeUnitF
+pattern CubeUnitStar = UntypedNode CubeUnitStarF
+pattern Cube2 = UntypedNode Cube2F
+pattern Cube2_0 = UntypedNode Cube2_0F
+pattern Cube2_1 = UntypedNode Cube2_1F
+pattern CubeI = UntypedNode CubeIF
+pattern CubeI_0 = UntypedNode CubeI_0F
+pattern CubeI_1 = UntypedNode CubeI_1F
+pattern CubeProduct l r = UntypedNode (CubeProductF l r)
+pattern CubeFlip t = UntypedNode (CubeFlipF t)
+pattern CubeUnflip t = UntypedNode (CubeUnflipF t)
+pattern CubeSup l r = UntypedNode (CubeSupF l r)
+pattern CubeInf l r = UntypedNode (CubeInfF l r)
+pattern TopeTop = UntypedNode TopeTopF
+pattern TopeBottom = UntypedNode TopeBottomF
+pattern TopeEQ l r = UntypedNode (TopeEQF l r)
+pattern TopeLEQ l r = UntypedNode (TopeLEQF l r)
+pattern TopeAnd l r = UntypedNode (TopeAndF l r)
+pattern TopeOr l r = UntypedNode (TopeOrF l r)
+pattern TopeInv t = UntypedNode (TopeInvF t)
+pattern TopeUninv t = UntypedNode (TopeUninvF t)
+pattern RecBottom = UntypedNode RecBottomF
+pattern RecOr rs = UntypedNode (RecOrF rs)
+pattern TypeFun orig md param mtope ret = UntypedNode (TypeFunF orig md param mtope ret)
+pattern TypeSigma orig md a b = UntypedNode (TypeSigmaF orig md a b)
+pattern TypeId a mtA b = UntypedNode (TypeIdF a mtA b)
+pattern App f x = UntypedNode (AppF f x)
+pattern Let orig mparam val body = UntypedNode (LetF orig mparam val body)
+pattern Lambda orig mparam body = UntypedNode (LambdaF orig mparam body)
+pattern Pair l r = UntypedNode (PairF l r)
+pattern First t = UntypedNode (FirstF t)
+pattern Second t = UntypedNode (SecondF t)
+pattern Refl mx = UntypedNode (ReflF mx)
+pattern IdJ a b c d e f = UntypedNode (IdJF a b c d e f)
+pattern Match scrut mmotive branches = UntypedNode (MatchF scrut mmotive branches)
+pattern MatchArm orig arm = UntypedNode (MatchArmF orig arm)
+pattern Unit = UntypedNode UnitF
+pattern TypeUnit = UntypedNode TypeUnitF
+pattern TypeAsc term ty = UntypedNode (TypeAscF term ty)
+pattern TypeRestricted ty rs = UntypedNode (TypeRestrictedF ty rs)
+pattern TypeModal md ty = UntypedNode (TypeModalF md ty)
+pattern ModApp md t = UntypedNode (ModAppF md t)
+pattern ModExtract app inn t = UntypedNode (ModExtractF app inn t)
+pattern LetMod orig app inn mparam mmotive val body = UntypedNode (LetModF orig app inn mparam mmotive val body)
+pattern Hole mname = UntypedNode (HoleF mname)
 
 {-# COMPLETE Var, Universe, UniverseCube, UniverseTope, CubeUnit, CubeUnitStar,
   Cube2, Cube2_0, Cube2_1, CubeI, CubeI_0, CubeI_1, CubeProduct, CubeFlip,

--- a/rzk/src/Language/Rzk/Foil/Syntax.hs
+++ b/rzk/src/Language/Rzk/Foil/Syntax.hs
@@ -234,13 +234,22 @@ type ScopedTermT = ScopedAST NameBinder (AnnSig TypeInfo TermSig)
 -- | A scope of an untyped term.
 type ScopedTerm = ScopedAST NameBinder (AnnSig SrcPos TermSig)
 
--- | Record where a term was written.
+-- | Record where a term was written, unless it is already recorded.
+--
+-- The conversion tags a node after converting what is under it, and desugaring
+-- hands surface nodes back to the conversion carrying the position of the node
+-- they came from. A node that already knows where it was written therefore
+-- learnt it from something more specific, and keeps it: the λ that a
+-- definition's parameters are wrapped in reuses the λ's own position as it
+-- peels them off, and would otherwise claim every diagnostic in the body.
 --
 -- A variable carries no node of its own, so it is returned unchanged; where a
 -- variable occurrence was written is on its 'VarIdent' instead.
 atSrcPos :: RzkPosition -> Term n -> Term n
-atSrcPos pos (Node (AnnSig _ sig)) = Node (AnnSig (SrcPos pos) sig)
-atSrcPos _ t@(Var _)               = t
+atSrcPos pos t@(Node (AnnSig (SrcPos old) sig))
+  | Nothing <- rzkLineCol old = Node (AnnSig (SrcPos pos) sig)
+  | otherwise                 = t
+atSrcPos _ t@(Var _)          = t
 
 -- | Where the term was written, when it came from a file.
 positionOfTerm :: Term n -> Maybe RzkPosition

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -134,15 +134,32 @@ toLspUri (RefInd.Uri { uriPath = p }) = filePathToUri p
 -- buffer when the file is open, from disk otherwise. A file that cannot be
 -- read converts as all-BMP, i.e. the conversion is the identity.
 astralLinesOfFile :: FilePath -> LSP Enc.AstralLines
-astralLinesOfFile path = do
+astralLinesOfFile = fmap Enc.astralLines . sourceOfFile
+
+-- | The text of a file as the client sees it: from the editor buffer when the
+-- file is open, from disk otherwise. A file that cannot be read is empty.
+sourceOfFile :: FilePath -> LSP T.Text
+sourceOfFile path = do
   mdoc <- getVirtualFile (filePathToNormalizedUri path)
   case virtualFileText <$> mdoc of
-    Just text -> return (Enc.astralLines (T.filter (/= '\r') text))
+    Just text -> return (T.filter (/= '\r') text)
     Nothing -> liftIO $ do
       result <- try @SomeException (readFile path)
       return $ case result of
-        Left _    -> Enc.astralLines ""
-        Right src -> Enc.astralLines (T.filter (/= '\r') (T.pack src))
+        Left _    -> ""
+        Right src -> T.filter (/= '\r') (T.pack src)
+
+-- | The lines of a document, by 0-based line number, for reading the token a
+-- diagnostic marks.
+newtype SourceLines = SourceLines (Map.Map Int T.Text)
+
+sourceLinesOf :: T.Text -> SourceLines
+sourceLinesOf src = SourceLines (Map.fromDistinctAscList (zip [0 ..] (T.lines src)))
+
+-- | A line outside the document is empty, as is one in a file that could not be
+-- read; a marking there falls back to a single character.
+lineOf :: SourceLines -> Int -> T.Text
+lineOf (SourceLines ls) line = Map.findWithDefault "" line ls
 
 fromLspPosition :: Enc.AstralLines -> LSP.Position -> RefInd.Position
 fromLspPosition als (LSP.Position l c) =
@@ -292,20 +309,30 @@ typecheckFromConfigFile = do
     -- max count of 0 forces an empty publish to the client, clearing it.
     publishModuleDiagnostics :: FilePath -> [TypeErrorInScopedContext] -> [CheckWarning] -> [HoleInfo] -> LSP ()
     publishModuleDiagnostics path typeErrors warnings holeInfos = do
-      let errDiagnostics  = [ (filepathOfTypeError err, [diagnosticOfTypeError err])
+      let errDiagnostics  = [ (filepathOfTypeError err, [Diag.diagnoseTypeError TopDown err])
                             | err <- typeErrors ]
-          warnDiagnostics = [ (path', [diagnosticOfWarning warning])
+          warnDiagnostics = [ (path', [Diag.diagnoseCheckWarning warning])
                             | warning <- warnings
                             , let path' = fromMaybe path
                                     (warningLocation warning >>= locationFilePath) ]
-          holeDiagnostics = [ (path', [diagnosticOfHole hole])
+          holeDiagnostics = [ (path', [Diag.diagnoseHole hole])
                             | hole <- holeInfos
                             , Just path' <- [holeLocation hole >>= locationFilePath] ]
           diagnosticsByFile = Map.insertWith (flip (<>)) path [] $
             Map.fromListWith (flip (<>)) (errDiagnostics <> warnDiagnostics <> holeDiagnostics)
-      forM_ (Map.toList diagnosticsByFile) $ \(path', diags) ->
-        publishDiagnostics (if null diags then 0 else maxDiagnosticCount)
-          (filePathToNormalizedUri path') Nothing (partitionBySource diags)
+      -- The source of each file with something to report, read once: a
+      -- diagnostic marks the token it points at, and its column is converted
+      -- to the UTF-16 the client counts in.
+      forM_ (Map.toList diagnosticsByFile) $ \(path', diags) -> do
+        lspDiags <- case diags of
+          [] -> return []
+          _  -> do
+            src <- sourceOfFile path'
+            let als = Enc.astralLines src
+                sourceLines = sourceLinesOf src
+            return (map (lspDiagnosticOf als sourceLines) diags)
+        publishDiagnostics (if null lspDiags then 0 else maxDiagnosticCount)
+          (filePathToNormalizedUri path') Nothing (partitionBySource lspDiags)
 
     -- Modules that a run never reaches (they come after a module with an
     -- error, and every rzk module depends on all earlier ones) get a single
@@ -338,11 +365,11 @@ typecheckFromConfigFile = do
         Just path -> path
         _         -> error "the impossible happened! Please contact Abdelrahman immediately!!!"
 
-    -- Map a structured library diagnostic to an LSP diagnostic. The range is
-    -- line-level (whole line), reflecting the granularity rzk currently retains.
-    lspDiagnosticOf :: Diag.Diagnostic -> Diagnostic
-    lspDiagnosticOf d = Diagnostic
-                      (Range (Position line 0) (Position line 99)) -- 99 to reach end of line and be visible until we actually have column information
+    -- Map a structured library diagnostic to an LSP diagnostic, marking the
+    -- term it is about in the given source.
+    lspDiagnosticOf :: Enc.AstralLines -> SourceLines -> Diag.Diagnostic -> Diagnostic
+    lspDiagnosticOf als sourceLines d = Diagnostic
+                      (Enc.rangeToUtf16 als (diagnosticRange sourceLines d))
                       (Just (lspSeverity (Diag.diagnosticSeverity d)))
                       (Just (InR (T.pack (Diag.diagnosticCode d))))
                       Nothing                   -- diagnostic description
@@ -351,11 +378,42 @@ typecheckFromConfigFile = do
                       Nothing                   -- tags
                       (Just [])                 -- related information
                       Nothing                   -- data that is preserved between different calls
+
+    -- What the diagnostic marks: the token the term it is about starts with.
+    --
+    -- The checker knows where a term begins and not where it ends (the surface
+    -- syntax records only the start of a node), so the marked span is the head
+    -- token. That puts the squiggle on the right thing without claiming an
+    -- extent that was never measured, and a hole is marked exactly, since @?@
+    -- and @?name@ are the whole term. A diagnostic that has no column is about
+    -- a whole declaration and still marks the line.
+    diagnosticRange :: SourceLines -> Diag.Diagnostic -> Range
+    diagnosticRange sourceLines d = case Diag.diagnosticLocation d of
+      Just loc
+        | Just lineNo <- locationLine loc
+        , Just col <- locationColumn loc
+        , let line = fromIntegral (lineNo - 1)  -- LSP counts lines from 0
+        , let start = fromIntegral (col - 1)    -- and columns too
+        -> Range (Position line start)
+                 (Position line (start + tokenWidth sourceLines line start))
+      Just loc
+        | Just lineNo <- locationLine loc
+        , let line = fromIntegral (lineNo - 1)
+        -> Range (Position line 0) (Position line 99) -- to the end of the line
+      _ -> Range (Position 0 0) (Position 0 99)
+
+    -- The width of the token starting at a position, in code points, and never
+    -- zero: an empty marking shows nothing at all. A token that opens with a
+    -- bracket or a separator is one character wide, since those delimit rather
+    -- than name; anything else runs to the next space or delimiter.
+    tokenWidth :: SourceLines -> UInt -> UInt -> UInt
+    tokenWidth sourceLines line start =
+      case T.drop (fromIntegral start) (lineOf sourceLines (fromIntegral line)) of
+        rest | Just (c, _) <- T.uncons rest, not (isDelimiter c)
+             -> max 1 (fromIntegral (T.length (T.takeWhile (not . isDelimiter) rest)))
+        _    -> 1
       where
-        line = fromIntegral $ fromMaybe 0 $ do
-          loc <- Diag.diagnosticLocation d
-          lineNo <- locationLine loc
-          return (lineNo - 1) -- VS Code indexes lines from 0, but locationLine starts with 1
+        isDelimiter c = c `elem` (" \t()[]{},;" :: String)
 
     lspSeverity :: Diag.Severity -> DiagnosticSeverity
     lspSeverity = \case
@@ -363,15 +421,6 @@ typecheckFromConfigFile = do
       Diag.SeverityWarning     -> DiagnosticSeverity_Warning
       Diag.SeverityInformation -> DiagnosticSeverity_Information
       Diag.SeverityHint        -> DiagnosticSeverity_Hint
-
-    diagnosticOfTypeError :: TypeErrorInScopedContext -> Diagnostic
-    diagnosticOfTypeError = lspDiagnosticOf . Diag.diagnoseTypeError TopDown
-
-    diagnosticOfHole :: HoleInfo -> Diagnostic
-    diagnosticOfHole = lspDiagnosticOf . Diag.diagnoseHole
-
-    diagnosticOfWarning :: CheckWarning -> Diagnostic
-    diagnosticOfWarning = lspDiagnosticOf . Diag.diagnoseCheckWarning
 
     diagnosticOfParseError :: Enc.AstralLines -> T.Text -> Diagnostic
     diagnosticOfParseError als err = Diagnostic (Enc.rangeToUtf16 als (Range (Position errLine errColumnStart) (Position errLine errColumnEnd)))

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -265,7 +265,7 @@ typecheckFromConfigFile = do
           -- /is/ the elaborated prefix, so nothing is replayed or re-elaborated.
           let prefix = case reverse checked of
                 (_, entry) : _ -> cachedModuleChecked entry
-                []             -> emptyChecked
+                []             -> emptyCheckedWithHoles
           tcResult <- liftIO $ tryTypecheck $ evaluate $
             recheckFrom prefix [(path, module_)]
           case tcResult of
@@ -947,7 +947,7 @@ isChanged cache path = toIsChanged $ do
   -- Re-check this file from the context of the prefix before it.
   let prefix = case reverse (takeWhile ((/= path) . fst) cache) of
         (_, entry) : _ -> cachedModuleChecked entry
-        []             -> emptyChecked
+        []             -> emptyCheckedWithHoles
   e <- toExceptTLifted $ try @SomeException $ evaluate $
     recheckFrom prefix [(path, module')]
   (checkedNow, _holes) <- toExceptT $ return e

--- a/rzk/src/Rzk/Diagnostic.hs
+++ b/rzk/src/Rzk/Diagnostic.hs
@@ -93,9 +93,10 @@ instance ToJSON Severity where
 -- | Encode a location as JSON. A plain helper rather than a @ToJSON@ instance,
 -- to avoid an orphan instance ('LocationInfo' is defined in "Rzk.TypeCheck").
 locationToJSON :: LocationInfo -> Value
-locationToJSON (LocationInfo path line) = object
+locationToJSON (LocationInfo path line column) = object
   [ "file" .= path
   , "line" .= line
+  , "column" .= column
   ]
 
 instance ToJSON Diagnostic where
@@ -278,5 +279,7 @@ ppHoleInfo HoleInfo{..} = unlines $
             | e <- entries ]
 
 ppLocationInfo :: LocationInfo -> String
-ppLocationInfo (LocationInfo mpath mline) =
-  maybe "<input>" id mpath <> maybe "" ((":" <>) . show) mline
+ppLocationInfo (LocationInfo mpath mline mcol) =
+  maybe "<input>" id mpath
+    <> maybe "" ((":" <>) . show) mline
+    <> maybe "" ((":" <>) . show) mcol

--- a/rzk/src/Rzk/TypeCheck/Context.hs
+++ b/rzk/src/Rzk/TypeCheck/Context.hs
@@ -49,8 +49,9 @@ import qualified Data.Map                    as Map
 import           Unsafe.Coerce               (unsafeCoerce)
 
 import           Language.Rzk.Foil.Syntax
-import           Language.Rzk.Foil.Names    (Binder (..), TModality (..),
-                                              VarIdent, binderName)
+import           Language.Rzk.Foil.Names    (Binder (..), RzkPosition (..),
+                                              TModality (..), VarIdent,
+                                              binderName)
 import qualified Language.Rzk.Syntax         as Rzk
 
 -- * The pieces of a context
@@ -70,10 +71,24 @@ data Verbosity
   | Silent
   deriving (Eq, Ord)
 
+-- | Where a diagnostic points.
+--
+-- The line and column are the start of whatever the diagnostic is about: the
+-- declaration being checked, narrowed to the sub-term as the checker descends
+-- into it (see @narrowLocation@ in "Rzk.TypeCheck.Monad"). The surface syntax
+-- records the start of a node and not its extent, so there is no end position
+-- to carry.
 data LocationInfo = LocationInfo
   { locationFilePath :: Maybe FilePath
   , locationLine     :: Maybe Int
+  , locationColumn   :: Maybe Int
   } deriving (Eq, Show)
+
+-- | Point a location at a position in the same file.
+atPosition :: RzkPosition -> LocationInfo -> LocationInfo
+atPosition pos loc = case rzkLineCol pos of
+  Nothing          -> loc
+  Just (line, col) -> loc { locationLine = Just line, locationColumn = Just col }
 
 -- | What is known about a hypothesis, local or top-level.
 data VarInfo n = VarInfo

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -999,7 +999,11 @@ withCommand command k action =
       { ctxCurrentCommand = Just command
       , ctxLocation = updatePosition (Rzk.hasPosition command) <$> ctxLocation ctx
       }
-    updatePosition pos loc = loc { locationLine = fst <$> pos }
+    -- Where the command starts. A judgement made inside it narrows this to the
+    -- sub-term it is about (see @narrowLocation@); this is what an error with
+    -- no sub-term of its own falls back to.
+    updatePosition pos loc =
+      loc { locationLine = fst <$> pos, locationColumn = snd <$> pos }
 
 -- | The binder leaves repeated within one binder /group/ of a surface
 -- command: the parameter list of a λ, of a declaration, or of a constructor
@@ -1061,6 +1065,23 @@ duplicateBinders x = concat
 
 -- | Elaborate a surface term in the current top-level scope: a free identifier
 -- resolves to the top-level entry it names.
+-- | Run a check with the location narrowed to where a surface term was written.
+--
+-- Descending through a judgement already narrows to the sub-term it is about
+-- (@narrowLocation@ in "Rzk.TypeCheck.Monad"), but only a /node/ carries a
+-- position: a variable is a leaf of the core syntax, with nowhere to put one.
+-- So a check that starts from a surface term says where that term starts, and a
+-- definition whose body is a bare variable is reported at the body rather than
+-- at the declaration above it.
+atSurface :: Rzk.HasPosition a => a -> TypeCheck n b -> TypeCheck n b
+atSurface x = local $ \ctx ->
+  ctx { ctxLocation = narrow <$> ctxLocation ctx }
+  where
+    narrow loc = case Rzk.hasPosition x of
+      Nothing          -> loc
+      Just (line, col) ->
+        loc { locationLine = Just line, locationColumn = Just col }
+
 elaborate :: forall n. Distinct n => Rzk.Term -> TypeCheck n (Term n)
 elaborate term = do
   ctx <- ask
@@ -1132,9 +1153,9 @@ checkCommands path i total commands k = case commands of
         -- stored type and value) would disagree with the term the user wrote;
         -- keeping the WHNF cached preserves the original one-shot reduction.
         tyTerm <- elaborate (addParamDecls paramDecls ty)
-        ty' <- memoizeWHNF =<< typecheck tyTerm universeT
+        ty' <- atSurface ty $ memoizeWHNF =<< typecheck tyTerm universeT
         valTerm <- elaborate (addParams params term)
-        term' <- memoizeWHNF =<< typecheck valTerm ty'
+        term' <- atSurface term $ memoizeWHNF =<< typecheck valTerm ty'
         withTopLevel (varIdentAt path name) ty' (Just term') False used Nothing $ \binder decl -> do
           backend <- asks ctxRenderBackend
           termSVG <- case backend of
@@ -1166,7 +1187,7 @@ checkCommands path i total commands k = case commands of
         used <- mapM (checkDefined . varIdentAt path) vars
         paramDecls <- concat <$> mapM paramToParamDecl params
         tyTerm <- elaborate (addParamDecls paramDecls ty)
-        ty' <- memoizeWHNF =<< typecheck tyTerm universeT
+        ty' <- atSurface ty $ memoizeWHNF =<< typecheck tyTerm universeT
         withTopLevel (varIdentAt path name) ty' Nothing False used Nothing $ \_binder decl ->
           checkCommands path (i + 1) total more $ \decls errs ->
             k (sinkDecl decl : decls) errs
@@ -1176,7 +1197,7 @@ checkCommands path i total commands k = case commands of
         <> intercalate " " [ Rzk.printTree name | name <- names ]) $
       withCommand command k $ do
         tyTerm <- elaborate ty
-        ty' <- typecheck tyTerm universeT
+        ty' <- atSurface ty $ typecheck tyTerm universeT
         assume (map (varIdentAt path) names) ty' $ \assumed ->
           checkCommands path (i + 1) total more $ \decls errs ->
             k (sinkDecls assumed <> decls) errs
@@ -1185,9 +1206,9 @@ checkCommands path i total commands k = case commands of
     announce (" Checking " <> Rzk.printTree term <> " : " <> Rzk.printTree ty) $
       withCommand command k $ do
         tyTerm <- elaborate ty
-        ty' <- typecheck tyTerm universeT >>= whnfT
+        ty' <- atSurface ty $ typecheck tyTerm universeT >>= whnfT
         termTerm <- elaborate term
-        _term' <- typecheck termTerm ty'
+        _term' <- atSurface term $ typecheck termTerm ty'
         checkCommands path (i + 1) total more k
 
   Rzk.CommandCompute loc term : more ->
@@ -1275,7 +1296,10 @@ checkModuleWithLocation
   -> TypeCheck n r
 checkModuleWithLocation (path, module_) k =
   traceTypeCheck Normal ("Checking module from " <> path) $
-    withLocation (LocationInfo { locationFilePath = Just path, locationLine = Nothing }) $
+    withLocation (LocationInfo
+      { locationFilePath = Just path
+      , locationLine = Nothing
+      , locationColumn = Nothing }) $
       checkModule (Just path) module_ k
 
 -- | Check a list of modules, one after another, in a scope that grows as it goes.

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -25,10 +25,9 @@
 module Rzk.TypeCheck.Decl where
 
 import           Control.Monad             (forM, forM_, unless, when)
-import           Control.Monad.Except      (catchError, runExcept)
+import           Control.Monad.Except      (catchError)
 import           Data.Data                 (Data, cast, gmapQ)
-import           Control.Monad.Reader      (ask, asks, local, runReaderT)
-import           Control.Monad.Trans.Writer.CPS (runWriterT)
+import           Control.Monad.Reader      (ask, asks, local)
 import           Data.List                 (intercalate)
 import qualified Data.Map                  as Map
 import qualified Data.Text                 as T
@@ -1299,17 +1298,18 @@ checkModules (m@(path, _) : ms) k =
 -- * The public entry points
 
 -- | Check the modules, and package the result with the scope it was checked in.
--- The warnings live on the writer channel during the run and are folded into
--- the 'Checked' package here.
+-- The warnings are recorded during the run and are folded into the 'Checked'
+-- package here.
 checkedModules :: [(FilePath, Rzk.Module)] -> Context Foil.VoidS -> Either TypeErrorInScopedContext (Checked, [HoleInfo])
 checkedModules modules ctx =
-  fmap package $ runExcept $ runWriterT $ flip runReaderT ctx $
+  package $ runTypeCheckWith ctx $
     checkModules modules $ \decls errs -> do
       ctx' <- ask
       pure (Checked ctx' decls errs [])
   where
-    package (Checked ctx' decls errs _, (holes, warnings)) =
-      (Checked ctx' decls errs warnings, holes)
+    package (Left err, _) = Left err
+    package (Right (Checked ctx' decls errs _), (holes, warnings)) =
+      Right (Checked ctx' decls errs warnings, holes)
 
 -- | Check the modules strictly: an unfilled hole is an error, and the first error
 -- stops the run.
@@ -1411,15 +1411,16 @@ recheckFrom
   -> [(FilePath, Rzk.Module)]
   -> Either TypeErrorInScopedContext (Checked, [HoleInfo])
 recheckFrom (Checked ctx decls _errs _warnings) modules =
-  fmap package $ runExcept $ runWriterT $ flip runReaderT ctx $
+  package $ runTypeCheckWith ctx $
     checkModules modules $ \newDecls errs -> do
       ctx' <- ask
       pure (Checked ctx' (sinkDeclGroups decls <> newDecls) errs [])
   where
     -- Only this run's warnings: like the errors, the prefix's warnings were
     -- already reported when the prefix was checked.
-    package (Checked ctx' decls' errs _, (holes, warnings)) =
-      (Checked ctx' decls' errs warnings, holes)
+    package (Left err, _) = Left err
+    package (Right (Checked ctx' decls' errs _), (holes, warnings)) =
+      Right (Checked ctx' decls' errs warnings, holes)
 
 -- | The errors of a checked run.
 checkedErrors :: Checked -> [TypeErrorInScopedContext]

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -1457,3 +1457,13 @@ checkedWarnings (Checked _ _ _ warnings) = warnings
 -- | Nothing checked yet: the empty context, and no declarations.
 emptyChecked :: Checked
 emptyChecked = Checked emptyContext [] [] []
+
+-- | Nothing checked yet, in lenient hole mode: what an editor resumes from.
+--
+-- A hole is work in progress there, to be reported with its goal and context
+-- rather than as an error (see 'allowHoles'). 'recheckFrom' continues in the
+-- context it is given, so the mode has to be set on the empty one it starts
+-- with: resuming from 'emptyChecked' made every hole a @TypeErrorUnsolvedHole@
+-- and stopped the file at the first one.
+emptyCheckedWithHoles :: Checked
+emptyCheckedWithHoles = Checked (allowHoles emptyContext) [] [] []

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -1063,8 +1063,14 @@ duplicateBinders x = concat
             earlier -> (varIdent v, map varIdent (reverse earlier)) : go (v : seen) vs
     sameSpelling (Rzk.VarIdent _ a) (Rzk.VarIdent _ b) = a == b
 
--- | Elaborate a surface term in the current top-level scope: a free identifier
--- resolves to the top-level entry it names.
+-- | Run a check, handing back its error instead of propagating it.
+--
+-- What it recorded on the way is kept: the record lives in the state beneath
+-- the error channel, so the holes the user wrote in a definition that fails are
+-- still reported (see "Rzk.TypeCheck.Monad").
+tryCheck :: TypeCheck n a -> TypeCheck n (Either TypeErrorInScopedContext a)
+tryCheck action = (Right <$> action) `catchError` (pure . Left)
+
 -- | Run a check with the location narrowed to where a surface term was written.
 --
 -- Descending through a judgement already narrows to the sub-term it is about
@@ -1082,6 +1088,8 @@ atSurface x = local $ \ctx ->
       Just (line, col) ->
         loc { locationLine = Just line, locationColumn = Just col }
 
+-- | Elaborate a surface term in the current top-level scope: a free identifier
+-- resolves to the top-level entry it names.
 elaborate :: forall n. Distinct n => Rzk.Term -> TypeCheck n (Term n)
 elaborate term = do
   ctx <- ask
@@ -1154,18 +1162,30 @@ checkCommands path i total commands k = case commands of
         -- keeping the WHNF cached preserves the original one-shot reduction.
         tyTerm <- elaborate (addParamDecls paramDecls ty)
         ty' <- atSurface ty $ memoizeWHNF =<< typecheck tyTerm universeT
-        valTerm <- elaborate (addParams params term)
-        term' <- atSurface term $ memoizeWHNF =<< typecheck valTerm ty'
-        withTopLevel (varIdentAt path name) ty' (Just term') False used Nothing $ \binder decl -> do
-          backend <- asks ctxRenderBackend
-          termSVG <- case backend of
-            Just RenderSVG   -> renderTermSVG (Var (Foil.nameOf binder))
-            Just RenderLaTeX -> issueTypeError $
-              TypeErrorOther "\"latex\" rendering is not yet supported"
-            Nothing          -> pure Nothing
+        -- The body is checked on its own, so that a definition whose type is
+        -- fine but whose proof is not still enters the scope, as a postulate of
+        -- that type. The rest of the file is then checked against it and its
+        -- own errors and holes reported, instead of the run stopping at this
+        -- one. Nothing is admitted by this: the error is still reported, and
+        -- the strict entry points still fail the run.
+        result <- tryCheck $ do
+          valTerm <- elaborate (addParams params term)
+          atSurface term $ memoizeWHNF =<< typecheck valTerm ty'
+        let (mvalue, bodyErrors) = case result of
+              Right term'  -> (Just term', [])
+              Left bodyErr -> (Nothing, [bodyErr])
+        withTopLevel (varIdentAt path name) ty' mvalue False used Nothing $ \binder decl -> do
+          -- A definition with no proof term has no diagram to draw.
+          termSVG <- case mvalue of
+            Nothing -> pure Nothing
+            Just _  -> asks ctxRenderBackend >>= \case
+              Just RenderSVG   -> renderTermSVG (Var (Foil.nameOf binder))
+              Just RenderLaTeX -> issueTypeError $
+                TypeErrorOther "\"latex\" rendering is not yet supported"
+              Nothing          -> pure Nothing
           maybe id trace termSVG $
             checkCommands path (i + 1) total more $ \decls errs ->
-              k (sinkDecl decl : decls) errs
+              k (sinkDecl decl : decls) (bodyErrors <> errs)
 
   command@(Rzk.CommandData _loc name (Rzk.DeclUsedVars _ vars) params sort body) : more ->
     announce (" Checking #data " <> Rzk.printTree name) $

--- a/rzk/src/Rzk/TypeCheck/Error.hs
+++ b/rzk/src/Rzk/TypeCheck/Error.hs
@@ -383,9 +383,11 @@ ppContext dir ctx@Context{..} = block dir $ dropWhile null
   [ block TopDown
     [ case ctxLocation of
         _ | dir == TopDown -> "" -- FIXME
-        Just (LocationInfo (Just path) (Just lineNo)) ->
+        Just (LocationInfo (Just path) (Just lineNo) (Just col)) ->
+          path <> " (line " <> show lineNo <> ", column " <> show col <> "):"
+        Just (LocationInfo (Just path) (Just lineNo) Nothing) ->
           path <> " (line " <> show lineNo <> "):"
-        Just (LocationInfo (Just path) _) ->
+        Just (LocationInfo (Just path) _ _) ->
           path <> ":"
         _  -> ""
     , case ctxCurrentCommand of

--- a/rzk/src/Rzk/TypeCheck/Eval.hs
+++ b/rzk/src/Rzk/TypeCheck/Eval.hs
@@ -21,10 +21,7 @@
 module Rzk.TypeCheck.Eval where
 
 import           Control.Monad               (forM, forM_, unless, when)
-import           Control.Monad.Except        (runExcept)
-import           Control.Monad.Reader        (ask, asks, local,
-                                              runReaderT)
-import           Control.Monad.Trans.Writer.CPS (runWriterT)
+import           Control.Monad.Reader        (ask, asks, local)
 import           Data.List                   (intercalate, nub, nubBy,
                                               tails)
 import           Data.Maybe                  (catMaybes)
@@ -354,9 +351,9 @@ withRefreshedTopes
   => (Context n -> Context n) -> TypeCheck n a -> TypeCheck n a
 withRefreshedTopes f action = do
   ctx' <- asks f
-  let sat = case runExcept (runWriterT (runReaderT (saturateForEntailment (ctxTopesNF ctx')) ctx')) of
-        Left _       -> Nothing
-        Right (s, _) -> Just s
+  let sat = case runTypeCheckIn ctx' (saturateForEntailment (ctxTopesNF ctx')) of
+        Left _  -> Nothing
+        Right s -> Just s
   local (const ctx' { ctxTopesSaturated = SaturationCached sat }) action
 
 -- | Run a check in every alternative of a disjunctive tope context.

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -19,7 +19,6 @@ import           Control.Applicative      ((<|>))
 import           Control.Monad            (forM, forM_, unless, when)
 import           Control.Monad.Except     (catchError)
 import           Control.Monad.Reader     (ask, asks, local)
-import           Control.Monad.Writer.CPS (censor)
 import           Data.List                (intercalate, sortOn, tails)
 import qualified Data.IntMap              as IntMap
 import qualified Data.IntSet              as IntSet
@@ -292,7 +291,7 @@ fitsInto :: Distinct n => TermT n -> TermT n -> TermT n -> TypeCheck n Bool
 fitsInto term ty target = do
   ty'     <- stripTypeRestrictions <$> whnfT ty
   target' <- stripTypeRestrictions <$> whnfT target
-  censor (const mempty) $ local structuralHoleUnify
+  suppressing $ local structuralHoleUnify
     ((unify (Just term) target' ty' >> pure True) `catchError` \_ -> pure False)
 
 -- | The eliminators a value of the given (weak head normal) type admits, each as a
@@ -575,7 +574,7 @@ saturateWithHoles term = do
 -- probing are discarded, leaving a pure yes\/no query.
 endpointsAgree :: Distinct n => TermT n -> TermT n -> TypeCheck n Bool
 endpointsAgree a b =
-  censor (const mempty)
+  suppressing
     ((unify Nothing a b >> pure True) `catchError` \_ -> pure False)
 
 -- | Ex falso: in a contradictory tope context @recBOT@ inhabits any type, so it is a
@@ -785,8 +784,8 @@ recordHoleShape mname goalTy mshape = do
 
   -- for each local hypothesis (and allow-listed lemma), the elimination spines that
   -- land in the goal (arguments left as holes). Probing must not leak holes into the
-  -- recorded output, hence the 'censor'.
-  candidates <- censor (const mempty) $ do
+  -- recorded output, hence the 'suppressing'.
+  candidates <- suppressing $ do
     -- over the shown hypotheses: a unit-bound point admits no elimination,
     -- and offering it bare would duplicate the @unit@ introduction
     elims <- concat <$>
@@ -843,7 +842,7 @@ recordHoleShape mname goalTy mshape = do
   -- the introduction forms for the goal itself (constituents left as holes); the Π
   -- binder is freshened against the names in scope so that it does not shadow,
   -- and the parse-back check applies like it does to the candidates.
-  introductions <- censor (const mempty) (allIntroductionsOf goalTy takenNames)
+  introductions <- suppressing (allIntroductionsOf goalTy takenNames)
   introductionMoves <- fmap concat $ forM introductions $ \i -> do
     let r = renderMove i
     ok <- parsesBackTo table i r
@@ -851,7 +850,7 @@ recordHoleShape mname goalTy mshape = do
   -- the goal cell: an SVG of the shape the hole must inhabit (an arrow, triangle or
   -- square), drawn from an abstract inhabitant with the proof term hidden. 'Nothing'
   -- when the goal is not a renderable shape.
-  diagram <- censor (const mempty) (renderGoalCellSVG goal')
+  diagram <- suppressing (renderGoalCellSVG goal')
 
   recordHoleInfo HoleInfo
     { holeName          = mname

--- a/rzk/src/Rzk/TypeCheck/Monad.hs
+++ b/rzk/src/Rzk/TypeCheck/Monad.hs
@@ -16,12 +16,13 @@
 module Rzk.TypeCheck.Monad where
 
 import           Control.Monad            (unless)
-import           Control.Monad.Except     (Except, MonadError (throwError),
-                                           runExcept)
+import           Control.Monad.Except     (ExceptT,
+                                           MonadError (catchError, throwError),
+                                           runExceptT)
 import           Control.Monad.Reader     (ReaderT (..), ask, asks, local)
 import           Control.Monad.Trans      (lift)
-import           Control.Monad.Trans.Writer.CPS (WriterT, runWriterT)
-import           Control.Monad.Writer.CPS (tell)
+import           Control.Monad.Trans.State.Strict (State, get, modify', put,
+                                           runState)
 import           Debug.Trace              (trace)
 
 import           Control.Monad.Foil       (Distinct)
@@ -101,24 +102,56 @@ data MetaPrefixRule
   | MetaPrefixStrictOnly
   deriving (Eq, Show)
 
+-- | What a run records besides its result: the holes it found and the non-fatal
+-- findings it made. Both accumulate in reverse and are turned around by
+-- 'checkLog' when the run ends.
+data CheckLog = CheckLog
+  { logHolesRev    :: [HoleInfo]
+  , logWarningsRev :: [CheckWarning]
+  }
+
+emptyCheckLog :: CheckLog
+emptyCheckLog = CheckLog [] []
+
+-- | What a run recorded, in the order it was recorded.
+checkLog :: CheckLog -> ([HoleInfo], [CheckWarning])
+checkLog (CheckLog holes warnings) = (reverse holes, reverse warnings)
+
+-- | The record of a run is kept in the /state/, beneath the error channel,
+-- rather than on a writer channel above it.
+--
+-- The two differ exactly where a caught error is concerned: a writer discards
+-- what the failing action wrote, and the state keeps it. That is what the
+-- checker wants. A command that fails still reports the holes the user wrote in
+-- it, and checking goes on to the next command with those holes in hand (see
+-- @withCommand@ in "Rzk.TypeCheck.Decl"). A probe that wants the older
+-- behaviour asks for it, with 'suppressing'.
 type TypeCheck n =
   ReaderT (Context n)
-    (WriterT ([HoleInfo], [CheckWarning]) (Except TypeErrorInScopedContext))
+    (ExceptT TypeErrorInScopedContext (State CheckLog))
+
+-- | Run a judgement in a given context, keeping what it recorded.
+runTypeCheckWith
+  :: Context n -> TypeCheck n a
+  -> (Either TypeErrorInScopedContext a, ([HoleInfo], [CheckWarning]))
+runTypeCheckWith ctx tc =
+  case runState (runExceptT (runReaderT tc ctx)) emptyCheckLog of
+    (result, logged) -> (result, checkLog logged)
 
 -- | Run a judgement in the empty context, discarding the holes it records.
 runTypeCheck :: TypeCheck Foil.VoidS a -> Either TypeErrorInScopedContext a
-runTypeCheck tc = fst <$> runExcept (runWriterT (runReaderT tc emptyContext))
+runTypeCheck = runTypeCheckIn emptyContext
 
 -- | Run a judgement in a given context, discarding the holes it records.
 runTypeCheckIn :: Context n -> TypeCheck n a -> Either TypeErrorInScopedContext a
-runTypeCheckIn ctx tc = fst <$> runExcept (runWriterT (runReaderT tc ctx))
+runTypeCheckIn ctx tc = fst (runTypeCheckWith ctx tc)
 
 -- | Run a judgement in another scope's context.
 --
 -- The error channel and the hole channel are shared and carry no scope index, so
 -- there is nothing to translate: this is 'runReaderT' with the inner scope's
--- context, lifted back. Holes recorded inside are told into the same writer, and
--- an error thrown inside already carries its own context.
+-- context, lifted back. Holes recorded inside land in the same state, and an
+-- error thrown inside already carries its own context.
 inContext :: Context l -> TypeCheck l a -> TypeCheck n a
 inContext ctx = lift . flip runReaderT ctx
 
@@ -202,15 +235,37 @@ performing action tc = do
            local (const ctx') tc
     else local (const ctx') tc
 
+-- * What a run records
+
+modifyLog :: (CheckLog -> CheckLog) -> TypeCheck n ()
+modifyLog f = lift (lift (modify' f))
+
+-- | Run a probe for its answer alone, discarding whatever it records.
+--
+-- A hole's inventory is built by trying candidate moves and seeing which fit,
+-- and each trial checks terms of its own; their holes and warnings are not the
+-- user's and must not reach the report. This is what the writer channel's
+-- @censor@ did before the record moved into the state: the state survives an
+-- error, so it is put back on that path too.
+suppressing :: TypeCheck n a -> TypeCheck n a
+suppressing action = do
+  saved <- lift (lift get)
+  let restore = lift (lift (put saved))
+  result <- action `catchError` \err -> restore >> throwError err
+  restore
+  return result
+
 -- * Holes
 
 recordHoleInfo :: HoleInfo -> TypeCheck n ()
-recordHoleInfo info = lift (tell ([info], []))
+recordHoleInfo info =
+  modifyLog $ \l -> l { logHolesRev = info : logHolesRev l }
 
 -- * Warnings
 
 recordCheckWarning :: CheckWarning -> TypeCheck n ()
-recordCheckWarning warning = lift (tell ([], [warning]))
+recordCheckWarning warning =
+  modifyLog $ \l -> l { logWarningsRev = warning : logWarningsRev l }
 
 -- * Locations
 

--- a/rzk/src/Rzk/TypeCheck/Monad.hs
+++ b/rzk/src/Rzk/TypeCheck/Monad.hs
@@ -29,6 +29,7 @@ import           Control.Monad.Foil       (Distinct)
 import qualified Control.Monad.Foil       as Foil
 
 import           Language.Rzk.Foil.Names (VarIdent)
+import           Language.Rzk.Foil.Syntax (positionOfTerm)
 import           Rzk.TypeCheck.Context
 import           Rzk.TypeCheck.Display
 import           Rzk.TypeCheck.Error
@@ -226,6 +227,7 @@ performing action tc = do
   let ctx' = ctx
         { ctxActionStack = action : ctxActionStack
         , ctxActionStackDepth = ctxActionStackDepth + 1
+        , ctxLocation = narrowLocation action ctxLocation
         }
   -- The trace message is built only when it is actually printed: at normal
   -- verbosity rendering the action's terms on every judgement would cost a
@@ -234,6 +236,22 @@ performing action tc = do
     then trace (ppAction (namingOfContext ctx) ctxActionStackDepth action) $
            local (const ctx') tc
     else local (const ctx') tc
+
+-- | Point the location at the sub-term an action is about.
+--
+-- The checker descends through 'performing', so the location narrows as it
+-- goes and an error is reported where the sub-term that caused it was written,
+-- rather than at the declaration it is in (issue #81). A judgement about a term
+-- the checker built itself carries no position, and leaves the location as it
+-- found it: that is the innermost enclosing term the user did write.
+narrowLocation :: Action n -> Maybe LocationInfo -> Maybe LocationInfo
+narrowLocation action loc = case termOf action of
+  Just term | Just pos <- positionOfTerm term -> atPosition pos <$> loc
+  _                                           -> loc
+  where
+    termOf (ActionTypeCheck term _) = Just term
+    termOf (ActionInfer term)       = Just term
+    termOf _                        = Nothing
 
 -- * What a run records
 

--- a/rzk/test/Rzk/TypeCheckSpec.hs
+++ b/rzk/test/Rzk/TypeCheckSpec.hs
@@ -40,6 +40,7 @@ data Expect = Expect
   , expectMessageContains :: Maybe [String]
   , expectLine            :: Maybe Int
   , expectColumn          :: Maybe Int
+  , expectErrorCount      :: Maybe Int
   , expectRegressionFor   :: Maybe [String]
   , expectModules         :: Maybe [FilePath]
   , expectApi             :: Maybe String
@@ -53,6 +54,7 @@ instance FromJSON Expect where
     <*> o .:? "message_contains"
     <*> o .:? "line"
     <*> o .:? "column"
+    <*> o .:? "error_count"
     <*> o .:? "regression_for"
     <*> o .:? "modules"
     <*> o .:? "api"
@@ -192,6 +194,13 @@ assertExpectCollect label Expect{..} (Right checked) = case checkedErrors checke
     [] ->
       expectationFailure $ "in " <> label <> ", expected type errors but got none"
     err : _ -> do
+      case expectErrorCount of
+        Nothing -> pure ()
+        Just n | length errs /= n ->
+          expectationFailure $ "in " <> label <> ", expected " <> show n
+            <> " errors, got " <> show (length errs) <> ":\n"
+            <> unlines (map (ppTypeErrorInScopedContext BottomUp) errs)
+        Just _ -> pure ()
       let tag = typeErrorConstructorName err
       case expectErrorTag of
         Nothing -> expectationFailure "expect.yaml missing error_tag for status: error"

--- a/rzk/test/Rzk/TypeCheckSpec.hs
+++ b/rzk/test/Rzk/TypeCheckSpec.hs
@@ -39,6 +39,7 @@ data Expect = Expect
   , expectErrorTag        :: Maybe String
   , expectMessageContains :: Maybe [String]
   , expectLine            :: Maybe Int
+  , expectColumn          :: Maybe Int
   , expectRegressionFor   :: Maybe [String]
   , expectModules         :: Maybe [FilePath]
   , expectApi             :: Maybe String
@@ -51,6 +52,7 @@ instance FromJSON Expect where
     <*> o .:? "error_tag"
     <*> o .:? "message_contains"
     <*> o .:? "line"
+    <*> o .:? "column"
     <*> o .:? "regression_for"
     <*> o .:? "modules"
     <*> o .:? "api"
@@ -63,6 +65,10 @@ instance FromJSON Expect where
 -- this had to unsafeCoerce its way back out.
 errorLine :: TypeErrorInScopedContext -> Maybe Int
 errorLine err = locationOfTypeError err >>= locationLine
+
+-- | The column an error was raised at: the start of the sub-term it is about.
+errorColumn :: TypeErrorInScopedContext -> Maybe Int
+errorColumn err = locationOfTypeError err >>= locationColumn
 
 -- | The constructor name of a type error, used to match @error_tag@ in fixtures.
 -- This is the library's own tag (also used for diagnostic codes), so the two cannot
@@ -150,6 +156,15 @@ assertExpect label Expect{..} (Left err) | expectStatus == "error" = do
         expectationFailure $ "in " <> label <> ", expected line " <> show ln
           <> " got " <> show got
       Just _ -> pure ()
+  case expectColumn of
+    Nothing -> pure ()
+    Just c -> case errorColumn err of
+      Nothing -> expectationFailure $ "in " <> label <> ", expected column "
+        <> show c <> " but error has no column"
+      Just got | got /= c ->
+        expectationFailure $ "in " <> label <> ", expected column " <> show c
+          <> " got " <> show got
+      Just _ -> pure ()
 assertExpect label Expect{expectStatus = "ok", expectWarnings = want} (Right checked) =
   assertWarnings label want checked
 assertExpect label Expect{expectStatus = st} _ =
@@ -197,6 +212,13 @@ assertExpectCollect label Expect{..} (Right checked) = case checkedErrors checke
           Nothing -> expectationFailure "expected line number on error"
           Just got | got /= ln ->
             expectationFailure $ "line mismatch: wanted " <> show ln <> " got " <> show got
+          Just _ -> pure ()
+      case expectColumn of
+        Nothing -> pure ()
+        Just c -> case errorColumn err of
+          Nothing -> expectationFailure "expected column on error"
+          Just got | got /= c ->
+            expectationFailure $ "column mismatch: wanted " <> show c <> " got " <> show got
           Just _ -> pure ()
   st ->
     expectationFailure $ "in " <> label <> ", unknown status " <> show st

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -134,7 +134,9 @@ Fixture comments and `regression_for` use stable prose (which judgment fails, wh
 | `status` | yes | `ok` if typechecking must succeed; `error` if it must fail with a type error. |
 | `error_tag` | if `status: error` | Name of the `TypeError` constructor after stripping `ScopedTypeError` wrappers, e.g. `TypeErrorUnify`, `TypeErrorUndefined`. |
 | `message_contains` | no | Substrings that must all appear in the rendered error (`ppTypeErrorInScopedContext'`). |
-| `line` | no | 1-based line number (approximate) in the Rzk file where the error is reported. |
+| `line` | no | 1-based line number in the Rzk file where the error is reported: the start of the sub-term the error is about, not of the declaration around it. |
+| `column` | no | 1-based column on that line, likewise the start of the sub-term. |
+| `error_count` | no | With `api: collect`, the exact number of errors the run must report. |
 | `regression_for` | no | Traceability strings (PR numbers, issue ids, commit themes). |
 | `modules` | no | If set (directory case), ordered list of module files for one `typecheckModulesWithLocation` run. |
 | `api` | no | Omit or `strict` (default): `typecheckModulesWithLocation` (throws on first error). `collect`: `typecheckModulesWithLocation'` — returns a list of errors without using `throwError`; note that the typechecker still stops per-module chaining when a module reports errors (see implementation in `Rzk.TypeCheck`). |

--- a/rzk/test/typecheck/SCHEMA.md
+++ b/rzk/test/typecheck/SCHEMA.md
@@ -21,6 +21,7 @@ Test cases live under `test/typecheck/cases/`.
 | `message_contains` | no | Substrings that must all appear in the rendered error (`ppTypeErrorInScopedContext'`). |
 | `line` | no | 1-based line number in the Rzk file where the error is reported: the start of the sub-term the error is about, not of the declaration around it. |
 | `column` | no | 1-based column on that line, likewise the start of the sub-term. A variable is a leaf of the core syntax and carries no position of its own, so an error blamed on one is reported at the innermost term around it that does. |
+| `error_count` | no | With `api: collect`, the exact number of errors the run must report. A definition whose body fails to check is entered as a postulate of its declared type and checking continues, so a file reports every error it has. |
 | `regression_for` | no | Traceability: GitHub issue/PR URLs, commit themes, or short **semantic** rule names (e.g. `contextEntailsUnion-recOR-boundary`). Avoid `TypeCheck.hs` line numbers and `issueTypeError-<line>` tags — they go stale. |
 | `modules` | no | If set (directory case), ordered list of module files for one `typecheckModulesWithLocation` run. |
 | `api` | no | Omit or `strict` (default): `typecheckModulesWithLocation` (throws on first error). `collect`: `typecheckModulesWithLocation'` — returns a list of errors without using `throwError`; note that the typechecker still stops per-module chaining when a module reports errors (see implementation in `Rzk.TypeCheck`). |

--- a/rzk/test/typecheck/SCHEMA.md
+++ b/rzk/test/typecheck/SCHEMA.md
@@ -19,7 +19,8 @@ Test cases live under `test/typecheck/cases/`.
 | `status` | yes | `ok` if typechecking must succeed; `error` if it must fail with a type error. |
 | `error_tag` | if `status: error` | Name of the `TypeError` constructor after stripping `ScopedTypeError` wrappers, e.g. `TypeErrorUnify`, `TypeErrorUndefined`. |
 | `message_contains` | no | Substrings that must all appear in the rendered error (`ppTypeErrorInScopedContext'`). |
-| `line` | no | 1-based line number (approximate) in the Rzk file where the error is reported. |
+| `line` | no | 1-based line number in the Rzk file where the error is reported: the start of the sub-term the error is about, not of the declaration around it. |
+| `column` | no | 1-based column on that line, likewise the start of the sub-term. A variable is a leaf of the core syntax and carries no position of its own, so an error blamed on one is reported at the innermost term around it that does. |
 | `regression_for` | no | Traceability: GitHub issue/PR URLs, commit themes, or short **semantic** rule names (e.g. `contextEntailsUnion-recOR-boundary`). Avoid `TypeCheck.hs` line numbers and `issueTypeError-<line>` tags — they go stale. |
 | `modules` | no | If set (directory case), ordered list of module files for one `typecheckModulesWithLocation` run. |
 | `api` | no | Omit or `strict` (default): `typecheckModulesWithLocation` (throws on first error). `collect`: `typecheckModulesWithLocation'` — returns a list of errors without using `throwError`; note that the typechecker still stops per-module chaining when a module reports errors (see implementation in `Rzk.TypeCheck`). |

--- a/rzk/test/typecheck/cases/ill-match-branch-arity.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-branch-arity.expect.yaml
@@ -3,6 +3,7 @@ error_tag: TypeErrorMatchBranchArity
 message_contains:
   - "match branch for constructor suc"
   - "binds 1 argument, but its method takes 2"
-line: 6
+line: 7
+column: 6
 regression_for:
   - match-branch-arity

--- a/rzk/test/typecheck/cases/ill-match-duplicate-branch.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-duplicate-branch.expect.yaml
@@ -2,6 +2,7 @@ status: error
 error_tag: TypeErrorMatchDuplicateBranch
 message_contains:
   - "duplicate match branch for constructor zero"
-line: 5
+line: 6
+column: 6
 regression_for:
   - match-branch-bijection

--- a/rzk/test/typecheck/cases/ill-match-missing-branch.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-missing-branch.expect.yaml
@@ -2,6 +2,7 @@ status: error
 error_tag: TypeErrorMatchMissingBranch
 message_contains:
   - "no branch for constructor suc"
-line: 5
+line: 6
+column: 6
 regression_for:
   - match-branch-bijection

--- a/rzk/test/typecheck/cases/ill-match-missing-path-branch.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-missing-path-branch.expect.yaml
@@ -2,6 +2,7 @@ status: error
 error_tag: TypeErrorMatchMissingBranch
 message_contains:
   - "match has no branch for constructor loop"
-line: 6
+line: 7
+column: 6
 regression_for:
   - data-stage3-path-constructors

--- a/rzk/test/typecheck/cases/ill-match-not-data.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-not-data.expect.yaml
@@ -3,6 +3,7 @@ error_tag: TypeErrorMatchScrutineeNotData
 message_contains:
   - "match scrutinee"
   - "is not of a #data type"
-line: 3
+line: 4
+column: 6
 regression_for:
   - match-scrutinee-data-former

--- a/rzk/test/typecheck/cases/ill-match-unknown-branch.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-match-unknown-branch.expect.yaml
@@ -3,6 +3,7 @@ error_tag: TypeErrorMatchUnknownBranch
 message_contains:
   - "match branch for succ"
   - "not a constructor"
-line: 5
+line: 6
+column: 6
 regression_for:
   - match-branch-bijection

--- a/rzk/test/typecheck/cases/ill-modal-let-into-body.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-modal-let-into-body.expect.yaml
@@ -2,7 +2,8 @@ status: error
 error_tag: TypeErrorUnify
 message_contains:
   - "cannot unify expected type"
-line: 6
+line: 12
+column: 46
 regression_for:
   - "let-mod-into-motive-checks-body"
   - "https://github.com/rzk-lang/rzk/pull/327"

--- a/rzk/test/typecheck/cases/ill-recover-after-body-error.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-recover-after-body-error.expect.yaml
@@ -1,0 +1,11 @@
+status: error
+api: collect
+error_tag: TypeErrorUnify
+message_contains:
+  - "cannot unify expected type"
+line: 7
+column: 6
+error_count: 2
+regression_for:
+  - "continue-checking-after-a-failed-definition-body"
+  - "https://github.com/rzk-lang/rzk/issues/81"

--- a/rzk/test/typecheck/cases/ill-recover-after-body-error.rzk
+++ b/rzk/test/typecheck/cases/ill-recover-after-body-error.rzk
@@ -1,0 +1,13 @@
+#lang rzk-1
+
+-- The proof of `broken` does not check, but its type does, so it is entered
+-- as a postulate and the rest of the file is checked against it: `uses-broken`
+-- uses it and checks, and the separate error in `also-broken` is reported too.
+#define broken (A : U) (a : A) : A
+  := A
+
+#define uses-broken (A : U) (a : A) : A
+  := broken A a
+
+#define also-broken (A : U) (a : A) : A
+  := U


### PR DESCRIPTION
Given

```rzk
#define pairup (A : U) (a : A) : Sigma (_ : A), A
  := (?, ?)

#define wrong (A : U) (a : A) : A
  := A

#define after (A : U) : A -> A
  := \ x -> ?
```

the editor now marks the two holes on `(?, ?)`, the error on `A`, and the hole in `after` beyond the error. It used to show a single error on the `#define pairup` line and nothing else.

1. **A hole is a warning carrying its goal, and every hole is reported.** The goal, the local context, and the candidate moves were all recorded already, and simply never reached while editing: the server resumes each module from `emptyChecked`, the plain empty context, in which a hole is a `TypeErrorUnsolvedHole` that stops the module. It resumes from a lenient context now.

2. **A diagnostic points at the sub-term it is about** ([#81](https://github.com/rzk-lang/rzk/issues/81)). An untyped term is now an annotated AST, as a typed one already was, carrying where it was written, and `performing` narrows the reported location to the sub-term a judgement concerns as the checker descends. The server marks the head token of that term, in the UTF-16 columns the client counts in. Until now the conversion from the surface syntax threw every node's position away, leaving the declaration as the only thing the checker could name.

3. **A file keeps checking after a definition fails.** Its type and its body are checked separately: if the type checks and the body does not, the definition enters the scope as a postulate of its declared type, and the rest of the file is checked against it rather than collapsing into undefined-variable errors. Nothing is admitted by this, since the error is reported like any other and the run still fails.

Two limitations worth stating. A variable is a leaf of the core syntax with nowhere to put a position, so an error blamed on one is reported at the innermost enclosing term that has one; `atSurface` covers the common case of a definition whose whole body is a variable. And the surface syntax records where a node begins and not where it ends, so the marked span is the head token rather than the whole term.

Fixtures may now assert a `column` and, under `api: collect`, an `error_count`. The seven whose `line` this changes now point at the term instead of the declaration: `ill-modal-let-into-body`, for instance, moves from the `#def` on line 6 to `c a` on line 12, column 46. `ill-recover-after-body-error` covers the recovery, with a broken proof, a later definition that uses it and checks, and a second error reported from beyond it.

The quick sHoTT benchmark is unmoved (0.99 s before, 0.93 s after) for 0.6% more allocation, which is the positions on the untyped terms elaboration builds.