### PR TITLE
Offer a lemma with a hole-headed result type

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## Unreleased
+
+Fixed:
+
+- **A lemma whose result type is a motive application is offered as a hole candidate.** A spine such as `#!rzk ind-path ? ? ? ? ? ?` has the type `#!rzk ?C ?x ?p`, an application headed by a hole. Such a type has no shape to mismatch with — filling the head decides what it is — so it now unifies with any goal while probing candidates, and the lemma is offered like any other. Previously only the built-in `#!rzk idJ` was suggested at an identity goal, and every eliminator written in the sHoTT style (`#!rzk ind-path`, a library `#!rzk ind-Void`, an `#!rzk ind-hom2`) was invisible as a move even when explicitly allow-listed. The allow-list still gates the suggestion, and a hole-headed spine is a suggestion rather than a solution: the motive and the base case are left as holes and the written term is type-checked as usual.
+
 ## v0.11.1 — 2026-07-25
 
 This release adds higher inductive types: a `#!rzk #data` constructor may now return an identity type, declaring a path, and the generated eliminators gain one method and one propositional computation rule per path constructor. Declarations may re-ascribe the type of a generated eliminator or computation rule with a definitionally equal spelling of their own, which is what makes the generated types readable through a library `#!rzk transport`/`#!rzk ap`/`#!rzk apd`. Modal `#!rzk let mod` gains an explicit motive, and the playground deploys are fixed.

--- a/rzk/src/Language/Rzk/Foil/Syntax.hs
+++ b/rzk/src/Language/Rzk/Foil/Syntax.hs
@@ -354,6 +354,20 @@ isHoleT :: TermT n -> Bool
 isHoleT HoleT{} = True
 isHoleT _       = False
 
+-- | Is the term a /flexible/ spine: a hole, or an application headed by one
+-- (@? a b@)?
+--
+-- Such a term is not yet committed to any shape: filling the head hole can turn
+-- it into anything. A type of this form therefore stands for an arbitrary type,
+-- which is what lets an eliminator whose result type is a motive application
+-- (@ind-path A a C d x p : C x p@) be judged against a concrete goal. Contrast
+-- 'containsHole', which is also true of a term whose /shape/ is already fixed
+-- and only has holes among its parts (@? = ?@ is an identity type either way).
+isHoleHeadedT :: TermT n -> Bool
+isHoleHeadedT HoleT{}     = True
+isHoleHeadedT (AppT _ f _) = isHoleHeadedT f
+isHoleHeadedT _           = False
+
 -- | The name of every hole in a term.
 holeNamesOf :: Term n -> [Maybe VarIdent]
 holeNamesOf (Hole mname) = [mname]

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -280,6 +280,12 @@ allEliminationsInto target takenNames hyp = do
 -- mismatch (an under-applied function does not match an extension-type goal, but a
 -- partial application that genuinely fits an ordinary-function goal does).
 --
+-- The exception is a /flexible/ type, one headed by a hole: it has no shape to
+-- mismatch with, so it fits any target. This is what makes an eliminator stated
+-- over a motive usable as a candidate --- @ind-path ? ? ? ? ? ?@ has type
+-- @?C ?x ?p@ and so is offered at every goal, exactly as @idJ@ already is, with
+-- the motive and the base case left as holes.
+--
 -- Outer type restrictions are stripped from both sides first: an extension-type
 -- boundary is satisfied by later refinement, not by the choice of spine, and
 -- matching against the restricted goal would reject the very spine that introduces

--- a/rzk/src/Rzk/TypeCheck/Unify.hs
+++ b/rzk/src/Rzk/TypeCheck/Unify.hs
@@ -174,10 +174,21 @@ unifyInCurrentContext mterm expected actual = performing action $ do
       -- mentions it. Such a branch is only entered because the hole is unfilled, so
       -- a mismatch under it is deferred too. 'structuralHoleUnify' turns this off,
       -- keeping a structural mismatch around a hole an error.
+      --
+      -- A /flexible/ side is the exception 'structuralHoleUnify' does not cover:
+      -- a term headed by a hole ('isHoleHeadedT') has no shape to mismatch with
+      -- yet, since filling the head decides what it is. It therefore unifies with
+      -- anything even under 'structuralHoleUnify'. This is what lets an
+      -- eliminator whose result is a motive application be offered as a hole
+      -- candidate: @ind-path ? ? ? ? ? ?@ has type @?C ?x ?p@, which fits any
+      -- goal. A move is a suggestion, not a solution -- the motive and the base
+      -- case are left as holes for the caller, and the result is type-checked
+      -- like any other term once written.
       defer <- asks ctxDeferHoleMismatches
       topeContextHasHole <- asks (any (containsHole . tTope) . ctxTopes)
-      let holePresent = defer &&
-            (containsHole expected' || containsHole actual' || topeContextHasHole)
+      let holePresent =
+            (defer && (containsHole expected' || containsHole actual' || topeContextHasHole))
+              || isHoleHeadedT expected' || isHoleHeadedT actual'
 
           err :: TypeCheck n ()
           err

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -453,6 +453,33 @@ spec = do
            cands h `shouldContain` ["my-id ?"]
            filter (== "my-id") (cands h) `shouldBe` []
 
+    -- A lemma whose result type is a motive application (@ind-path ... : C x p@)
+    -- is offered like any other: the spine's type is headed by a hole, which has
+    -- no shape to mismatch with, so it fits any goal. Without this, every
+    -- eliminator written in the sHoTT style is invisible as a move while the
+    -- built-in @idJ@ is offered, and a level cannot teach the library spelling.
+    it "offers a lemma whose result type is headed by a hole" $
+      let indSrc = "#lang rzk-1\n"
+                <> "#define ind-path (A : U) (a : A)\n"
+                <> "  (C : (x : A) -> (a = x) -> U) (d : C a refl)\n"
+                <> "  (x : A) (p : a = x) : C x p\n"
+                <> "  := idJ (A , a , C , d , x , p)\n"
+                <> "#define goal (A : U) (x y : A) (p : x = y) : y = x := ?\n"
+      in flip oneHole (holesWithLemmas ["ind-path"] indSrc) $ \h ->
+           cands h `shouldContain` ["ind-path ? ? ? ? ? ?"]
+
+    -- Fitting anything does not mean escaping the allow-list: a hole-headed
+    -- lemma is still only offered when the level grants it.
+    it "does not offer a hole-headed lemma that was not allow-listed" $
+      let indSrc = "#lang rzk-1\n"
+                <> "#define ind-path (A : U) (a : A)\n"
+                <> "  (C : (x : A) -> (a = x) -> U) (d : C a refl)\n"
+                <> "  (x : A) (p : a = x) : C x p\n"
+                <> "  := idJ (A , a , C , d , x , p)\n"
+                <> "#define goal (A : U) (x y : A) (p : x = y) : y = x := ?\n"
+      in flip oneHole (holesWithLemmas [] indSrc) $ \h ->
+           filter (isInfixOf "ind-path") (cands h) `shouldBe` []
+
   describe "holeCandidates under shadowing" $ do
     let cands = map show . holeCandidates
         -- the motive λ rebinds b, so at the inner hole the telescope's b is


### PR DESCRIPTION
Given this prelude and goal, with `ind-path` allow-listed:

```rzk
#define ind-path (A : U) (a : A)
  (C : (x : A) -> (a = x) -> U) (d : C a refl)
  (x : A) (p : a = x) : C x p
  := idJ (A , a , C , d , x , p)

#define goal (A : U) (x y : A) (p : x = y) : y = x := ?
```

the hole offered only `idJ (A, x, \ b -> \ q -> ?, ?, y, p)`, never `ind-path`. It now offers `ind-path ? ? ? ? ? ?` as well.

The spine `ind-path ? ? ? ? ? ?` has the type `?C ?x ?p`, an application headed by a hole. `fitsInto` judges it under `structuralHoleUnify`, where a hole is a wildcard leaf but a structural mismatch around one is still a mismatch, and a hole-headed application is not a leaf, so it lost against every rigid goal.

This PR:

- treats a term headed by a hole as **flexible**: it has no shape to mismatch with, since filling the head decides what it is, so it unifies with anything even under `structuralHoleUnify` (the standard flex-rigid case);
- fixes this for every eliminator stated over a motive, not just path induction: a library `ind-Void` or an `ind-hom2` was invisible for the same reason;
- keeps the allow-list gating the suggestion, so nothing new is offered unless the caller asked for that lemma by name;
- leaves normal checking untouched, since it defers hole mismatches already, so the new case only fires where deferral is off, which is the candidate probe;
- adds two cases to the hole-candidate spec, one for the offer and one pinning that the allow-list still applies.

Soundness is not at stake: a candidate is a suggestion, not a solution. The motive and the base case are left as holes, and the written term is type-checked like any other.